### PR TITLE
HRSPLT-179: Extreme Makeover: Time & Absence edition

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -24,7 +24,69 @@
 
 <c:set var="showJobTitle" value="${fn:length(personalData.jobs) > 1}"/>
 
-<div id="${n}dl-time-absence" class="fl-widget portlet dl-time-absence">
+<style>
+.sidebar { background-color: transparent; }
+.inner-nav-container {
+  border:0px solid transparent;
+  padding:0px;
+  margin:0px;
+}
+.inner-nav-container .inner-nav {
+  background-color:#fff;
+  border:0px solid transparent;
+  border-top-left-radius:0px;
+  border-top-right-radius:0px;
+  border-bottom-left-radius:0px;
+  border-bottom-right-radius:0px;
+  padding:0px;
+  margin:0px;
+  border-bottom:1px solid #b70101;
+}
+
+
+.inner-nav-container .inner-nav li {
+  background:#fff;
+  border:0px solid transparent;
+  border-top-left-radius:0px;
+  border-top-right-radius:0px;
+  margin:0px;
+  padding:0px;
+  top:0px;
+}
+.inner-nav-container .inner-nav li a {
+  padding:8px 20px;
+  margin:0px;
+  font-size:16px;
+  font-weight:400;
+  color:#777;
+}
+.inner-nav-container .inner-nav li a:hover {
+  background-color:#fff;
+  padding:8px 20px 10px;
+  border-bottom:1px solid #b70101;
+  color:#666;
+}
+.inner-nav-container .inner-nav li.ui-tabs-selected {
+  border-bottom:3px solid #b70101 !important;
+  padding-bottom:0px;
+}
+.inner-nav-container .inner-nav li.ui-tabs-selected a {
+  font-weight:600;
+  color:#222;
+}
+.inner-nav-container .inner-nav li.ui-tabs-selected a:hover {
+padding:8px 20px;
+border-bottom:0px !important;
+}
+.inner-nav-container .inner-nav li.ui-tabs-selected a:focus {
+outline:none;
+}
+.inner-nav-container .inner-nav li.ui-tabs-selected a:active {
+outline:none;
+}
+</style>
+
+<%-- <div id="${n}dl-time-absence" class="fl-widget portlet dl-time-absence">
   <div class="dl-banner-links">
     <c:if test="${not empty hrsUrls['Benefits Enrollment']}">
       <div class="dl-banner-link">
@@ -61,22 +123,22 @@
         <a href="${hrsUrls['Web Clock']}" target="_blank">Web Clock</a><br/>
       </div>
     </sec:authorize>
-  </div>
-  <div id="${n}dl-tabs" class="dl-tabs ui-tabs ui-widget ui-widget-content ui-corner-all">
-    <ul class="ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all">
+  </div> --%>
+  <div id="${n}dl-tabs" class="dl-tabs ui-tabs ui-widget ui-widget-content ui-corner-all inner-nav-container">
+    <ul class="ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all inner-nav">
       <c:set var="activeTabStyle" value="ui-tabs-selected ui-state-active"/>
-      <sec:authorize ifAllGranted="ROLE_VIEW_ABSENCE_HISTORIES">
+      <%-- <sec:authorize ifAllGranted="ROLE_VIEW_ABSENCE_HISTORIES"> --%>
         <li class="ui-state-default ui-corner-top ${activeTabStyle}"><a href="#${n}dl-absence">Absence</a></li>
         <c:set var="activeTabStyle" value=""/>
-      </sec:authorize>
+      <%-- </sec:authorize> --%>
       <li class="ui-state-default ui-corner-top ${activeTabStyle}"><a href="#${n}dl-leave-balance">Leave Balance</a></li>
-      <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET">
+      <%-- <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET"> --%>
         <li class="ui-state-default ui-corner-top"><a href="#${n}dl-time-entry">Time Entry</a></li>
-      </sec:authorize>
+      <%-- </sec:authorize> --%>
       <li class="ui-state-default ui-corner-top"><a href="#${n}dl-absence-statements">Leave Reports</a></li>
     </ul>
     <c:set var="hiddenTabStyle" value=""/>
