### PR TITLE
HRSPLT-212 Change HRS portlets error message to be more generic.

### DIFF
--- a/hrs-portlets-webapp/src/main/resources/messages.properties
+++ b/hrs-portlets-webapp/src/main/resources/messages.properties
@@ -40,8 +40,8 @@ bottomNotePart1=Please note that you can update Home Address, Phone, Release Inf
 bottomNotePart2=To update your Business/Office Address, please contact your Payroll Office.
 
 noEmplId=There is no employment record identifier available for your account.
-genericError=Data could not be retrieved, please try again later. If the problem persists, contact the UW Service Center Support Team at 855-4UW-SUPP or 608-890-1501 and select option 1, via email at <a href="mailto:servicecenter@sc.wisc.edu">servicecenter@sc.wisc.edu</a>, or via chat. <a class="dl-refresh" href="{0}">Refresh</a>
-genericStatementError=Data could not be retrieved, please try again later. If the problem persists, contact the UW Service Center Support Team at 855-4UW-SUPP or 608-890-1501 and select option 1, via email at <a href="mailto:servicecenter@sc.wisc.edu">servicecenter@sc.wisc.edu</a>, or via chat.
+genericError=Sorry! MyUW was unable to retrieve your data. Please try again later or <a href="https://kb.wisc.edu/myuw/page.php?id=50338" target="_blank">learn how to get help with this issue.</a>
+genericStatementError=Sorry!  MyUW was unable to retrieve your data. Please try again later or <a href="https://kb.wisc.edu/myuw/page.php?id=50338" target="_blank">learn how to get help with this issue.</a>
 refresh=Refresh
 noLeaveOrSabbaticalStatements=You have no Leave Reports or Sabbatical statements.
 

--- a/hrs-portlets-webapp/src/main/resources/messages.properties
+++ b/hrs-portlets-webapp/src/main/resources/messages.properties
@@ -40,8 +40,8 @@ bottomNotePart1=Please note that you can update Home Address, Phone, Release Inf
 bottomNotePart2=To update your Business/Office Address, please contact your Payroll Office.
 
 noEmplId=There is no employment record identifier available for your account.
-genericError=Sorry! MyUW was unable to retrieve your data. Please try again later or <a href="https://kb.wisc.edu/myuw/page.php?id=50338" target="_blank">learn how to get help with this issue.</a>
-genericStatementError=Sorry!  MyUW was unable to retrieve your data. Please try again later or <a href="https://kb.wisc.edu/myuw/page.php?id=50338" target="_blank">learn how to get help with this issue.</a>
+genericError=Sorry! MyUW was unable to load your information. Please try again later or <a href="https://kb.wisc.edu/myuw/page.php?id=50338" target="_blank">get help</a>.
+genericStatementError=Sorry! MyUW was unable to load your information. Please try again later or <a href="https://kb.wisc.edu/myuw/page.php?id=50338" target="_blank">get help</a>.
 refresh=Refresh
 noLeaveOrSabbaticalStatements=You have no Leave Reports or Sabbatical statements.
 


### PR DESCRIPTION
Changes the error message to be less specific and link a KBA rather than providing contact info directly, so that we are more able to hot-edit the troubleshooting guidance via the KBA.

New message:

> Sorry! MyUW was unable to load your information. Please try again later or [get help](https://kb.wisc.edu/myuw/page.php?id=50338).

In response to the pending WiscIT ticket about this.

Did not test on localhost.  It's a message change.  Intend to test on my-test post-merge.
## Before:

![myuw-data-cannot-be-retrieved-](https://cloud.githubusercontent.com/assets/952283/7116487/7eb9f296-e1b7-11e4-8977-d5f8bb5f8aa1.png)
