### PR TITLE
HRSPLT-272 filter away furlough noise

### DIFF
--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/absbal/ClassifiedFurloughAllocatedPredicate.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/absbal/ClassifiedFurloughAllocatedPredicate.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package edu.wisc.hrs.dao.absbal;
+
+import com.google.common.base.Predicate;
+import edu.wisc.hr.dm.absbal.AbsenceBalance;
+
+/**
+ * Predicate matching absence balances that are of type Classified Furlough Allocated.
+ */
+public class ClassifiedFurloughAllocatedPredicate
+    implements Predicate {
+
+    public static final String CLASSIFIED_FURLOUGH_ALLOCATED_LABEL =
+        "Classified Furlough Allocated";
+
+    @Override public boolean apply(final Object input) {
+
+        if (null == input) {
+            throw new NullPointerException(
+                "ClassifiedFurloughAllocatedPredicate ill defined over null input.");
+        }
+
+        final AbsenceBalance absenceBalance = (AbsenceBalance) input;
+
+        final String entitlementType = absenceBalance.getEntitlement();
+
+        return CLASSIFIED_FURLOUGH_ALLOCATED_LABEL.equals(entitlementType);
+    }
+}

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/absbal/ZeroBalancePredicate.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/absbal/ZeroBalancePredicate.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package edu.wisc.hrs.dao.absbal;
+
+import com.google.common.base.Predicate;
+import edu.wisc.hr.dm.absbal.AbsenceBalance;
+
+import java.math.BigDecimal;
+
+/**
+ * Predicate over AbsenceBalance s returning true when the balance for the entitlement is zero.
+ */
+public class ZeroBalancePredicate
+    implements Predicate {
+
+    @Override
+    public boolean apply(final Object input) {
+
+        if (null == input) {
+            throw new NullPointerException("ZeroBalancePredicate ill defined over null input.");
+        }
+
+        final AbsenceBalance absenceBalance = (AbsenceBalance) input;
+
+        final BigDecimal balance = absenceBalance.getBalance();
+
+        return (BigDecimal.ZERO.equals(balance));
+
+    }
+}

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/absbal/ClassifiedFurloughAllocatedPredicateTest.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/absbal/ClassifiedFurloughAllocatedPredicateTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package edu.wisc.hrs.dao.absbal;
+
+import com.google.common.base.Predicate;
+import edu.wisc.hr.dm.absbal.AbsenceBalance;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class ClassifiedFurloughAllocatedPredicateTest {
+
+    private final Predicate classifiedFurloughAllocatedPredicate =
+        new ClassifiedFurloughAllocatedPredicate();
+
+
+    @Test
+    public void trueForClassifiedFurloughAllocated() {
+
+        final AbsenceBalance classifiedFurloughAllocatedAbsenceBalance = new AbsenceBalance();
+        classifiedFurloughAllocatedAbsenceBalance.setEntitlement("Classified Furlough Allocated");
+
+        assertTrue(classifiedFurloughAllocatedPredicate.
+            apply(classifiedFurloughAllocatedAbsenceBalance));
+    }
+
+    /**
+     * The predicate will not inadvertently match hypothetical future absence balances that are
+     * near to but not exactly ClassifiedFurloughAllocated.
+     */
+    @Test
+    public void falseForVariousOtherEntitlements() {
+
+        final AbsenceBalance notQuiteClassifiedFurloughAllocated = new AbsenceBalance();
+
+        notQuiteClassifiedFurloughAllocated.setEntitlement("Classified Furlough Unallocated");
+        assertFalse(classifiedFurloughAllocatedPredicate.apply
+            (notQuiteClassifiedFurloughAllocated));
+
+        notQuiteClassifiedFurloughAllocated.setEntitlement("Academic Furlough Allocated");
+        assertFalse(classifiedFurloughAllocatedPredicate.apply
+            (notQuiteClassifiedFurloughAllocated));
+
+        notQuiteClassifiedFurloughAllocated.setEntitlement("University Staff Furlough Allocated");
+        assertFalse(classifiedFurloughAllocatedPredicate.apply
+            (notQuiteClassifiedFurloughAllocated));
+
+        notQuiteClassifiedFurloughAllocated.setEntitlement("Academic Staff Furlough Allocated");
+        assertFalse(classifiedFurloughAllocatedPredicate.apply
+            (notQuiteClassifiedFurloughAllocated));
+
+        notQuiteClassifiedFurloughAllocated.setEntitlement("Some other hypothetical furlough");
+        assertFalse(classifiedFurloughAllocatedPredicate.apply
+            (notQuiteClassifiedFurloughAllocated));
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void throwsNullPointerExceptionOnNullInput() {
+
+        classifiedFurloughAllocatedPredicate.apply(null);
+
+    }
+
+}

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/absbal/ZeroBalancePredicateTest.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/absbal/ZeroBalancePredicateTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package edu.wisc.hrs.dao.absbal;
+
+import com.google.common.base.Predicate;
+import edu.wisc.hr.dm.absbal.AbsenceBalance;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.Assert.*;
+
+
+public class ZeroBalancePredicateTest {
+
+    private Predicate zeroBalancePredicate = new ZeroBalancePredicate();
+
+    /**
+     * Test that predicate returns true for a zero-balance input.
+     */
+    @Test
+    public void trueOnZeroBalanceInput() {
+
+        final AbsenceBalance zeroBalanceEntitlement = new AbsenceBalance();
+
+        zeroBalanceEntitlement.setEntitlement("Parental leave");
+        zeroBalanceEntitlement.setBalance(BigDecimal.ZERO);
+
+        assertTrue(zeroBalancePredicate.apply(zeroBalanceEntitlement));
+    }
+
+    /**
+     * Test that predicate returns false for a non-zero-balance input.
+     */
+    @Test
+    public void falseOnNonzeroBalanceInput() {
+
+        final AbsenceBalance oneBalanceEntitlement = new AbsenceBalance();
+
+        oneBalanceEntitlement.setEntitlement("Jury duty");
+        oneBalanceEntitlement.setBalance(BigDecimal.ONE);
+
+        assertFalse(zeroBalancePredicate.apply(oneBalanceEntitlement));
+
+    }
+
+    /**
+     * Test that throws NPE on null input,
+     * as specified by Predicate.apply() API.
+     */
+    @Test(expected=NullPointerException.class)
+    public void throwsNullPointerExceptionOnNullInput() {
+
+        zeroBalancePredicate.apply(null);
+
+    }
+
+}


### PR DESCRIPTION
For years absence balances have included a zero-balance "Classified Furlough Allocated" item that's just noise. Furlough is diquieting; the term "classified" is no longer correct; displaying this noise often makes the balances table page, reducing usability without adding value.

Filter away the noise, but do so as tightly as possible. If some other furlough is introduced in the future, it will display. If this furlough starts having nonzero balance, it will display.

Uses the `Predicate` API to implement this using ridiculously small objects. That are amenable to unit testing. Also, I was told there would be objects in object-oriented programming.


Before:
![leave-balances-with-furlough](https://user-images.githubusercontent.com/952283/27964989-d39d3f36-62ff-11e7-81f9-6b8f5d1eb5f5.png)

After:

![no-more-furlough](https://user-images.githubusercontent.com/952283/27969098-35e3f46e-630f-11e7-9033-36f249516dfb.png)