-    <sec:authorize ifAllGranted="ROLE_VIEW_ABSENCE_HISTORIES">
+    <%-- <sec:authorize ifAllGranted="ROLE_VIEW_ABSENCE_HISTORIES"> --%>
       <c:set var="hiddenTabStyle" value="ui-tabs-hide"/>
       <div id="${n}dl-absence" class="dl-absence ui-tabs-panel ui-widget-content ui-corner-bottom">
         <div class="fl-pager">
@@ -112,7 +174,7 @@
           <hrs:pagerNavBar position="bottom" />
         </div>
       </div>
-    </sec:authorize>
+    <%-- </sec:authorize> --%>
     <div id="${n}dl-leave-balance" class="dl-leave-balance ui-tabs-panel ui-widget-content ui-corner-bottom ${hiddenTabStyle}">
       <div class="balance-header">
         <span>Balances as of the last pay check</span>
@@ -144,7 +206,7 @@
         <hrs:pagerNavBar position="bottom" />
       </div>
     </div>
-    <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET">
+    <%-- <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET"> --%>
       <div id="${n}dl-time-entry" class="dl-time-entry ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />
@@ -188,7 +250,7 @@
           </div>
         </div>
       </div>
-    </sec:authorize>
+    <%-- </sec:authorize> --%>
     <div id="${n}dl-absence-statements" class="dl-absence-statements ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
       <div class="data-table-description-header">
         <div class="data-table-description">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -24,6 +24,28 @@
 
 <c:set var="showJobTitle" value="${fn:length(personalData.jobs) > 1}"/>
 
+<style>
+  .my-uw .dl-pager-navbar {
+    height:auto;
+    text-align:center;
+  }
+  .my-uw .dl-table {
+    margin-bottom:30px;
+  }
+  .my-uw table.dl-table {
+    border:1px solid #eee !important;
+  }
+  .my-uw table.dl-table tr:nth-child(even) {
+    background-color:#eee;
+  }
+  .my-uw .hrs-notification-wrapper {
+    padding:10px;
+    margin-bottom:50px;
+    text-align:center;
+  }
+  
+</style>
+
 <div id="${n}dl-time-absence" class="fl-widget portlet dl-time-absence">
   
   

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -25,23 +25,8 @@
 <c:set var="showJobTitle" value="${fn:length(personalData.jobs) > 1}"/>
 
 <div id="${n}dl-time-absence" class="fl-widget portlet dl-time-absence">
-  <div class="dl-banner-links">
-    <%-- <c:if test="${not empty hrsUrls['Benefits Enrollment']}"> --%>
-      <div class="dl-banner-link">
-        You have a benefit enrollment opportunity. Please enroll online by clicking the
-        following link. <a target="_blank" href="${hrsUrls['Benefits Enrollment']}">Benefits Enrollment</a> 
-      </div>
-    <%-- </c:if> --%>
-    <div class="dl-help-link">
-      <a href="${helpUrl}" target="_blank">Help</a>
-    </div>
-  </div>
   
-  <hrs:notification/>
   
-  <div>
-    
-  </div>
   <div id="${n}dl-tabs" class="dl-tabs ui-tabs ui-widget ui-widget-content ui-corner-all inner-nav-container">
     <ul class="ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all inner-nav">
       <c:set var="activeTabStyle" value="ui-tabs-selected ui-state-active"/>
@@ -61,8 +46,8 @@
       <div id="${n}dl-absence" class="dl-absence ui-tabs-panel ui-widget-content ui-corner-bottom">
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />
-          <div class="fl-container-flex dl-pager-table-data fl-pager-data">
-            <table class="dl-table table-responsive">
+          <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
+            <table class="dl-table table">
               <thead>
                 <tr rsf:id="header:">
                   <th class="flc-pager-sort-header" rsf:id="name"><a href="javascript:;">Name</a></th>
@@ -99,8 +84,8 @@
       </div>
       <div class="fl-pager">
         <hrs:pagerNavBar position="top" showSummary="${true}" />
-        <div class="fl-container-flex dl-pager-table-data fl-pager-data">
-          <table class="dl-table table-responsive">
+        <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
+          <table class="dl-table table">
             <thead>
               <tr rsf:id="header:">
                 <th class="flc-pager-sort-header" rsf:id="entitlement"><a href="javascript:;">Entitlement</a></th>
@@ -128,8 +113,8 @@
       <div id="${n}dl-time-entry" class="dl-time-entry ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />
