### PR TITLE
Fix c:choose grouchiness

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
@@ -83,9 +83,9 @@
         <hrs:pagerNavBar position="bottom" />
       </div>
       <div class="container-fluid row">
-        <!-- when URL available from portlet pref, use that -->
-        <!-- else use URL from URLs web service if available -->
-        <!-- implied otherwise: simply drop the button -->
+        <%-- when URL available from portlet pref, use that --%>
+        <%-- else use URL from URLs web service if available --%>
+        <%-- implied otherwise: simply drop the button --%>
         <c:choose>
           <c:when test="${not empty prefs['benefitsSummaryUrl']
             && not empty prefs['benefitsSummaryUrl'][0]}">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
@@ -83,8 +83,10 @@
         <hrs:pagerNavBar position="bottom" />
       </div>
       <div class="container-fluid row">
+        <!-- when URL available from portlet pref, use that -->
+        <!-- else use URL from URLs web service if available -->
+        <!-- implied otherwise: simply drop the button -->
         <c:choose>
-          <!-- when URL available from portlet pref, use that -->
           <c:when test="${not empty prefs['benefitsSummaryUrl']
             && not empty prefs['benefitsSummaryUrl'][0]}">
             <div class='col-xs-4 col-xs-offset-2'>
@@ -95,7 +97,6 @@
               </a>
             </div>
           </c:when>
-          <!-- else use URL from URLs web service if available -->
           <c:when test="${not empty hrsUrls['Benefits Summary']}">
             <div class='col-xs-4 col-xs-offset-2'>
               <a href="${hrsUrls['Benefits Summary']}" 
@@ -105,7 +106,6 @@
               </a>
             </div>
           </c:when>
-          <!-- implied otherwise: simply drop the button -->
         </c:choose>
         <div class='col-xs-3'>
             <a href="${hrsUrls['Update TSA Deductions']}" target="_blank" class="btn btn-default">Update TSA Deductions</a>


### PR DESCRIPTION
#78 broke the build with some grouchiness about HTML comments being disallowed inside `<c:choose>`.

This despite `mvn package` worked just fine locally thanks.

Anyway, this should fix it by 

1. Moving the comments out of the `<c:choose>`
2. Switching from HTML comments to JSP comments while we're at it.