### PR TITLE
Disable context menu on resource url for download

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -134,7 +134,19 @@
 <script type="text/javascript" language="javascript">
 <rs:compressJs>
 (function($, fluid, dl) {
-    $(function() {
+    dl.jQuery(function() {
+        
+        <%-- Disable Right Clicks in Safari browsers --%>
+        <%-- Safari (not webkit) does not honor context header for naming downloads
+             If indexOf('Constructor')>0 then we are in Safari Browser--%>
+        if (Object.prototype.toString.call(window.HTMLElement).indexOf('Constructor') > 0) {
+            $(".dl-clickable").live("contextmenu", function() {
+                return false;
+            });
+        }
+        
+        $(document).ready(function(){
+        
         var updateAmmountVisibility = function(checkbox) {
             var checked = checkbox.is(':checked');
             var ammounts = $("#${n}dl-payroll-information table.dl-table a.dl-earning-amount");
@@ -225,6 +237,7 @@
         dl.tabs("#${n}dl-tabs");
         
         dl.util.clickableContainer("#${n}dl-payroll-information");
+        });
     });    
 })(dl_v1.jQuery, dl_v1.fluid, dl_v1);
 </rs:compressJs>

--- a/hrs-portlets-webapp/src/main/webapp/resources.xml
+++ b/hrs-portlets-webapp/src/main/webapp/resources.xml
@@ -27,5 +27,5 @@
   <css import="true">common-resources.xml</css>
     
   <js import="true">common-resources.xml</js>
-    
+  
 </resources>


### PR DESCRIPTION
We have a button that does work masquerading as a link to a file.  This results in an issue with uPortal's naming convention of URL's.  Example from what the URL is on this link: `http://localhost:8080/portal/f/u28l1s4/p/PayrollInformation.n94/normal/irs_statement.pdf.resource.uP?pP_docId=3`.  Normally we can add some info in the context header telling the browser to expect a file returned and file name to save it as.  Safari does not honor this when saving from the context menu (menu that appears when a user right clicks something).
This commit adds a class that can be used to disable the context menu for certain elements.
`class="contextMenuDisallowed"`

This class is added to the link shown below.  It will prevent users in Safari from bring up the context menu and clicking save-as.
![image](https://cloud.githubusercontent.com/assets/5521429/2842782/45b760e2-d078-11e3-80c8-ca86f4e6b094.png)

Browser detection and functionality tested with Mac: Safari, Chrome, Firefox. Linux: Chrome, Firefox. Windows: Chrome, Firefox, Internet Explorer.