-          <div class="fl-container-flex dl-pager-table-data fl-pager-data">
-            <table class="dl-table table-responsive">
+          <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
+            <table class="dl-table table">
               <thead>
                 <tr rsf:id="header:">
                   <th class="flc-pager-sort-header" rsf:id="date"><a href="javascript:;">Date</a></th>
@@ -157,7 +142,7 @@
           <hrs:pagerNavBar position="bottom" />
         </div>
         <div>
-          <div class="dl-link">
+          <div class="dl-link center">
             <a href="${hrsUrls['Payable time detail']}" target="_blank" class="btn btn-default">View Details</a>
             <a href="${hrsUrls['Time Exceptions']}" target="_blank" class="btn btn-default">View Time Entry Exceptions</a>
             <a href="https://uwservice.wisc.edu/docs/forms/time-missed-punch.pdf" target="_blank" class="btn btn-default">Missed Punch Form</a>
@@ -177,8 +162,8 @@
       	</p>
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />
-          <div class="fl-container-flex dl-pager-table-data fl-pager-data">
-            <table class="dl-table table-responsive">
+          <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
+            <table class="dl-table table">
               <thead>
                 <tr rsf:id="header:">
                   <th class="flc-pager-sort-header" rsf:id="payPeriod"><a href="javascript:;">Pay Period</a></th>
@@ -202,8 +187,8 @@
       <div id="${n}dl-sabbatical-reports">
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />
-          <div class="fl-container-flex dl-pager-table-data fl-pager-data">
-            <table class="dl-table table-responsive">
+          <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
+            <table class="dl-table table">
               <thead>
                 <tr rsf:id="header:">
                   <th class="flc-pager-sort-header" rsf:id="year"><a href="javascript:;">Year</a></th>
@@ -229,33 +214,32 @@
     </div>
   </div>
   <div>
-    <%--
-    <div class="dl-link">
-      <a href="${prefs['UnclassifiedFurloughTimeReport_NonInstructionalStaffUrl'][0]}" target="_blank">Unclassified Furlough Time Report - Non-Instructional Staff</a><br/>
-    </div>
-    <div class="dl-link">
-      <a href="${prefs['UnclassifiedFurloughTimeReport_InstructionalStaffUrl'][0]}" target="_blank">Unclassified Furlough Time Report - Instructional Staff</a>
-    </div>
-     --%>
-    <div class="dl-link">
-      <p><a href="${prefs['UnclassifiedLeaveReportUrl'][0]}" target="_blank">Unclassified Leave Report</a>
-      <c:if test="${not empty prefs['UnclassifiedLeaveReportForSummerUrl'][0]}"></p>
-        <p><a href="${prefs['UnclassifiedLeaveReportForSummerUrl'][0]}" target="_blank">Unclassified Summer Session/Service Leave Report</a></p>
+    <hrs:notification/>
+    <ul class="dl-link inline-link-list">
+      <c:if test="${not empty hrsUrls['Benefits Enrollment']}">
+        <p>You have a benefit enrollment opportunity. Please enroll online at <a target="_blank" href="${hrsUrls['Benefits Enrollment']}">Benefits Enrollment</a></p>
       </c:if>
