### PR TITLE
HRSPLT-169: mUniversality is more functional

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
@@ -50,6 +50,15 @@
   .flc-pager-top {
     margin-top:15px;
   }
+  .portlet .fl-pager ul.fl-pager-ui.dl-pager-bar {
+    text-align:center;
+  }
+  .up .fl-pager .fl-pager-ui .flc-pager-next {
+    position:relative;
+  }
+  .up .fl-pager .fl-pager-ui .flc-pager-previous {
+    position:relative;
+  }
 </style>
 
 <div id="${n}dl-benefit-summary" class="fl-widget portlet dl-benefit-summary">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerTimeApproval.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerTimeApproval.jsp
@@ -50,6 +50,15 @@
   .flc-pager-top {
     margin-top:15px;
   }
+  .portlet .fl-pager ul.fl-pager-ui.dl-pager-bar {
+    text-align:center;
+  }
+  .up .fl-pager .fl-pager-ui .flc-pager-next {
+    position:relative;
+  }
+  .up .fl-pager .fl-pager-ui .flc-pager-previous {
+    position:relative;
+  }
 
 </style>
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -50,6 +50,15 @@
   .flc-pager-top {
     margin-top:15px;
   }
+  .portlet .fl-pager ul.fl-pager-ui.dl-pager-bar {
+    text-align:center;
+  }
+  .up .fl-pager .fl-pager-ui .flc-pager-next {
+    position:relative;
+  }
+  .up .fl-pager .fl-pager-ui .flc-pager-previous {
+    position:relative;
+  }
 
 </style>
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -52,6 +52,15 @@
   .flc-pager-top {
     margin-top:15px;
   }
+  .portlet .fl-pager ul.fl-pager-ui.dl-pager-bar {
+    text-align:center;
+  }
+  .up .fl-pager .fl-pager-ui .flc-pager-next {
+    position:relative;
+  }
+  .up .fl-pager .fl-pager-ui .flc-pager-previous {
+    position:relative;
+  }
 
   
 </style>


### PR DESCRIPTION
Now the arrows don't cover up the page numbers so you can more easily navigate the portlets under mUniversality. Still doesn't look spectacular but it's functional. Also the previous changes made to HRS portlets helped.
### Before:

![image](https://cloud.githubusercontent.com/assets/1919535/6152345/01c64c26-b1e2-11e4-8588-3d2fe58f0208.png)
### After:

![image](https://cloud.githubusercontent.com/assets/1919535/6152157/8bd07808-b1e0-11e4-8275-f42edb3975fc.png)
