### PR TITLE
add in a quick and easy URL to the base controller so we can get the …

### DIFF
--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/HrsControllerBase.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/HrsControllerBase.java
@@ -28,18 +28,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.portlet.bind.annotation.ResourceMapping;
 
 import edu.wisc.hr.dao.url.HrsUrlDao;
 
 /**
  * Common functions and dependencies for HRS controllers
- * 
+ *
  * @author Eric Dalquist
  * @version $Revision: 1.2 $
  */
 public class HrsControllerBase {
     protected final Logger logger = LoggerFactory.getLogger(getClass());
-    
+
     private String notificationPreferences = "notification";
     protected static final String helpUrlPreferences = "helpUrl";
     private static final String GENERIC_ERROR_MESSAGE_PREFERENCE_NAME = "genericErrorMessage";
@@ -54,7 +56,7 @@ public class HrsControllerBase {
     public void setHrsUrlDao(HrsUrlDao hrsUrlDao) {
         this.hrsUrlDao = hrsUrlDao;
     }
-    
+
     /**
      * Populate the ModelMap with the navigation links from the portlet preferences
      */
@@ -63,9 +65,9 @@ public class HrsControllerBase {
         final PortletPreferences preferences = request.getPreferences();
         return preferences.getValue(helpUrlPreferences, "#");
     }
-    
+
     /**
-     * The generic Message if you want to override the default in 
+     * The generic Message if you want to override the default in
      * messages.properties
      */
     @ModelAttribute("genericErrorMessage")
@@ -73,17 +75,17 @@ public class HrsControllerBase {
         final PortletPreferences preferences = request.getPreferences();
         return preferences.getValue(GENERIC_ERROR_MESSAGE_PREFERENCE_NAME, DEFAULT_ERROR_MESSAGE);
     }
-    
+
     /**
      * Populate the ModelMap with the notification message
      */
     @ModelAttribute("notification")
     public final String[] getNotification(PortletRequest request) {
         final PortletPreferences preferences = request.getPreferences();
-        
+
         return preferences.getValues(this.notificationPreferences, null);
     }
-    
+
     /**
      * Populate the ModelMap with the HRS Urls
      */
@@ -91,4 +93,11 @@ public class HrsControllerBase {
     public final Map<String, String> getHrsUrls() {
         return this.hrsUrlDao.getHrsUrls();
     }
+
+    @ResourceMapping("getHrsUrlsJson")
+    public String getURLRestService(ModelMap modelMap) {
+      modelMap.addAttribute("report", this.hrsUrlDao.getHrsUrls());
+      return "reportAttrJsonView";
+    }
+
 }

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeSheetDataController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeSheetDataController.java
@@ -36,21 +36,20 @@ import edu.wisc.hr.dm.tlpayable.TimeSheet;
 import org.jasig.springframework.security.portlet.authentication.PrimaryAttributeUtils;
 
 /**
- * 
- * 
+ *
+ *
  * @author Eric Dalquist
  */
 @Controller
 @RequestMapping("VIEW")
 public class TimeSheetDataController {
     private TimeSheetDao timeSheetDao;
-    
+
     @Autowired
     public void setTimeSheetDao(TimeSheetDao timeSheetDao) {
         this.timeSheetDao = timeSheetDao;
     }
 
-    
     /**
      * Gets Time sheets - limited to most recent 80 results for the requesting user
      * @param modelMap
@@ -62,7 +61,7 @@ public class TimeSheetDataController {
         final String emplid = PrimaryAttributeUtils.getPrimaryId();
 
         final List<TimeSheet> timeSheets = this.timeSheetDao.getTimeSheets(emplid);
-        
+
         //sorts the list from most recent time sheets to oldest time sheets
         Collections.sort(timeSheets, new Comparator<TimeSheet>(){
             @Override
@@ -79,5 +78,4 @@ public class TimeSheetDataController {
         modelMap.addAttribute("report", timeSheets.subList(0, timeSheets.size()>80 ? 80:timeSheets.size()));
         return "reportAttrJsonView";
     }
-
 }


### PR DESCRIPTION
…hrs urls for say... widgets

You can hit this in any of the hrs portlets. Example: 

`http://localhost:8080/portal/p/leave-statement/max/getHRSUrls.resource.uP` returns the same data as `http://localhost:8080/portal/p/earnings-statement/max/getHrsUrlsJson.resource.uP`

This returns an object with a key of 'report' that has a list of "URL Key" : "URL" pairs.

``` json
{
  "report": {
    "Some URL" : "http://www.example.com",
    "Google" : "http://www.google.com"
  }
}
```
