### PR TITLE
HRSPLT-166 Gracefully degrade when status URLs not available

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -180,24 +180,32 @@
   </div>
 
   <div class="federal-reporting-statuses">
+      <c:if test="${not empty hrsUrls['Disability Status']}">
       <div>
           <span class="label"><spring:message code="label.disability.status" text="Disability Status"/></span>
           <span>( <a href="${hrsUrls['Disability Status']}" target="_blank">
               <spring:message code="label.status.link" text="view/update"/>
                  </a> )</span>
       </div>
+      </c:if>
+
+      <c:if test="${not empty hrsUrls['Veteran Status']}">
       <div>
           <span class="label"><spring:message code="label.veteran.status" text="Veteran Status"/></span>
           <span>( <a href="${hrsUrls['Veteran Status']}" target="_blank">
               <spring:message  code="label.status.link" text="view/update"/>
                  </a> )</span>
       </div>
+      </c:if>
+
+      <c:if test="${not empty hrsUrls['Ethnic Groups']}">
       <div>
           <span class="label"><spring:message code="label.ethnic.groups" text="Ethnic Groups"/></span>
           <span>( <a href="${hrsUrls['Ethnic Groups']}" target="_blank">
               <spring:message code="label.status.link" text="view/update"/>
                  </a> )</span>
       </div>
+      </c:if>
   </div>
 
   <div class="dl-contact-info-update">


### PR DESCRIPTION
Gracefully degrade in showing or not the new voluntary status reporting links depending on whether those URLs are available in the URL map.  This will allow the updated portlet to migrate to production independently of the timeline on which the new URL key-value pairs are available in the production HRS web services.

Thought of this improvement to robustness in the face of actually experiencing what the portlet now looks like when these URLs aren't available (it's confusing).
