### PR TITLE
Note HRS service window

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
@@ -152,6 +152,9 @@
       </div>
     </div>
   </div>
+
+  <%@ include file="/WEB-INF/jsp/footer.jsp"%>
+
 </div>
 
 <portlet:resourceURL var="benefitSummaryUrl" id="benefitSummary" escapeXml="false"/>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -281,6 +281,9 @@
       </fieldset>
     </form>
   </div>
+
+  <%@ include file="/WEB-INF/jsp/footer.jsp"%>
+
 </div>
 
 <c:if test="${showBusinessEmail}">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/footer.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/footer.jsp
@@ -18,15 +18,7 @@
     under the License.
 
 --%>
-<%@ include file="/WEB-INF/jsp/include.jsp"%>
-
-<portlet:renderURL var="refreshUrl" />
 <div>
-    <div>
-      <span><spring:message code="noEmplId" /> </span>
-      <a href="${refreshUrl}"><spring:message code="refresh" /></a>
-    </div>
-
-    <%@ include file="/WEB-INF/jsp/footer.jsp"%>
-
+  <strong>Service Notice:</strong>
+  This app may be offline on Sundays, 6-10 AM for routine maintenance.
 </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/footer.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/footer.jsp
@@ -19,6 +19,6 @@
 
 --%>
 <div>
-  <strong>Service Notice:</strong>
+  <strong>Service notice:</strong>
   This app may be offline on Sundays, 6-10 AM for routine maintenance.
 </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/footer.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/footer.jsp
@@ -20,5 +20,5 @@
 --%>
 <div>
   <strong>Service notice:</strong>
-  This app may be offline on Sundays, 6-10 AM for routine maintenance.
+  This app may be offline on Sundays, 6-10 a.m. for routine maintenance.
 </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/hrsUnavailable.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/hrsUnavailable.jsp
@@ -25,4 +25,7 @@
     <div>
       ${genericErrorMessage}
     </div>
+
+    <%@ include file="/WEB-INF/jsp/footer.jsp"%>
+
 </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerTimeApproval.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerTimeApproval.jsp
@@ -119,6 +119,9 @@
   <sec:authorize ifNotGranted="ROLE_VIEW_MANAGED_ABSENCES,ROLE_VIEW_MANAGED_TIMES">
     <div class="center">This module is for managers. If you believe you are a manager and should see content, please contact HR.</div>
   </sec:authorize>
+
+  <%@ include file="/WEB-INF/jsp/footer.jsp"%>
+
 </div>
 
 <portlet:resourceURL var="managedAbsencesUrl" id="managedAbsences" escapeXml="false"/>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -131,6 +131,9 @@
       </c:if>
     </c:if>
   </div>
+
+  <%@ include file="/WEB-INF/jsp/footer.jsp"%>
+
 </div>
 
 <portlet:resourceURL var="earningStatementsUrl" id="earningStatements" escapeXml="false"/>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -267,6 +267,9 @@
       <a href="${prefs['UnclassifiedLeaveReportForSummerUrl'][0]}" target="_blank"  class='btn btn-default'>Unclassified Summer Session/Service Leave Report</a></c:if>
     </div>
   </div>
+
+  <%@ include file="/WEB-INF/jsp/footer.jsp"%>
+
 </div>
 
 <portlet:resourceURL var="absenceHistoriesUrl" id="absenceHistories" escapeXml="false"/>


### PR DESCRIPTION
Document for users the weekly HRS service window in a footer shared across all HRS apps.

![hrs-apps-footer](https://user-images.githubusercontent.com/952283/30457763-3dea143c-996e-11e7-869b-41a1a9ded60d.png)


I struggled with whether "Service notice:" should be sentence case or title case. Figure always prefer sentence case.

I struggled with whether to take the AM as provided in the requested text or apply [the umark style guide guidance on times](https://editorial-styleguide.umark.wisc.edu/term/times/), but, what's the point of having a style guide if we're not going to follow it, so taking a shot at following that editorial style guide.

I'm probably abusing `style:` in Conventional Commits commit messages now that I think about it, since these commits are editorial style, not code formatting style, changes, but it'll probably be fine since this isn't in practice actually a collaborative open source project, it's just a pile of code.

*I didn't actually locally test this; the screenshot is a mockup using Chrome dev tools. Figure test it in `test.my`.*