-      <c:if test="${not empty hrsUrls['Year End Leave Balances']}">
-        <a href="${hrsUrls['Year End Leave Balances']}"
-          target="_blank">12/28/14 to 12/31/14 Classified Leave Balance</a><br/>
-        </c:if>
-        <sec:authorize ifAnyGranted="ROLE_VIEW_ABSENCE_HISTORIES">
-          <a href="${hrsUrls['Request Absence']}" target="_blank">Enter Absence</a><br/>
-        </sec:authorize>
-        <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_SHEET,ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK">
-          <a href="${hrsUrls['Timesheet']}" target="_blank">Timesheet</a><br/>
-        </sec:authorize>
-        <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK">
-          <a href="${hrsUrls['Web Clock']}" target="_blank">Web Clock</a><br/>
-        </sec:authorize>
-    </div>
+      <%-- <li><a href="${prefs['UnclassifiedFurloughTimeReport_NonInstructionalStaffUrl'][0]}" target="_blank">Unclassified Furlough Time Report - Non-Instructional Staff</a></li>
+      <li><a href="${prefs['UnclassifiedFurloughTimeReport_InstructionalStaffUrl'][0]}" target="_blank">Unclassified Furlough Time Report - Instructional Staff</a></li> --%>
+      <li><a href="${prefs['UnclassifiedLeaveReportUrl'][0]}" target="_blank">Unclassified Leave Report</a></li>
+      <%-- <c:if test="${not empty prefs['UnclassifiedLeaveReportForSummerUrl'][0]}"></p> --%>
+        <li><a href="${prefs['UnclassifiedLeaveReportForSummerUrl'][0]}" target="_blank">Unclassified Summer Session/Service Leave Report</a></li>
+      <%-- </c:if> --%>
+      <%-- <c:if test="${not empty hrsUrls['Year End Leave Balances']}"> --%>
+        <li><a href="${hrsUrls['Year End Leave Balances']}"
+          target="_blank">12/28/14 to 12/31/14 Classified Leave Balance</a></li>
+        <%-- </c:if> --%>
+        <%-- <sec:authorize ifAnyGranted="ROLE_VIEW_ABSENCE_HISTORIES"> --%>
+          <li><a href="${hrsUrls['Request Absence']}" target="_blank">Enter Absence</a></li>
+        <%-- </sec:authorize> --%>
+        <%-- <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_SHEET,ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK"> --%>
+          <li><a href="${hrsUrls['Timesheet']}" target="_blank">Timesheet</a></li>
+        <%-- </sec:authorize> --%>
+        <%-- <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK"> --%>
+          <li><a href="${hrsUrls['Web Clock']}" target="_blank">Web Clock</a></li>
+        <%-- </sec:authorize> --%>
+        <li><a href="${helpUrl}" target="_blank">Help</a></li>
+    </ul>
   </div>
 </div>
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -30,18 +30,18 @@
   <div id="${n}dl-tabs" class="dl-tabs ui-tabs ui-widget ui-widget-content ui-corner-all inner-nav-container">
     <ul class="ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all inner-nav">
       <c:set var="activeTabStyle" value="ui-tabs-selected ui-state-active"/>
-      <%-- <sec:authorize ifAllGranted="ROLE_VIEW_ABSENCE_HISTORIES"> --%>
+      <sec:authorize ifAllGranted="ROLE_VIEW_ABSENCE_HISTORIES">
         <li class="ui-state-default ui-corner-top ${activeTabStyle}"><a href="#${n}dl-absence">Absence</a></li>
         <c:set var="activeTabStyle" value=""/>
-      <%-- </sec:authorize> --%>
+      </sec:authorize>
       <li class="ui-state-default ui-corner-top ${activeTabStyle}"><a href="#${n}dl-leave-balance">Leave Balance</a></li>
-      <%-- <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET"> --%>
+      <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET">
         <li class="ui-state-default ui-corner-top"><a href="#${n}dl-time-entry">Time Entry</a></li>
-      <%-- </sec:authorize> --%>
+      </sec:authorize>
       <li class="ui-state-default ui-corner-top"><a href="#${n}dl-absence-statements">Leave Reports</a></li>
     </ul>
     <c:set var="hiddenTabStyle" value=""/>
-    <%-- <sec:authorize ifAllGranted="ROLE_VIEW_ABSENCE_HISTORIES"> --%>
+    <sec:authorize ifAllGranted="ROLE_VIEW_ABSENCE_HISTORIES">
       <c:set var="hiddenTabStyle" value="ui-tabs-hide"/>
       <div id="${n}dl-absence" class="dl-absence ui-tabs-panel ui-widget-content ui-corner-bottom">
         <div class="fl-pager">
@@ -77,7 +77,7 @@
           <hrs:pagerNavBar position="bottom" />
         </div>
       </div>
-    <%-- </sec:authorize> --%>
+    </sec:authorize>
     <div id="${n}dl-leave-balance" class="dl-leave-balance ui-tabs-panel ui-widget-content ui-corner-bottom ${hiddenTabStyle}">
       <div class="balance-header">
         <span>Balances as of the last pay check</span>
@@ -109,7 +109,7 @@
         <hrs:pagerNavBar position="bottom" />
       </div>
     </div>
