### PR TITLE
HRSPLT-237 : Tweak reference to earnings statement in Leave Balances tab

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -118,7 +118,7 @@
     </sec:authorize>
     <div id="${n}dl-leave-balance" class="dl-leave-balance ui-tabs-panel ui-widget-content ui-corner-bottom ${hiddenTabStyle}">
       <div class="balance-header">
-        <span>Balances as of the last pay check</span>
+        <span>Leave balances are also available on your current Earnings Statement.</span>
       </div>
       <div class="fl-pager">
         <hrs:pagerNavBar position="top" showSummary="${true}" />


### PR DESCRIPTION
Text Change in leave balances tab.

Before: "Balances as of the last pay check"

After: "Leave balances are also available on your current Earnings Statement."
