### PR TITLE
HRSPLT-235 Note in Time and Absence that Sabbatical is now Banked Leave.

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -38,7 +38,11 @@
     </div>
   </div>
   <div class="fl-widget hrs-notification-wrapper alert alert-info">
-    <div class="hrs-notification-content">&quot;Sabbatical&quot; is now labeled as &quot;Banked Leave.&quot;  Balances are unaffected by this name change.</div>
+    <div class="hrs-notification-content">
+      <a href="https://uwservice.wisc.edu/news/post/254" target="_blank">
+        &quot;Sabbatical&quot; is now labeled as &quot;Banked Leave.&quot;</a> 
+      Balances are unaffected by this name change.
+    </div>
   </div>
       <hrs:notification/>
   </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -37,7 +37,9 @@
       <a href="${helpUrl}" target="_blank">Help</a>
     </div>
   </div>
-    
+  <div class="fl-widget hrs-notification-wrapper alert alert-info">
+    <div class="hrs-notification-content">&quot;Sabbatical&quot; is now labeled as &quot;Banked Leave.&quot;  Balances are unaffected by this name change.</div>
+  </div>
       <hrs:notification/>
   </div>
   


### PR DESCRIPTION
Adds an alert that "Sabbatical" is now called "Banked Leave".

Introduces a new alert box above the existing dynamic alert box to preserve the existing dynamic alert feature for other alert needs that may arise.

As rendered in old MyUW / My UW System:

![sabbatical is now](https://cloud.githubusercontent.com/assets/952283/10829104/1cea1eb6-7e46-11e5-98b0-240e8babbb43.png)

As rendered in new MyUW:

![sabbatical is now in new myuw](https://cloud.githubusercontent.com/assets/952283/10829088/0e27c07c-7e46-11e5-86f7-91e3662acfb2.png)

(Screenshots from before the addition of the hyperlink, so reality slightly different.)