-    <%-- <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET"> --%>
+    <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET">
       <div id="${n}dl-time-entry" class="dl-time-entry ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />
@@ -149,7 +149,7 @@
           </div>
         </div>
       </div>
-    <%-- </sec:authorize> --%>
+    </sec:authorize>
     <div id="${n}dl-absence-statements" class="dl-absence-statements ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
       <div class="data-table-description-header">
         <div class="data-table-description">
@@ -222,22 +222,22 @@
       <%-- <li><a href="${prefs['UnclassifiedFurloughTimeReport_NonInstructionalStaffUrl'][0]}" target="_blank">Unclassified Furlough Time Report - Non-Instructional Staff</a></li>
       <li><a href="${prefs['UnclassifiedFurloughTimeReport_InstructionalStaffUrl'][0]}" target="_blank">Unclassified Furlough Time Report - Instructional Staff</a></li> --%>
       <li><a href="${prefs['UnclassifiedLeaveReportUrl'][0]}" target="_blank">Unclassified Leave Report</a></li>
-      <%-- <c:if test="${not empty prefs['UnclassifiedLeaveReportForSummerUrl'][0]}"></p> --%>
+      <c:if test="${not empty prefs['UnclassifiedLeaveReportForSummerUrl'][0]}">
         <li><a href="${prefs['UnclassifiedLeaveReportForSummerUrl'][0]}" target="_blank">Unclassified Summer Session/Service Leave Report</a></li>
-      <%-- </c:if> --%>
-      <%-- <c:if test="${not empty hrsUrls['Year End Leave Balances']}"> --%>
+      </c:if>
+      <c:if test="${not empty hrsUrls['Year End Leave Balances']}">
         <li><a href="${hrsUrls['Year End Leave Balances']}"
           target="_blank">12/28/14 to 12/31/14 Classified Leave Balance</a></li>
-        <%-- </c:if> --%>
-        <%-- <sec:authorize ifAnyGranted="ROLE_VIEW_ABSENCE_HISTORIES"> --%>
+        </c:if>
+        <sec:authorize ifAnyGranted="ROLE_VIEW_ABSENCE_HISTORIES">
           <li><a href="${hrsUrls['Request Absence']}" target="_blank">Enter Absence</a></li>
-        <%-- </sec:authorize> --%>
-        <%-- <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_SHEET,ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK"> --%>
+        </sec:authorize>
+        <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_SHEET,ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK">
           <li><a href="${hrsUrls['Timesheet']}" target="_blank">Timesheet</a></li>
-        <%-- </sec:authorize> --%>
-        <%-- <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK"> --%>
+        </sec:authorize>
+        <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK">
           <li><a href="${hrsUrls['Web Clock']}" target="_blank">Web Clock</a></li>
-        <%-- </sec:authorize> --%>
+        </sec:authorize>
         <li><a href="${helpUrl}" target="_blank">Help</a></li>
     </ul>
   </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -24,76 +24,14 @@
 
 <c:set var="showJobTitle" value="${fn:length(personalData.jobs) > 1}"/>
 
-<style>
-.sidebar { background-color: transparent; }
-.inner-nav-container {
-  border:0px solid transparent;
-  padding:0px;
-  margin:0px;
-}
-.inner-nav-container .inner-nav {
-  background-color:#fff;
-  border:0px solid transparent;
-  border-top-left-radius:0px;
-  border-top-right-radius:0px;
-  border-bottom-left-radius:0px;
-  border-bottom-right-radius:0px;
-  padding:0px;
-  margin:0px;
-  border-bottom:1px solid #b70101;
-}
-
-
-.inner-nav-container .inner-nav li {
-  background:#fff;
-  border:0px solid transparent;
-  border-top-left-radius:0px;
-  border-top-right-radius:0px;
-  margin:0px;
-  padding:0px;
-  top:0px;
-}
-.inner-nav-container .inner-nav li a {
-  padding:8px 20px;
-  margin:0px;
-  font-size:16px;
-  font-weight:400;
-  color:#777;
-}
-.inner-nav-container .inner-nav li a:hover {
-  background-color:#fff;
-  padding:8px 20px 10px;
-  border-bottom:1px solid #b70101;
-  color:#666;
-}
-.inner-nav-container .inner-nav li.ui-tabs-selected {
-  border-bottom:3px solid #b70101 !important;
-  padding-bottom:0px;
-}
-.inner-nav-container .inner-nav li.ui-tabs-selected a {
-  font-weight:600;
-  color:#222;
-}
-.inner-nav-container .inner-nav li.ui-tabs-selected a:hover {
-padding:8px 20px;
-border-bottom:0px !important;
-}
-.inner-nav-container .inner-nav li.ui-tabs-selected a:focus {
-outline:none;
-}
-.inner-nav-container .inner-nav li.ui-tabs-selected a:active {
-outline:none;
-}
-</style>
-
-<%-- <div id="${n}dl-time-absence" class="fl-widget portlet dl-time-absence">
+<div id="${n}dl-time-absence" class="fl-widget portlet dl-time-absence">
   <div class="dl-banner-links">
