### PR TITLE
HRSPLT-235 : make notifications multivalue

### DIFF
--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/HrsControllerBase.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/HrsControllerBase.java
@@ -78,10 +78,10 @@ public class HrsControllerBase {
      * Populate the ModelMap with the notification message
      */
     @ModelAttribute("notification")
-    public final String getNotification(PortletRequest request) {
+    public final String[] getNotification(PortletRequest request) {
         final PortletPreferences preferences = request.getPreferences();
         
-        return preferences.getValue(this.notificationPreferences, null);
+        return preferences.getValues(this.notificationPreferences, null);
     }
     
     /**

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/tags/hrs/notification.tag
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/tags/hrs/notification.tag
@@ -3,7 +3,7 @@
 <%@ tag dynamic-attributes="attributes" isELIgnored="false" %>
 
 <c:if test="${not empty notification}">
-  <c:forEach var='note' items="notification">
+  <c:forEach var='note' items="${notification}">
    <div class="fl-widget hrs-notification-wrapper alert alert-info">
        <div class="hrs-notification-content">${note}</div>
    </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/tags/hrs/notification.tag
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/tags/hrs/notification.tag
@@ -3,7 +3,9 @@
 <%@ tag dynamic-attributes="attributes" isELIgnored="false" %>
 
 <c:if test="${not empty notification}">
-  <div class="fl-widget hrs-notification-wrapper alert alert-info">
-      <div class="hrs-notification-content">${notification}</div>
-  </div>
+  <c:forEach var='note' items="notification">
+   <div class="fl-widget hrs-notification-wrapper alert alert-info">
+       <div class="hrs-notification-content">${note}</div>
+   </div>
+  </c:forEach>
 </c:if>


### PR DESCRIPTION
Also requires a entity change to `*leave-statements.portlet-definition.xml` of 

``` diff
+        <value><![CDATA[<a href="https://uwservice.wisc.edu/news/post/254" target="_blank">&quot;Sabbatical&quot; is now labeled as &quot;Banked Leave.&quot;</a> Balances are unaffected by this name change.]]></value>
```

but here it is:

![http://goo.gl/AVOhp5](http://goo.gl/AVOhp5)
