### PR TITLE
HRSPLT-283 Link new HRS self-service Personal Information UI for HRS PUM22

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -206,49 +206,143 @@
     </c:choose>
   </div>
 
-  <div class="federal-reporting-statuses">
-      <c:if test="${not empty hrsUrls['Disability Status']}">
-      <div>
-          <span><strong><spring:message code="label.disability.status" text="Disability Status"/></strong></span>
-          <span>( <a aria-label="view or update Disability Status" href="${hrsUrls['Disability Status']}" target="_blank">
-              <spring:message code="label.status.link" text="view/update"/>
-                 </a> )</span>
-      </div>
-      </c:if>
 
-      <c:if test="${not empty hrsUrls['Veteran Status']}">
-      <div>
-          <span><strong><spring:message code="label.veteran.status" text="Veteran Status"/></strong></span>
-          <span>( <a aria-label="view or update Veteran Status" href="${hrsUrls['Veteran Status']}" target="_blank">
-              <spring:message  code="label.status.link" text="view/update"/>
-                 </a> )</span>
-      </div>
-      </c:if>
 
-      <c:if test="${not empty hrsUrls['Ethnic Groups']}">
-      <div>
-          <span><strong><spring:message code="label.ethnic.groups" text="Ethnic Groups"/></strong></span>
-          <span>( <a aria-label="view or update Ethnic Groups" href="${hrsUrls['Ethnic Groups']}" target="_blank">
-              <spring:message code="label.status.link" text="view/update"/>
-                 </a> )</span>
-      </div>
-      </c:if>
-  </div>
-
-  <div class="dl-contact-info-update">
-    <a href="${hrsUrls['Personal Information']}" target="_blank"><spring:message code="updateInfoLink"/></a>
-    <br/>
-    <div>
-        <p class="padded-paragraph">
-            <spring:message code="bottomNotePart1" text="Please note that you can update Home Address, Phone, Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in HRS."/>
-        </p>
-        <p>
+  <c:choose>
+    <c:when test="${not empty prefs['updateMyPersonalInfoUrl']
+      && not empty prefs['updateMyPersonalInfoUrl'][0]}">
+      
+      <!-- configured with HRS self-service personal information update
+       URL via portlet-preference. Use HRS PUM 22 content. -->
+       
+       <!-- federal reporting statuses deliberately removed in PUM22 mode,
+            in favor of that data just being down inside 
+            linked HRS self-service UI. -->
+      
+      <div class="dl-contact-info-update">
+        <a href="prefs['updateMyPersonalInfoUrl'][0]" 
+          target="_blank" rel="noopener noreferer">
+          <spring:message code="updateInfoLink"/>
+        </a>
+        <br/>
+        <div>
+          <p class="padded-paragraph">
+            You can 
+            <a href="prefs['updateMyPersonalInfoUrl'][0]" 
+              target="_blank" rel="noopener noreferer">update personal information in the Human Resources System (HRS)</a> including:
+addresses (home &amp; mail), contact details (phone &amp; email), emergency contacts, home information release, marital status, coordination of benefits, Medicare information, ethnic groups, veteran status, and disability status.
+          </p>
+          <p>
             <strong>
-                <spring:message code="bottomNotePart2" text="To update your Business/Office Address, please contact your Payroll Office."/>
+              <spring:message code="bottomNotePart2" text="To update your Business/Office Address, contact your Payroll Office."/>
             </strong>
-        </p>
-    </div>
-  </div>
+          </p>
+        </div>
+      </div>  
+    </c:when>
+    <c:when test="${not empty hrsUrls['Personal Information']}">
+      
+      <!-- Not configured with a self-service personal information update URL
+      via portlet preference, but have a URL fom HRS URLs web service.
+      Legacy mode. -->
+      
+      <div class="federal-reporting-statuses">
+        <!-- federal reporting statuses only show in legacy mode. -->
+        <c:if test="${not empty hrsUrls['Disability Status']}">
+          <div>
+            <span>
+              <strong>
+                <spring:message 
+                  code="label.disability.status" 
+                  text="Disability Status"/>
+              </strong>
+            </span>
+            <span>( 
+              <a 
+                aria-label="view or update Disability Status" 
+                href="${hrsUrls['Disability Status']}" 
+                target="_blank"
+                rel="noopener noreferer">
+                  <spring:message code="label.status.link" text="view/update"/>
+              </a> 
+            )</span>
+          </div>
+        </c:if>
+
+        <c:if test="${not empty hrsUrls['Veteran Status']}">
+          <div>
+            <span>
+              <strong>
+                <spring:message 
+                  code="label.veteran.status" 
+                  text="Veteran Status"/>
+              </strong>
+            </span>
+            <span>( 
+              <a 
+                aria-label="view or update Veteran Status" 
+                href="${hrsUrls['Veteran Status']}" 
+                target="_blank">
+                  <spring:message  
+                    code="label.status.link" 
+                    text="view/update"/>
+              </a> 
+            )</span>
+          </div>
+        </c:if>
+
+        <c:if test="${not empty hrsUrls['Ethnic Groups']}">
+          <div>
+            <span>
+              <strong>
+                <spring:message 
+                  code="label.ethnic.groups" 
+                  text="Ethnic Groups"/>
+              </strong>
+            </span>
+            <span>( 
+              <a 
+                aria-label="view or update Ethnic Groups" 
+                href="${hrsUrls['Ethnic Groups']}" 
+                target="_blank"
+                rel="noopener noreferer">
+                  <spring:message code="label.status.link" text="view/update"/>
+              </a> 
+            )</span>
+          </div>
+        </c:if>
+      </div>
+      
+      <div class="dl-contact-info-update">
+        <a 
+          href="${hrsUrls['Personal Information']}" 
+          target="_blank"
+          rel="noopener noreferer">
+            <spring:message code="updateInfoLink"/>
+        </a>
+        <br/>
+        <div>
+          <p class="padded-paragraph">
+            <spring:message code="bottomNotePart1" text="Please note that you can update Home Address, Phone, Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in HRS."/>
+          </p>
+          <p>
+            <strong>
+              <spring:message code="bottomNotePart2" text="To update your Business/Office Address, please contact your Payroll Office."/>
+            </strong>
+          </p>
+        </div>
+      </div>
+    </c:when>
+
+    <c:otherwise>
+      <!-- in case where cannot source HRS self-service UI URL from
+        portlet preference nor from HRS URLs web service,
+        show error. -->
+      <p>Error: this application is not configured with a link to
+        HRS self service personal information UI.</p>
+    </c:otherwise>
+
+  </c:choose>
   
   <div class="change-business-email-dialog hrs" title="Change Campus Business Email">
     <div>


### PR DESCRIPTION
Add option to set HRS Self-Service Personal Information UI link via `updateMyPersonalInfoUrl` portlet preference.

![personal-information-link-change-mockup2](https://user-images.githubusercontent.com/952283/31137377-b4c92e5a-a830-11e7-915f-f26fea2ff47e.png)

+ When portlet preference, show that link in new HRS PUM22 mode.
+ When no portlet preference but still URL from web service, legacy behavior.
+ When neither, graceful failure error message.

Intended to be a no-op in case where new portlet preference is not set.

As tracked in [HRSPLT-283](https://jira.doit.wisc.edu/jira/browse/HRSPLT-283).