-    <c:if test="${not empty hrsUrls['Benefits Enrollment']}">
+    <%-- <c:if test="${not empty hrsUrls['Benefits Enrollment']}"> --%>
       <div class="dl-banner-link">
         You have a benefit enrollment opportunity. Please enroll online by clicking the
         following link. <a target="_blank" href="${hrsUrls['Benefits Enrollment']}">Benefits Enrollment</a> 
       </div>
-    </c:if>
+    <%-- </c:if> --%>
     <div class="dl-help-link">
       <a href="${helpUrl}" target="_blank">Help</a>
     </div>
@@ -102,28 +40,8 @@ outline:none;
   <hrs:notification/>
   
   <div>
-    <c:if test="${not empty hrsUrls['Year End Leave Balances']}">
-        <div class="dl-link">
-            <a href="${hrsUrls['Year End Leave Balances']}"
-               target="_blank">12/28/14 to 12/31/14 Classified Leave Balance</a><br/>
-        </div>
-    </c:if>
-    <sec:authorize ifAnyGranted="ROLE_VIEW_ABSENCE_HISTORIES">
-      <div class="dl-link">
-        <a href="${hrsUrls['Request Absence']}" target="_blank">Enter Absence</a><br/>
-      </div>
-    </sec:authorize>
-    <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_SHEET,ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK">
-      <div class="dl-link">
-        <a href="${hrsUrls['Timesheet']}" target="_blank">Timesheet</a><br/>
-      </div>
-    </sec:authorize>
-    <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK">
-      <div class="dl-link">
-        <a href="${hrsUrls['Web Clock']}" target="_blank">Web Clock</a><br/>
-      </div>
-    </sec:authorize>
-  </div> --%>
+    
+  </div>
   <div id="${n}dl-tabs" class="dl-tabs ui-tabs ui-widget ui-widget-content ui-corner-all inner-nav-container">
     <ul class="ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all inner-nav">
       <c:set var="activeTabStyle" value="ui-tabs-selected ui-state-active"/>
@@ -144,7 +62,7 @@ outline:none;
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />
           <div class="fl-container-flex dl-pager-table-data fl-pager-data">
-            <table class="dl-table">
+            <table class="dl-table table-responsive">
               <thead>
                 <tr rsf:id="header:">
                   <th class="flc-pager-sort-header" rsf:id="name"><a href="javascript:;">Name</a></th>
@@ -182,7 +100,7 @@ outline:none;
       <div class="fl-pager">
         <hrs:pagerNavBar position="top" showSummary="${true}" />
         <div class="fl-container-flex dl-pager-table-data fl-pager-data">
-          <table class="dl-table">
+          <table class="dl-table table-responsive">
             <thead>
               <tr rsf:id="header:">
                 <th class="flc-pager-sort-header" rsf:id="entitlement"><a href="javascript:;">Entitlement</a></th>
@@ -211,7 +129,7 @@ outline:none;
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />
           <div class="fl-container-flex dl-pager-table-data fl-pager-data">
-            <table class="dl-table">
+            <table class="dl-table table-responsive">
               <thead>
                 <tr rsf:id="header:">
                   <th class="flc-pager-sort-header" rsf:id="date"><a href="javascript:;">Date</a></th>
@@ -240,13 +158,9 @@ outline:none;
         </div>
         <div>
           <div class="dl-link">
