### PR TITLE
HRSPLT-287 optionally benefits summary self-serv URL from portlet-pref

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
@@ -83,9 +83,30 @@
         <hrs:pagerNavBar position="bottom" />
       </div>
       <div class="container-fluid row">
-        <div class='col-xs-4 col-xs-offset-2'>
-            <a href="${hrsUrls['Benefits Summary']}" target="_blank" class="btn btn-default">View Benefits Summary Detail</a>
-        </div>
+        <c:choose>
+          <!-- when URL available from portlet pref, use that -->
+          <c:when test="${not empty prefs['benefitsSummaryUrl']
+            && not empty prefs['benefitsSummaryUrl'][0]}">
+            <div class='col-xs-4 col-xs-offset-2'>
+              <a href="${prefs['benefitsSummaryUrl'][0]}" 
+                target="_blank" rel="noopener noreferer"
+                class="btn btn-default">
+                  View Benefits Summary Detail
+              </a>
+            </div>
+          </c:when>
+          <!-- else use URL from URLs web service if available -->
+          <c:when test="${not empty hrsUrls['Benefits Summary']}">
+            <div class='col-xs-4 col-xs-offset-2'>
+              <a href="${hrsUrls['Benefits Summary']}" 
+                target="_blank" rel="noopener noreferer"
+                class="btn btn-default">
+                  View Benefits Summary Detail
+              </a>
+            </div>
+          </c:when>
+          <!-- implied otherwise: simply drop the button -->
+        </c:choose>
         <div class='col-xs-3'>
             <a href="${hrsUrls['Update TSA Deductions']}" target="_blank" class="btn btn-default">Update TSA Deductions</a>
         </div>


### PR DESCRIPTION
+ New: if `benefitsSummaryUrl` portlet-preference present, use it as URL for existing "View Benefits Summary Detail" link.
+ Otherwise, continue status quo: use "Benefits Summary" HRS URL from SOAP.
+ New: if neither set, suppress "View Benefits Summary Detail" link to fail gracefully.

This gives more flexibility in whether and how the "View Benefits Summary Detail" link will change with HRS PUM22's release of improved Fluid self-service UI for viewing benefits summary detail.