### PR TITLE
Add logging to SOAP HRS URL DAO and update unit test

### DIFF
--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/url/SoapHrsUrlDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/url/SoapHrsUrlDao.java
@@ -63,7 +63,13 @@ public class SoapHrsUrlDao extends BaseHrsSoapDao implements HrsUrlDao {
 	    
 	    final GetCompIntfcUWPORTAL1URLResponse response = this.internalInvoke(request);
 	    
-	    return this.convertUrlMap(response);
+	    Map<String, String> urlMap = this.convertUrlMap(response);
+
+        if (logger.isInfoEnabled()) {
+            logger.info(computeUrlMapLogMessage(urlMap));
+        }
+
+        return urlMap;
     }
 
     protected Map<String, String> convertUrlMap(final GetCompIntfcUWPORTAL1URLResponse response) {
@@ -78,5 +84,29 @@ public class SoapHrsUrlDao extends BaseHrsSoapDao implements HrsUrlDao {
         }
 	    
         return hrsUrls;
+    }
+
+    /**
+     * Compute a loggable String describing the retrieved URL map, to enable reasonable logging.
+     * This method is non-private only to enable unit testing.
+     * This method is not part of the exposed API of this class.
+     * @param urlMap non-null Map from String keys to String values
+     * @return a String suitable for logging.
+     */
+    static String computeUrlMapLogMessage(final Map<String, String> urlMap) {
+
+        StringBuilder logMessage = new StringBuilder();
+        logMessage.append("Retrieved URL map (and updating the URL map cache) with these name : value pairs: \n");
+
+        for (Map.Entry<String, String> entry : urlMap.entrySet()) {
+            logMessage.append("  ");
+            logMessage.append(entry.getKey());
+            logMessage.append(" : ");
+            logMessage.append(entry.getValue());
+            logMessage.append("\n");
+        }
+
+        return logMessage.toString();
+
     }
 }

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/url/SoapHrsUrlDaoIT.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/url/SoapHrsUrlDaoIT.java
@@ -50,6 +50,8 @@ public class SoapHrsUrlDaoIT extends BaseSoapDaoTest {
     protected void verifyMappedData(final Map<String, String> urlMap) {
         assertNotNull(urlMap);
         assertEquals(17, urlMap.size());
-        assertEquals("https://www.google.com/#q=Disability+Status", urlMap.get("Disability Status"));
+        assertEquals(
+          "https://proxy.hrstest.ps.wisconsin.edu/psc/hrtst-bd/EMPLOYEE/HRMS/c/UW_HR_SS_PI_MENU.UW_DISABL_STS_SELF.GBL",
+          urlMap.get("Disability Status"));
     }
 }

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/url/SoapHrsUrlDaoIT.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/url/SoapHrsUrlDaoIT.java
@@ -49,6 +49,7 @@ public class SoapHrsUrlDaoIT extends BaseSoapDaoTest {
 
     protected void verifyMappedData(final Map<String, String> urlMap) {
         assertNotNull(urlMap);
-        assertEquals(14, urlMap.size());
+        assertEquals(17, urlMap.size());
+        assertEquals("https://www.google.com/#q=Disability+Status", urlMap.get("Disability Status"));
     }
 }

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/url/SoapHrsUrlDaoTest.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/url/SoapHrsUrlDaoTest.java
@@ -20,14 +20,17 @@ package edu.wisc.hrs.dao.url;
 
 import static junit.framework.Assert.assertNotNull;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.xml.transform.stream.StreamSource;
 
+import edu.wisc.hr.dao.roles.HrsRolesDao;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -82,5 +85,24 @@ public class SoapHrsUrlDaoTest extends SoapHrsUrlDaoIT {
         
         final Map<String, String> urlMap = client.convertUrlMap(response);
         verifyMappedData(urlMap);
+    }
+
+    /**
+     * Test that the log message computation utility method composes messages as expected.
+     */
+    @Test
+    public void testUrlMapLogMessageComputation() {
+
+        final Map<String, String> someKeyValuePairs = new HashMap<String, String>();
+        someKeyValuePairs.put("key1", "value1");
+
+        System.out.println(SoapHrsUrlDao.computeUrlMapLogMessage(someKeyValuePairs));
+
+        final String expected =
+                "Retrieved URL map (and updating the URL map cache) with these name : value pairs: \n" +
+                "  key1 : value1\n";
+
+        assertEquals(expected, SoapHrsUrlDao.computeUrlMapLogMessage(someKeyValuePairs));
+
     }
 }

