### PR TITLE
Basic Travis-CI build-and-test safety net.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+
+install: true
+script: "mvn package"


### PR DESCRIPTION
Add basic Travis-CI configuration to build-and-test the portlet suite.

This is an additional developer safety net in addition to that provided by Jenkins.  Travis-CI will, free-of-charge because this is a public repo, build the putative result of merging pull requests before those requests are merged and will, if you let it, build the tips of your development branches in your own forks of the repo, so it can provide some build-and-test-issue-catching-goodness before our normal build-and-test goodness with Jenkins picks up.

You can see this configuration successfully working [here in my own fork](https://travis-ci.org/apetro/hrs-portlets/builds/46225922).  If this pull request is merged to `uw-master` then I can flip the switch in Travis-CI to start running Travis-CI on this `UW-Madison-DoIT` fork.
