### PR TITLE
HRSPLT-177 Updates text at bottom of Personal Info

### DIFF
--- a/hrs-portlets-webapp/src/main/resources/messages.properties
+++ b/hrs-portlets-webapp/src/main/resources/messages.properties
@@ -36,7 +36,8 @@ updateInfoLink=Update my personal information
 no=No
 yes=Yes
 
-bottomNote=Please note that you can update Home Address, Phone, Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in Oracle.  To update your Business/Office Address, please contact your Payroll Office.
+bottomNotePart1=Please note that you can update Home Address, Phone, Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in HRS.
+bottomNotePart2=To update your Business/Office Address, please contact your Payroll Office.
 
 noEmplId=There is no employment record identifier available for your account.
 genericError=Data could not be retrieved, please try again later. If the problem persists, contact the UW Service Center Support Team at 855-4UW-SUPP or 608-890-1501 and select option 1, via email at <a href="mailto:servicecenter@sc.wisc.edu">servicecenter@sc.wisc.edu</a>, or via chat. <a class="dl-refresh" href="{0}">Refresh</a>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -105,7 +105,7 @@
 		</div>
 		<div class='edit-notice'>
 	  		<c:if test="${!empty prefs['notice'][0]}">
-			  <p>
+			  <p class="prefNotice">
 			  	 ${prefs['notice'][0]}
 			  </p>
 			</c:if>
@@ -212,7 +212,14 @@
     <a href="${hrsUrls['Personal Information']}" target="_blank"><spring:message code="updateInfoLink"/></a>
     <br/>
     <div>
-    <spring:message code="bottomNote" text="Please note that you can update Home Address, Phone, Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in Oracle.  To update your Business/Office Address, please contact your Payroll Office."/>
+        <p class="padded-paragraph">
+            <spring:message code="bottomNotePart1" text="Please note that you can update Home Address, Phone, Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in HRS."/>
+        </p>
+        <p>
+            <strong>
+                <spring:message code="bottomNotePart2" text="To update your Business/Office Address, please contact your Payroll Office."/>
+            </strong>
+        </p>
     </div>
   </div>
   

--- a/hrs-portlets-webapp/src/main/webapp/css/HRSPortlet.css
+++ b/hrs-portlets-webapp/src/main/webapp/css/HRSPortlet.css
@@ -28,7 +28,7 @@
  	padding : 1em;
  }
  
- .dl-contact-info p {
+ .dl-contact-info p.pref-notice {
  	font-style: italic;
  	font-size: x-small;
  }


### PR DESCRIPTION
Split the `bottom message` in the message bundle into two parts.

Also adds in styling to that second part.

Before:
![image](https://cloud.githubusercontent.com/assets/5521429/4544988/82a4417c-4e37-11e4-8be9-0b70be17676b.png)

After:
![image](https://cloud.githubusercontent.com/assets/5521429/4544998/a6a80b62-4e37-11e4-916a-9455e54574b6.png)
