### PR TITLE
HRSPLT-148 Voluntary status reporting

### DIFF
--- a/hrs-portlets-webapp/src/main/resources/messages.properties
+++ b/hrs-portlets-webapp/src/main/resources/messages.properties
@@ -60,3 +60,4 @@ button.cancel=Cancel
 label.disability.status=Disability Status
 label.veteran.status=Veteran Status
 label.ethnic.groups=Ethnic Groups
+label.status.link=view/update

--- a/hrs-portlets-webapp/src/main/resources/messages.properties
+++ b/hrs-portlets-webapp/src/main/resources/messages.properties
@@ -36,6 +36,8 @@ updateInfoLink=Update my Personal Information
 no=No
 yes=Yes
 
+bottomNote=Please note that you can update Home Address, Phone, Release Home Address Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in Oracle.  To update your Business/Office Address, please contact your Payroll Office.
+
 noEmplId=There is no employment record identifier available for your account.
 genericError=Data could not be retrieved, please try again later. If the problem persists, contact the UW Service Center Support Team at 855-4UW-SUPP or 608-890-1501 and select option 1, via email at <a href="mailto:servicecenter@sc.wisc.edu">servicecenter@sc.wisc.edu</a>, or via chat. <a class="dl-refresh" href="{0}">Refresh</a>
 genericStatementError=Data could not be retrieved, please try again later. If the problem persists, contact the UW Service Center Support Team at 855-4UW-SUPP or 608-890-1501 and select option 1, via email at <a href="mailto:servicecenter@sc.wisc.edu">servicecenter@sc.wisc.edu</a>, or via chat.

--- a/hrs-portlets-webapp/src/main/resources/messages.properties
+++ b/hrs-portlets-webapp/src/main/resources/messages.properties
@@ -56,3 +56,7 @@ error.firstName.invalidCharacter=We have detected an invalid character in your f
 error.toolong=Names are limited to 30 characters.
 error.required=The first name is required.
 button.cancel=Cancel
+
+label.disability.status=Disability Status
+label.veteran.status=Veteran Status
+label.ethnic.groups=Ethnic Groups

--- a/hrs-portlets-webapp/src/main/resources/messages.properties
+++ b/hrs-portlets-webapp/src/main/resources/messages.properties
@@ -32,7 +32,7 @@ officePhoneLabel=Primary Office Phone:
 open.enrollment=Open Enrollment
 otherPhoneLabel=Other Phone:
 emailLabel=Email:
-updateInfoLink=Update my Personal Information
+updateInfoLink=Update my personal information
 no=No
 yes=Yes
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -197,8 +197,9 @@
   <div class="dl-contact-info-update">
     <a href="${hrsUrls['Personal Information']}" target="_blank"><spring:message code="updateInfoLink"/></a>
     <br/>
-    Click to update Home Address, Phone, Release Home Address Release Information, Emergency Contacts, Marital Status and
-    Coordination of Benefits.<br/><br/><b>Please contact your Payroll Office to update Business/Office Address.</b>
+    <div>
+    <spring:message code="bottomNote" text="Please note that you can update Home Address, Phone, Release Home Address Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in Oracle.  To update your Business/Office Address, please contact your Payroll Office."/>
+    </div>
   </div>
   
   <div class="change-business-email-dialog" title="Change Campus Business Email">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -182,15 +182,21 @@
   <div class="federal-reporting-statuses">
       <div>
           <span class="label"><spring:message code="label.disability.status" text="Disability Status"/></span>
-          <span>(<a href="${hrsUrls['Disability Status']}" target="_blank">view/update</a>)</span>
+          <span>(<a href="${hrsUrls['Disability Status']}" target="_blank">
+              <spring:message code="label.status.link" text="view/update"/>
+                 </a>)</span>
       </div>
       <div>
           <span class="label"><spring:message code="label.veteran.status" text="Veteran Status"/></span>
-          <span>(<a href="${hrsUrls['Veteran Status']}" target="_blank">view/update</a>)</span>
+          <span>(<a href="${hrsUrls['Veteran Status']}" target="_blank">
+              <spring:message  code="label.status.link" text="view/update"/>
+                 </a>)</span>
       </div>
       <div>
           <span class="label"><spring:message code="label.ethnic.groups" text="Ethnic Groups"/></span>
-          <span>(<a href="${hrsUrls['Ethnic Groups']}" target="_blank">view/update</a>)</span>
+          <span>(<a href="${hrsUrls['Ethnic Groups']}" target="_blank">
+              <spring:message code="label.status.link" text="view/update"/>
+                 </a>)</span>
       </div>
   </div>
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -181,15 +181,15 @@
 
   <div class="federal-reporting-statuses">
       <div>
-          <span class="label">Disability Status</span>
+          <span class="label"><spring:message code="label.disability.status" text="Disability Status"/></span>
           <span>(<a href="${hrsUrls['Disability Status']}" target="_blank">view/update</a>)</span>
       </div>
       <div>
-          <span class="label">Veteran Status</span>
+          <span class="label"><spring:message code="label.veteran.status" text="Veteran Status"/></span>
           <span>(<a href="${hrsUrls['Veteran Status']}" target="_blank">view/update</a>)</span>
       </div>
       <div>
-          <span class="label">Ethnic Group</span>
+          <span class="label"><spring:message code="label.ethnic.groups" text="Ethnic Groups"/></span>
           <span>(<a href="${hrsUrls['Ethnic Groups']}" target="_blank">view/update</a>)</span>
       </div>
   </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -179,6 +179,21 @@
     </c:choose>
   </div>
 
+  <div class="federal-reporting-statuses">
+      <div>
+          <span class="label">Disability Status</span>
+          <span>(<a href="${hrsUrls['Disability Status']}" target="_blank">view/update</a>)</span>
+      </div>
+      <div>
+          <span class="label">Veteran Status</span>
+          <span>(<a href="${hrsUrls['Veteran Status']}" target="_blank">view/update</a>)</span>
+      </div>
+      <div>
+          <span class="label">Ethnic Group</span>
+          <span>(<a href="${hrsUrls['Ethnic Groups']}" target="_blank">view/update</a>)</span>
+      </div>
+  </div>
+
   <div class="dl-contact-info-update">
     <a href="${hrsUrls['Personal Information']}" target="_blank"><spring:message code="updateInfoLink"/></a>
     <br/>

--- a/hrs-portlets-webapp/src/main/webapp/css/HRSPortlet.css
+++ b/hrs-portlets-webapp/src/main/webapp/css/HRSPortlet.css
@@ -89,4 +89,7 @@
  .dl-benefit-summary .dl-banner-links .dl-banner-link a {
     font-weight:bold;
  }
- 
+
+.federal-reporting-statuses {
+    margin-top: 1em;
+}


### PR DESCRIPTION
Add voluntary status reporting view/edit links to the Personal Information HRS portlet.

As per [mockup](http://6zngze.axshare.com/#p=myuw_-_personal_information__new_) 
- Adds 3 statuses with (view/edit) links.
- Updates the instructions note at the bottom of the portlet.
- Changes "Update my Personal Information" to sentence-case "Update my personal information"

Differs from mockup in _not_ adding additional "Update my personal information" link alongside Help.  Fought with CSS on that for a bit and then gave up -- if we want to realize that part of the updated design, should loop in @jhanstra to make what I'm sure is a very feasible tweak for one more comfortable in CSS.

Gets the URLs for the (view/edit) links from the HRS URL service using the keys specified in [HRSPLT-148](https://jira.doit.wisc.edu/jira/browse/HRSPLT-148).
