### PR TITLE
Disable travis-ci by dropping travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: java
-
-install: true
-script: "mvn package"


### PR DESCRIPTION
The UW-Madison Maven repository access control tightened so that Travis-CI cannot pull dependencies it needs to run the build.

This will yield false failures on every build, making Travis-CI useless.
