### PR TITLE
Add enrollmentFlag to benefitSummary resourceUrl

### DIFF
--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitSummaryDataController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitSummaryDataController.java
@@ -51,7 +51,9 @@ public class BenefitSummaryDataController {
         final BenefitSummary benefitSummary = this.benefitSummaryDao.getBenefitSummary(emplid);
         modelMap.addAttribute("benefits", benefitSummary.getBenefits());
         modelMap.addAttribute("dependents", benefitSummary.getDependents());
-        
+        modelMap.addAttribute(
+          "enrollmentFlag", benefitSummary.getEnrollmentFlag())
+
         return "jsonView";
     }
 }


### PR DESCRIPTION
Adds `BenefitSummary` `enrollmentFlag` to the `benefitSummary` resource URL.

Context: proof of concept that can surface this flag via `JSON`, so it could inform widgets or even form the basis of hacking up Notifications to include a meta-notification predicated on this flag.

First step is proving that we can already surface this flag in `JSON`, which may save ServiceCenter some effort in that they won't necessarily need to separately build a solution to surface this flag via `JSON` at this time.