### PR TITLE
Log when null SOAP response coerced to empty role set

### DIFF
--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/roles/SoapHrsRolesDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/roles/SoapHrsRolesDao.java
@@ -66,24 +66,23 @@ public class SoapHrsRolesDao extends BaseHrsSoapDao implements HrsRolesDao {
     protected WebServiceOperations getWebServiceOperations() {
         return this.webServiceOperations;
     }
-	
-	@Override
-	@Cacheable(cacheName="hrsRoles", decoratedCacheType=DecoratedCacheType.SELF_POPULATING_CACHE, selfPopulatingTimeout=20000, exceptionCacheName="hrsUnknownExceptionCache")
+    @Override
+    @Cacheable(cacheName="hrsRoles", decoratedCacheType=DecoratedCacheType.SELF_POPULATING_CACHE, selfPopulatingTimeout=20000, exceptionCacheName="hrsUnknownExceptionCache")
     public Set<String> getHrsRoles(String emplId) {
-	    final GetCompIntfcUWPORTAL1ROLES request = this.createRequest(emplId);
-	    
-	    final GetCompIntfcUWPORTAL1ROLESResponse response = this.internalInvoke(request);
-	    
-	    return this.convertRoles(response);
+        final GetCompIntfcUWPORTAL1ROLES request = this.createRequest(emplId);
+
+        final GetCompIntfcUWPORTAL1ROLESResponse response = this.internalInvoke(request);
+
+        return this.convertRoles(response);
     }
 
     protected GetCompIntfcUWPORTAL1ROLES createRequest(String emplId) {
         EmplidTypeShape value = HrsUtils.createValue(EmplidTypeShape.class, emplId);
-	    
-	    final GetCompIntfcUWPORTAL1ROLES request = new GetCompIntfcUWPORTAL1ROLES();
-	    request.setEmplid(value);
 
-	    return request;
+        final GetCompIntfcUWPORTAL1ROLES request = new GetCompIntfcUWPORTAL1ROLES();
+        request.setEmplid(value);
+
+        return request;
     }
 
     protected Set<String> convertRoles(final GetCompIntfcUWPORTAL1ROLESResponse response) {
@@ -103,7 +102,7 @@ public class SoapHrsRolesDao extends BaseHrsSoapDao implements HrsRolesDao {
                 roles.addAll(mappedRoleNames);
             }
         }
-	    
+
         return roles;
     }
 }

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/roles/SoapHrsRolesDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/roles/SoapHrsRolesDao.java
@@ -88,6 +88,7 @@ public class SoapHrsRolesDao extends BaseHrsSoapDao implements HrsRolesDao {
 
     protected Set<String> convertRoles(final GetCompIntfcUWPORTAL1ROLESResponse response) {
         if (response == null) {
+            logger.warn("Converted null roles web service SOAP response to empty role set.");
             return Collections.emptySet();
         }
         


### PR DESCRIPTION
It turns out there's a path through the code where the Roles SOAP integration silently interprets a `null` SOAP response as an empty set of roles.

Hypothesis: a `null` response worth WARNing about in the logs. Failing gracefully and failing safe (no roles) is all to the good, but a `null` response is a technical error to be aware of in operating the integration.

This changeset adds that log message.

This changeset also corrects the partial-tabs whitespace of the touched file.