### PR TITLE
HRSPLT-234 Tweak Leave Reports empty state to rm Sabbatical terminology.

### DIFF
--- a/hrs-portlets-webapp/src/main/resources/messages.properties
+++ b/hrs-portlets-webapp/src/main/resources/messages.properties
@@ -41,7 +41,7 @@ bottomNotePart2=To update your Business/Office Address, please contact your Payr
 
 noEmplId=There is no employment record identifier available for your account.
 refresh=Refresh
-noLeaveOrSabbaticalStatements=You have no Leave Reports or Sabbatical statements.
+noLeaveOrSabbaticalStatements=You have no Leave Reports or Banked Leave statements.
 
 label.official.name=Primary/Legal Name
 label.preferred.name=Preferred Name


### PR DESCRIPTION
Update the empty state message for the Leave Reports tab to stop using the deprecated "Sabbatical" terminology and instead use the now preferred "Banked Leave" terminology.
