### PR TITLE
HRSPLT-191 add Year End Leave Balance link.

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -40,6 +40,12 @@
   <hrs:notification/>
   
   <div>
+    <c:if test="${not empty hrsUrls['Year End Leave Balances']}">
+        <div class="dl-link">
+            <a href="${hrsUrls['Year End Leave Balances']}"
+               target="_blank">Year End Leave Balances</a><br/>
+        </div>
+    </c:if>
     <sec:authorize ifAnyGranted="ROLE_VIEW_ABSENCE_HISTORIES">
       <div class="dl-link">
         <a href="${hrsUrls['Request Absence']}" target="_blank">Enter Absence</a><br/>


### PR DESCRIPTION
Adds Year End Leave Balances link per [HRSPLT-191](https://jira.doit.wisc.edu/jira/browse/HRSPLT-191).

**Degrades gracefully**: if the URL is not included in the URLs provided to the portlet via the HRS URLs web service, no worries, it simply doesn't display the Year End Leave Balances link.  This means that this change could be promoted into tiers where the URL is not yet available, with no ill effect.  This also means that if the URL is made available in a tier and then subsequently retired (because the year-end has long since past!), no worries, the link will simply disappear.

Proposing this changeset as possibly "good enough" solution to this Blocker issue.  Would like to promote this up into test tier so it can potentially meet HRS test tier changes when they become available.

Potential issues:
1. Key to the URL may not be correct.  I've proposed the key be `Year End Leave Balances`, but that's not yet confirmed.
2. Link label may not be what is ultimately desired.  May even have to get the link label dynamically.  That's up in the air in the JIRA etc.
3. Display of the link maybe ought to be gated on the user having a particular role.  It's unclear what role should be required.  Lack of predicating on the role should not be a security vulnerability (since the other end of the URL should be enforcing its own access control), just an annoyance if not predicating means displaying it to users to whom it's not relevant.  Clarification of whether and what role is required is also running in the JIRA issue etc.