-            <a href="${hrsUrls['Payable time detail']}" target="_blank">View Details</a><br/>
-          </div>
-          <div class="dl-link">
-            <a href="${hrsUrls['Time Exceptions']}" target="_blank">View Time Entry Exceptions</a><br/>
-          </div>
-          <div class="dl-link">  
-            <a href="https://uwservice.wisc.edu/docs/forms/time-missed-punch.pdf" target="_blank">Missed Punch Form</a>
+            <a href="${hrsUrls['Payable time detail']}" target="_blank" class="btn btn-default">View Details</a>
+            <a href="${hrsUrls['Time Exceptions']}" target="_blank" class="btn btn-default">View Time Entry Exceptions</a>
+            <a href="https://uwservice.wisc.edu/docs/forms/time-missed-punch.pdf" target="_blank" class="btn btn-default">Missed Punch Form</a>
           </div>
         </div>
       </div>
@@ -264,7 +178,7 @@ outline:none;
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />
           <div class="fl-container-flex dl-pager-table-data fl-pager-data">
-            <table class="dl-table">
+            <table class="dl-table table-responsive">
               <thead>
                 <tr rsf:id="header:">
                   <th class="flc-pager-sort-header" rsf:id="payPeriod"><a href="javascript:;">Pay Period</a></th>
@@ -289,7 +203,7 @@ outline:none;
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />
           <div class="fl-container-flex dl-pager-table-data fl-pager-data">
-            <table class="dl-table">
+            <table class="dl-table table-responsive">
               <thead>
                 <tr rsf:id="header:">
                   <th class="flc-pager-sort-header" rsf:id="year"><a href="javascript:;">Year</a></th>
@@ -324,7 +238,23 @@ outline:none;
     </div>
      --%>
     <div class="dl-link">
-      <a href="${prefs['UnclassifiedLeaveReportUrl'][0]}" target="_blank">Unclassified Leave Report</a><c:if test="${not empty prefs['UnclassifiedLeaveReportForSummerUrl'][0]}">&nbsp;|&nbsp;<a href="${prefs['UnclassifiedLeaveReportForSummerUrl'][0]}" target="_blank">Unclassified Summer Session/Service Leave Report</a></c:if>
+      <p><a href="${prefs['UnclassifiedLeaveReportUrl'][0]}" target="_blank">Unclassified Leave Report</a>
+      <c:if test="${not empty prefs['UnclassifiedLeaveReportForSummerUrl'][0]}"></p>
+        <p><a href="${prefs['UnclassifiedLeaveReportForSummerUrl'][0]}" target="_blank">Unclassified Summer Session/Service Leave Report</a></p>
+      </c:if>
+      <c:if test="${not empty hrsUrls['Year End Leave Balances']}">
+        <a href="${hrsUrls['Year End Leave Balances']}"
+          target="_blank">12/28/14 to 12/31/14 Classified Leave Balance</a><br/>
+        </c:if>
+        <sec:authorize ifAnyGranted="ROLE_VIEW_ABSENCE_HISTORIES">
+          <a href="${hrsUrls['Request Absence']}" target="_blank">Enter Absence</a><br/>
+        </sec:authorize>
+        <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_SHEET,ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK">
+          <a href="${hrsUrls['Timesheet']}" target="_blank">Timesheet</a><br/>
+        </sec:authorize>
+        <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK">
+          <a href="${hrsUrls['Web Clock']}" target="_blank">Web Clock</a><br/>
+        </sec:authorize>
     </div>
   </div>
 </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/tags/hrs/pagerNavBar.tag
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/tags/hrs/pagerNavBar.tag
@@ -14,7 +14,6 @@
     <li>
       <ul class="flc-pager-links dl-pager-links">
         <li class="flc-pager-pageLink dl-pager-pageLink-default"><a href="javascript:;" class="btn btn-default">1</a></li>
-        <%-- <li class="flc-pager-pageLink-skip dl-pager-pageLink-skip">&#8230;</li> --%>
         <li class="flc-pager-pageLink"><a href="javascript:;" class="btn btn-default">2</a></li>
       </ul>
     </li>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/tags/hrs/pagerNavBar.tag
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/tags/hrs/pagerNavBar.tag
@@ -7,20 +7,20 @@
 <%@ attribute name="hideNav" description="If the entire nav bar should be hidden" %>
 
 <div class="flc-pager-${position} dl-pager-navbar" style="display:none">
