### PR TITLE
Allow retrieving dependencies from Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,11 @@
     
     <repositories>
         <repository>
+          <id>central</id>
+          <name>central</name>
+          <url>https://repo1.maven.org/maven2</url>
+        </repository>
+        <repository>
 			<id>code.doit-uw-releases</id>
 			<name>code.doit-uw-releases</name>
 			<url>https://code.doit.wisc.edu/maven/content/repositories/uw-releases</url>


### PR DESCRIPTION
so that the Travis-CI build depends less on Madison's Nexus repo.
