### PR TITLE
HRSPLT-246 add 2 Affordable Care Act links.

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -119,8 +119,6 @@
       <a href="https://uwservice.wisc.edu/docs/publications/tax-1095c-explanation.pdf" target="_blank" class="btn btn-default">1095-C Explanation</a>
       <span class='hidden-xs visible-xs'>|</span>
       <a href="https://www.wisconsin.edu/ohrwd/aca/" target="_blank" class="btn btn-default">ACA Information</a>
-      <span class='hidden-xs visible-xs'>|</span>
-      <a href="https://uwservice.wisconsin.edu/news/post/266" target="_blank" class="btn btn-default">New IRS Form 1095-C</a>
     </div>
     <c:if test="${personalDataError or personalData.onVisa}">
       <div class="dl-link">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -114,6 +114,13 @@
       <a href="https://uwservice.wisc.edu/docs/publications/tax-w2-explanation.pdf" target="_blank" class="btn btn-default">W-2 Explanation</a>
       <span class='hidden-xs visible-xs'>|</span>
       <a href="https://uwservice.wisc.edu/docs/publications/itx-1042s-explanation.pdf" target="_blank" class="btn btn-default">1042-S Explanation</a>
+      <%-- Affordable Care Act links --%>
+      <span class='hidden-xs visible-xs'>|</span>
+      <a href="https://uwservice.wisc.edu/docs/publications/tax-1095c-explanation.pdf" target="_blank" class="btn btn-default">1095-C Explanation</a>
+      <span class='hidden-xs visible-xs'>|</span>
+      <a href="https://www.wisconsin.edu/ohrwd/aca/" target="_blank" class="btn btn-default">ACA Information</a>
+      <span class='hidden-xs visible-xs'>|</span>
+      <a href="https://uwservice.wisconsin.edu/news/post/266" target="_blank" class="btn btn-default">New IRS Form 1095-C</a>
     </div>
     <c:if test="${personalDataError or personalData.onVisa}">
       <div class="dl-link">


### PR DESCRIPTION
Add ~~3x~~ 2x links to provide context for the forthcoming Affordable Care Act-related tax statements.

In old my.wisc / current my.wisconsin: (mockup)

![new aca links in classic - system](https://cloud.githubusercontent.com/assets/952283/12566251/4de43c36-c37e-11e5-93e5-f67bdfef5c77.png)

In new MyUW: (mockup)

![added aca links](https://cloud.githubusercontent.com/assets/952283/12566169/e485066c-c37d-11e5-99f4-7e0413c93768.png)

(Note: subsequent refinement to lose that last link/button, so now slightly less buttony.)

Known issue: `https://uwservice.wisc.edu/docs/publications/tax-1095c-explanation.pdf` `404`s. Verified with Tim Miller that that's nonetheless the correct URL, a placeholder for the forthcoming explanation PDF.
