### PR TITLE
Document enrollmentFlag values in data object XSD.

### DIFF
--- a/hrs-portlets-api/src/main/resources/xsd/hrs-portlet-bnsumm-1.0.xsd
+++ b/hrs-portlets-api/src/main/resources/xsd/hrs-portlet-bnsumm-1.0.xsd
@@ -31,6 +31,11 @@
                 <xs:element name="benefits" type="Benefit" minOccurs="0" maxOccurs="unbounded" />
                 <xs:element name="dependents" type="Dependent" minOccurs="0" maxOccurs="unbounded" />
                 <xs:element name="enrollmentFlag" type="xs:string" />
+                  <!-- Values for enrollmentFlag seem to be
+                       O : indicates enrollment opportunity arising from
+                       _o_pen enrollment aka annual benefits enrollment.
+                       H : indicates personal enrollment opportunity arising from _h_iring or another Qualifying Event.
+                  -->
             </xs:sequence>
         </xs:complexType>
     </xs:element>


### PR DESCRIPTION
Was trying to understand potential values for `BenefitSummary.enrollmentFlag`. Was able to reverse engineer (a couple of) these values from their usage in a JSP. But I figure the semantics of the values of `enrollmentFlag` would best be documented right where the flag itself is defined. Which in this case is in an XSD (from which Java classes are generated. Thanks JAXB.)

"seem to be" is obnoxious in documentation, but I think it's the right tone here -- I'm not actually authoritative about what values HRS sets and what HRS thinks they mean, I am just extrapolating from the way I see a couple of those values used.