### PR TITLE
HRSPLT-148 fix UI glitches in voluntary status reporting

### DIFF
--- a/hrs-portlets-webapp/src/main/resources/messages.properties
+++ b/hrs-portlets-webapp/src/main/resources/messages.properties
@@ -36,7 +36,7 @@ updateInfoLink=Update my personal information
 no=No
 yes=Yes
 
-bottomNote=Please note that you can update Home Address, Phone, Release Home Address Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in Oracle.  To update your Business/Office Address, please contact your Payroll Office.
+bottomNote=Please note that you can update Home Address, Phone, Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in Oracle.  To update your Business/Office Address, please contact your Payroll Office.
 
 noEmplId=There is no employment record identifier available for your account.
 genericError=Data could not be retrieved, please try again later. If the problem persists, contact the UW Service Center Support Team at 855-4UW-SUPP or 608-890-1501 and select option 1, via email at <a href="mailto:servicecenter@sc.wisc.edu">servicecenter@sc.wisc.edu</a>, or via chat. <a class="dl-refresh" href="{0}">Refresh</a>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -204,7 +204,7 @@
     <a href="${hrsUrls['Personal Information']}" target="_blank"><spring:message code="updateInfoLink"/></a>
     <br/>
     <div>
-    <spring:message code="bottomNote" text="Please note that you can update Home Address, Phone, Release Home Address Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in Oracle.  To update your Business/Office Address, please contact your Payroll Office."/>
+    <spring:message code="bottomNote" text="Please note that you can update Home Address, Phone, Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in Oracle.  To update your Business/Office Address, please contact your Payroll Office."/>
     </div>
   </div>
   

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -182,21 +182,21 @@
   <div class="federal-reporting-statuses">
       <div>
           <span class="label"><spring:message code="label.disability.status" text="Disability Status"/></span>
-          <span>(<a href="${hrsUrls['Disability Status']}" target="_blank">
+          <span>( <a href="${hrsUrls['Disability Status']}" target="_blank">
               <spring:message code="label.status.link" text="view/update"/>
-                 </a>)</span>
+                 </a> )</span>
       </div>
       <div>
           <span class="label"><spring:message code="label.veteran.status" text="Veteran Status"/></span>
-          <span>(<a href="${hrsUrls['Veteran Status']}" target="_blank">
+          <span>( <a href="${hrsUrls['Veteran Status']}" target="_blank">
               <spring:message  code="label.status.link" text="view/update"/>
-                 </a>)</span>
+                 </a> )</span>
       </div>
       <div>
           <span class="label"><spring:message code="label.ethnic.groups" text="Ethnic Groups"/></span>
-          <span>(<a href="${hrsUrls['Ethnic Groups']}" target="_blank">
+          <span>( <a href="${hrsUrls['Ethnic Groups']}" target="_blank">
               <spring:message code="label.status.link" text="view/update"/>
-                 </a>)</span>
+                 </a> )</span>
       </div>
   </div>
 


### PR DESCRIPTION
Fixes a couple UI glitches I noticed when reviewing on my-test.
- Remove a redundant "Home Address Release" in the bottom note text on Personal Information.
- Normalize spacing around "view/update" within its paren from `( view/update)` to `( view/update )`.

Before:

![note_before](https://cloud.githubusercontent.com/assets/952283/4383635/a28b83b4-43a7-11e4-9791-cac73530853a.png)

After:

![note_after](https://cloud.githubusercontent.com/assets/952283/4383637/a7ebacbc-43a7-11e4-8c15-c67eb181a331.png)

Before:

![paren_before](https://cloud.githubusercontent.com/assets/952283/4383640/ac802e1a-43a7-11e4-853f-66c2467579c9.png)

After:

![paren_after](https://cloud.githubusercontent.com/assets/952283/4383641/af2dd0c2-43a7-11e4-9fe3-fff86cb814e4.png)
