### PR TITLE
MUMMNG-3688 Troubleshooting vanishing Leave Reports column

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -440,7 +440,7 @@
           columnDefs: [
              dl.pager.colDef("payPeriod", {sortable: true, sortValueExtractor: dl.pager.mmyyyyDateExtractor}),
              {
-                 key: name,
+                 key: "",
                  valuebinding: "*.leaveFurloughReportLinks",
                  components: {
                      markup: dl.util.templateUrl("TMPLT_*.leaveFurloughReportLinks_TMPLT")


### PR DESCRIPTION
removing reference to a mysterious global variable, setting it to empty string which seems to work