-  <ul class="dl-pager-bar fl-pager-ui">
+  <ul class="dl-pager-bar fl-pager-ui uw-pager-bar">
     <li class="flc-pager-previous dl-pager-previous">
-      <a href="javascript:;" title="Previous Page">&lt; Previous</a>
+      <a href="javascript:;" title="Previous Page" class="btn btn-default">Previous</a>
     </li>
     <li>
       <ul class="flc-pager-links dl-pager-links">
-        <li class="flc-pager-pageLink dl-pager-pageLink-default"><a href="javascript:;">1</a></li>
-        <li class="flc-pager-pageLink-skip dl-pager-pageLink-skip">&#8230;</li>
-        <li class="flc-pager-pageLink"><a href="javascript:;">2</a></li>
+        <li class="flc-pager-pageLink dl-pager-pageLink-default"><a href="javascript:;" class="btn btn-default">1</a></li>
+        <%-- <li class="flc-pager-pageLink-skip dl-pager-pageLink-skip">&#8230;</li> --%>
+        <li class="flc-pager-pageLink"><a href="javascript:;" class="btn btn-default">2</a></li>
       </ul>
     </li>
-    <li class="flc-pager-next dl-pager-next"><a href="javascript:;" title="Next Page">Next &gt;</a></li>
-    <c:if test="${showSummary == true}">
+    <li class="flc-pager-next dl-pager-next"><a href="javascript:;" title="Next Page" class="btn btn-default">Next</a></li>
+    <%-- <c:if test="${showSummary == true}">
       <li class="flc-pager-summary hrs-pager-summary"></li>
-    </c:if>
+    </c:if> --%>
   </ul>
 </div>


### PR DESCRIPTION
## Overview

In the process of adding styles to the Time & Absence portlet (and thinking about the other HRS portlets as well), I thought about better ways to organize the content in the portlet. CSS can only get you so far in designing a better user experience before you have to actually move elements around on the page to make the experience better. The big things I did were to make important links into buttons, move all other not-as-important links to the bottom, center much of the content, put the tabs at the top as navigation, and use Bootstrap/UW-UI-Toolkit for much of the UI components.
## Why

I think there are a number of things in the Time & Absence portlet that can be improved, and I tried to address each of them in this pull request. Let me know what your thoughts are on these:
- The links at the top of the portlet (Help, HRS notification, and Classified Leave Balance, etc - these are the ones that show for me, though other people could see a few more) clutter the top of the div and detract from finding the information that matters
- The table is scrunched and the content of the table is the same size as everything else
- The beige color is gross
- The tabs that serve as the main navigation are not at the top of the portlet
- The Next/Previous/page links are not clearly pagination links (and kind of ugly)
- There's a lack of symmetry and balance, and makes the portlet feel hacky and unorganized
## Before

![image](https://cloud.githubusercontent.com/assets/1919535/6063699/d5f5d14c-ad1e-11e4-9c53-9b3169e14810.png)

![image](https://cloud.githubusercontent.com/assets/1919535/6063706/e9f6f004-ad1e-11e4-8047-0de42eb3b2d4.png)
## After

![screen shot 2015-02-04 at 8 20 28 pm](https://cloud.githubusercontent.com/assets/1919535/6063711/f1c1762e-ad1e-11e4-83d9-7327cf6fb384.png)

![screen shot 2015-02-04 at 8 20 54 pm](https://cloud.githubusercontent.com/assets/1919535/6063714/f5b281ce-ad1e-11e4-8908-517c1e0c86f7.png)

![screen shot 2015-02-04 at 8 21 08 pm](https://cloud.githubusercontent.com/assets/1919535/6063716/f9ca247e-ad1e-11e4-9c20-a31380429a0f.png)
Note above the links that are most important and action-y are buttons. Links to KB docs, etc are relegated to the link section at the bottom.

Mobile:
![screen shot 2015-02-04 at 8 21 55 pm](https://cloud.githubusercontent.com/assets/1919535/6063720/014cf42e-ad1f-11e4-9052-117a19f5f96b.png)

![screen shot 2015-02-04 at 8 21 28 pm](https://cloud.githubusercontent.com/assets/1919535/6063718/fc90e4b8-ad1e-11e4-8275-efb9e33f9e8f.png)
