### PR TITLE
HRSPLT-236 Simplify Leave Reports tab by removing text.

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -189,11 +189,6 @@
       </div>
     </sec:authorize>
     <div id="${n}dl-absence-statements" class="dl-absence-statements ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
-      <div class="data-table-description-header">
-        <div class="data-table-description">
-          Leave balance information is now available on your earnings statement in the Payroll Information portlet
-        </div>
-      </div>
       <div id="${n}dl-leave-statements">
       	<p class="padded-paragraph">
       		<a href="#" id="${n}oustandingMissingLeaveReports" target="_blank" style="display: none;">Outstanding Missing Leave Reports</a>


### PR DESCRIPTION
rm message about where to find leave balances from leave reports tab.

Before:

![status_quo-leave-balance-message-on-leave-reports-tab](https://cloud.githubusercontent.com/assets/952283/10829525/753f7e10-7e48-11e5-8f7b-ee0c662f70f2.png)

After:

![after_statement-zapped](https://cloud.githubusercontent.com/assets/952283/10829520/6f327252-7e48-11e5-8ed1-0aba2a719e35.png)
