### PR TITLE
HRSPLT-183 modifies styling to work with bucky

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -115,11 +115,11 @@
   
   <div class="contact-info-job">
     <div class="contact-info-dept">
-      <span class="label"><spring:message code="departmentLabel"/></span>
+      <span><strong><spring:message code="departmentLabel"/></strong></span>
       <span> ${fn:escapeXml(contactInformation.primaryJob.departmentName)}</span>
     </div>
     <div class="contact-info-title">
-      <span class="label"><spring:message code="titleLabel"/></span>
+      <span><strong><spring:message code="titleLabel"/></strong></span>
       <span> ${fn:escapeXml(contactInformation.primaryJob.title)}</span>
     </div>
   </div>
@@ -127,11 +127,11 @@
     <c:if test="${contactInformation.primaryJob != otherJob}">
 	    <div class="contact-info-other-job">
 	      <div class="contact-info-dept">
-	        <span class="label"><spring:message code="otherDepartmentLabel"/></span>
+	        <span><strong><spring:message code="otherDepartmentLabel"/></strong></span>
 	        <span> ${fn:escapeXml(otherJob.departmentName)}</span>
 	      </div>
 	      <div class="contact-info-title">
-	        <span class="label"><spring:message code="titleLabel"/></span>
+	        <span><strong><spring:message code="titleLabel"/></strong></span>
 	        <span> ${fn:escapeXml(otherJob.title)}</span>
 	      </div>
 	    </div>
@@ -140,12 +140,12 @@
   <hrs:addressOut messagePrefix="office" address="${contactInformation.officeAddress}" />
   <c:if test="${not empty contactInformation.officeAddress.otherPhone}">
     <div class="contact-info-phone">
-      <span class="label"><spring:message code="otherPhoneLabel" /></span>
+      <span><strong><spring:message code="otherPhoneLabel" /></strong></span>
       <span> ${fn:escapeXml(contactInformation.officeAddress.otherPhone)}</span>
     </div>
   </c:if>
   <div class="business-email-details">
-    <span class="label">Campus Business Email: </span>
+    <span><strong>Campus Business Email:</strong> </span>
     <!-- TODO switch to spring-sec role check? -->
     <span class="email-address">${fn:escapeXml(contactInformation.email)}</span>
     <c:if test="${showBusinessEmail and not empty preferredEmail.name}">
@@ -168,7 +168,7 @@
   </div>
   <hrs:addressOut messagePrefix="home" address="${contactInformation.homeAddress}" />
   <div class="home-addr-release">
-    <span class="label"><spring:message code="releaseHomeAddress"/></span>
+    <span><strong><spring:message code="releaseHomeAddress"/></strong></span>
     <c:choose>
       <c:when test="${contactInformation.homeAddress.releaseHomeAddress}">
         <span> <spring:message code="yes"/></span>
@@ -182,7 +182,7 @@
   <div class="federal-reporting-statuses">
       <c:if test="${not empty hrsUrls['Disability Status']}">
       <div>
-          <span class="label"><spring:message code="label.disability.status" text="Disability Status"/></span>
+          <span><strong><spring:message code="label.disability.status" text="Disability Status"/></strong></span>
           <span>( <a href="${hrsUrls['Disability Status']}" target="_blank">
               <spring:message code="label.status.link" text="view/update"/>
                  </a> )</span>
@@ -191,7 +191,7 @@
 
       <c:if test="${not empty hrsUrls['Veteran Status']}">
       <div>
-          <span class="label"><spring:message code="label.veteran.status" text="Veteran Status"/></span>
+          <span><strong><spring:message code="label.veteran.status" text="Veteran Status"/></strong></span>
           <span>( <a href="${hrsUrls['Veteran Status']}" target="_blank">
               <spring:message  code="label.status.link" text="view/update"/>
                  </a> )</span>
@@ -200,7 +200,7 @@
 
       <c:if test="${not empty hrsUrls['Ethnic Groups']}">
       <div>
-          <span class="label"><spring:message code="label.ethnic.groups" text="Ethnic Groups"/></span>
+          <span><strong><spring:message code="label.ethnic.groups" text="Ethnic Groups"/></strong></span>
           <span>( <a href="${hrsUrls['Ethnic Groups']}" target="_blank">
               <spring:message code="label.status.link" text="view/update"/>
                  </a> )</span>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/emailUpdateForm.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/emailUpdateForm.jsp
@@ -66,11 +66,11 @@
               </tr>
             </c:if>
             <tr>
-              <th class="dl-email-update-label"><label class="label" for="email1">New Campus Business Email:</label></th>
+              <th class="dl-email-update-label"><label for="email1"><strong>New Campus Business Email:</strong></label></th>
               <td><input type="email" name="email1" required="required" /></td>
             </tr>
             <tr>
-              <th class="dl-email-update-label"><label class="label" for="email2">Confirm Campus Business Email:</label></th>
+              <th class="dl-email-update-label"><label for="email2"><strong>Confirm Campus Business Email:</strong></label></th>
               <td><input type="email" name="email2" required="required" /></td>
             </tr>
             <tr>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/tags/hrs/addressOut.tag
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/tags/hrs/addressOut.tag
@@ -7,7 +7,7 @@
 
 <c:if test="${not empty address}">
 <div class="contact-info-address">
-  <h4 class="contact-info-address-type"><spring:message code="${messagePrefix}Address" /></h4>
+ <h4 class="contact-info-address-type"><strong><spring:message code="${messagePrefix}Address" /></strong></h4>
 
   <div class="contact-info-room_mail">
     <hrs:out prefix='<span class="contact-info-room">Room ' data="${fn:escapeXml(address.roomNumber)}" suffix="</span>"/><hrs:out prefix='<span class="contact-info-maildrop">, Mail Drop ID: ' data="${fn:escapeXml(address.mailDrop)}" suffix="</span>"/>
@@ -18,7 +18,7 @@
   <div class="contact-info-csz"><hrs:out data="${fn:escapeXml(address.city)}" suffix=", "/><hrs:out data="${fn:escapeXml(address.state)}" suffix=" "/>${fn:escapeXml(address.zip)}</div>
 
   <div class="contact-info-phone">
-    <span class="label"><spring:message code="${messagePrefix}PhoneLabel" /></span>
+    <span><strong><spring:message code="${messagePrefix}PhoneLabel" /></strong></span>
     <span> ${fn:escapeXml(address.primaryPhone)}</span>
   </div>  
 </div>


### PR DESCRIPTION
Adds strong tag to items that want to be displayed strong.  
This is an issue in bucky only, respondr/mUniversality/universality doesn't have this issue because the label class isn't being overwritten.

The styling for mUniversality/universality looks similar with this new change.  The styling on bucky looks dramatically different.

If there is a better spot to put the `<strong>` tags, I am A-OK to moving them around (ie, pre span, etc).
# Bucky
## Before

![alt text](http://goo.gl/GkGXDJ)
## After

![alt text](http://goo.gl/XHT5O2)
# Universality
## Before

![alt text](http://goo.gl/3huAkk)
## After

![alt text](http://goo.gl/41cCrN)
# mUniversality
## Before

![alt text](http://goo.gl/nf2dVp)
## After

![alt text](http://goo.gl/r0Jc6d)

Relies on the changes to uPortal bucky styling it pull request: https://github.com/UW-Madison-DoIT/uPortal/pull/254  If that PR isn't merged, just some styling is off.  They can go independent of each other.