--- a/hrs-portlets-ps-impl/src/test/resources/hrs/url.xml
+++ b/hrs-portlets-ps-impl/src/test/resources/hrs/url.xml
@@ -91,4 +91,19 @@
         <m90:Descr>Open Enrollment/Hire Event</m90:Descr>
         <m90:Adp>N</m90:Adp>
     </m90:Installation>
+    <m90:Installation>
+        <m90:Url>https://www.google.com/#q=Disability+Status</m90:Url>
+        <m90:Descr>Disability Status</m90:Descr>
+        <m90:Adp>N</m90:Adp>
+    </m90:Installation>
+    <m90:Installation>
+        <m90:Url>https://www.google.com/#q=Veteran%20Status</m90:Url>
+        <m90:Descr>Veteran Status</m90:Descr>
+        <m90:Adp>N</m90:Adp>
+    </m90:Installation>
+    <m90:Installation>
+        <m90:Url>https://www.google.com/#q=Ethnic+Groups</m90:Url>
+        <m90:Descr>Ethnic Groups</m90:Descr>
+        <m90:Adp>N</m90:Adp>
+    </m90:Installation>
 </m90:Get__CompIntfc__UW_PORTAL1_URLResponse>

--- a/hrs-portlets-ps-impl/src/test/resources/hrs/url.xml
+++ b/hrs-portlets-ps-impl/src/test/resources/hrs/url.xml
@@ -92,17 +92,17 @@
         <m90:Adp>N</m90:Adp>
     </m90:Installation>
     <m90:Installation>
-        <m90:Url>https://www.google.com/#q=Disability+Status</m90:Url>
+        <m90:Url>https://proxy.hrstest.ps.wisconsin.edu/psc/hrtst-bd/EMPLOYEE/HRMS/c/UW_HR_SS_PI_MENU.UW_DISABL_STS_SELF.GBL</m90:Url>
         <m90:Descr>Disability Status</m90:Descr>
         <m90:Adp>N</m90:Adp>
     </m90:Installation>
     <m90:Installation>
-        <m90:Url>https://www.google.com/#q=Veteran%20Status</m90:Url>
+        <m90:Url>https://proxy.hrstest.ps.wisconsin.edu/psc/hrtst-bd/EMPLOYEE/HRMS/c/UW_HR_SS_PI_MENU.UW_VEVRAA_STS_SELF.GBL</m90:Url>
         <m90:Descr>Veteran Status</m90:Descr>
         <m90:Adp>N</m90:Adp>
     </m90:Installation>
     <m90:Installation>
-        <m90:Url>https://www.google.com/#q=Ethnic+Groups</m90:Url>
+        <m90:Url>https://proxy.hrstest.ps.wisconsin.edu/psc/hrtst-bd/EMPLOYEE/HRMS/c/ROLE_EMPLOYEE.HR_ETHNIC_GROUPS.GBL</m90:Url>
         <m90:Descr>Ethnic Groups</m90:Descr>
         <m90:Adp>N</m90:Adp>
     </m90:Installation>


### PR DESCRIPTION
- Updates the unit test to include the three new URL keys in #8 .
- Adds `INFO` level logging to the SOAP implementation of the HRS URL DAO to help with troubleshooting whether the URLs are being read properly in a given deployment environment.  Unit tests the underlying log message composition.

This shouldn't result in an overwhelming amount of noise in the logs since the DAO refreshes only infrequently, what with the caching annotation.  `INFO` level because in practice we seem to have trouble with knowing whether and where the URL values are updating.
