### PR TITLE
HRSPLT-288 Link direct deposit self service for authorized users

### DIFF
--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -71,6 +71,11 @@
                 <value>ROLE_VIEW_MANAGED_TIMES</value>
             </set>
         </entry>
+        <entry key="UW_DYN_PY_DIRDEP_SS">
+          <set>
+              <value>ROLE_VIEW_DIRECT_DEPOSIT</value>
+          </set>
+        </entry>
     </util:map>
     
     <bean id="absenceBalanceDestinationProvider" class="org.jasig.springframework.ws.client.support.destination.FailSafeWsdl11DestinationProvider" />

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -116,7 +116,7 @@
             && not empty prefs['directDepositSelfServiceUrl'][0]}">
             <a 
               href="${prefs['directDepositSelfServiceUrl']}" 
-              target="_blank"
+              target="_blank" rel="noopener noreferrer"
               class="btn btn-default">
               Update your Direct Deposit</a>
           </c:when>
@@ -125,7 +125,7 @@
               fall back on the PDF form. -->
             <a 
               href="https://uwservice.wisc.edu/docs/forms/pay-direct-deposit.pdf"
-              target="_blank"
+              target="_blank" rel="noopener noreferrer"
               class="btn btn-default">
               Update your Direct Deposit</a>
           </c:otherwise>
@@ -136,7 +136,7 @@
         if not authorized for self-service -->
         <a 
           href="https://uwservice.wisc.edu/docs/forms/pay-direct-deposit.pdf" 
-          target="_blank" 
+          target="_blank" rel="noopener noreferrer"
           class="btn btn-default">
           Update your Direct Deposit</a>
       </sec:authorize>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -111,14 +111,25 @@
       <!-- show the self-service direct deposit link if authorized-->
       <sec:authorize ifAnyGranted="ROLE_VIEW_DIRECT_DEPOSIT">
         <!-- Only show the self-service direct deposit link if configured. -->
-        <c:if test="${not empty prefs['directDepositSelfServiceUrl']
-          && not empty prefs['directDepositSelfServiceUrl'][0]}">
-          <a 
-            href="${prefs['directDepositSelfServiceUrl']}" 
-            target="_blank" 
-            class="btn btn-default">
-            Update your Direct Deposit</a>
-        </c:if>
+        <c:choose>
+          <c:when test="${not empty prefs['directDepositSelfServiceUrl']
+            && not empty prefs['directDepositSelfServiceUrl'][0]}">
+            <a 
+              href="${prefs['directDepositSelfServiceUrl']}" 
+              target="_blank" 
+              class="btn btn-default">
+              Update your Direct Deposit</a>
+          </c:when>
+          <c:otherwise>
+            <!-- even if authorized for self-service, if that URL is not set
+              fall back on the PDF form. -->
+            <a 
+              href="https://uwservice.wisc.edu/docs/forms/pay-direct-deposit.pdf" 
+              target="_blank" 
+              class="btn btn-default">
+              Update your Direct Deposit</a>
+          </c:otherwise>
+        </c:choose>
       </sec:authorize>
       <sec:authorize ifNotGranted="ROLE_VIEW_DIRECT_DEPOSIT">
         <!-- show the link to the PDF form 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -116,7 +116,7 @@
             && not empty prefs['directDepositSelfServiceUrl'][0]}">
             <a 
               href="${prefs['directDepositSelfServiceUrl']}" 
-              target="_blank" 
+              target="_blank"
               class="btn btn-default">
               Update your Direct Deposit</a>
           </c:when>
@@ -124,8 +124,8 @@
             <!-- even if authorized for self-service, if that URL is not set
               fall back on the PDF form. -->
             <a 
-              href="https://uwservice.wisc.edu/docs/forms/pay-direct-deposit.pdf" 
-              target="_blank" 
+              href="https://uwservice.wisc.edu/docs/forms/pay-direct-deposit.pdf"
+              target="_blank"
               class="btn btn-default">
               Update your Direct Deposit</a>
           </c:otherwise>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -108,7 +108,27 @@
     <div class="dl-link">
       <a href="https://uwservice.wisc.edu/docs/forms/pay-employee-withholding.pdf" target="_blank" class="btn btn-default">Update your W4</a>
       <span class='hidden-xs visible-xs'>|</span>
-      <a href="https://uwservice.wisc.edu/docs/forms/pay-direct-deposit.pdf" target="_blank" class="btn btn-default">Update your Direct Deposit</a>
+      <!-- show the self-service direct deposit link if authorized-->
+      <sec:authorize ifAnyGranted="ROLE_VIEW_DIRECT_DEPOSIT">
+        <!-- Only show the self-service direct deposit link if configured. -->
+        <c:if test="${not empty prefs['directDepositSelfServiceUrl']
+          && not empty prefs['directDepositSelfServiceUrl'][0]}">
+          <a 
+            href="${prefs['directDepositSelfServiceUrl']}" 
+            target="_blank" 
+            class="btn btn-default">
+            Update your Direct Deposit</a>
+        </c:if>
+      </sec:authorize>
+      <sec:authorize ifNotGranted="ROLE_VIEW_DIRECT_DEPOSIT">
+        <!-- show the link to the PDF form 
+        if not authorized for self-service -->
+        <a 
+          href="https://uwservice.wisc.edu/docs/forms/pay-direct-deposit.pdf" 
+          target="_blank" 
+          class="btn btn-default">
+          Update your Direct Deposit</a>
+      </sec:authorize>
     </div>
     <div class="dl-link">
       <a href="https://uwservice.wisc.edu/docs/publications/tax-w2-explanation.pdf" target="_blank" class="btn btn-default">W-2 Explanation</a>


### PR DESCRIPTION
If

+ employee has new `UW_DYN_PY_DIRDEP_SS` role, AND
+ new portlet-preference `directDepositSelfServiceUrl`  is set configuring the self-service direct deposit UI URL,

then link new self-service direct deposit UI URL.

Contrarily, if 

+ not authorized with `UW_DYN_PY_DIRDEP_SS` role OR 
+ new portlet-preference `directDepositSelfServiceUrl` is not set

continue status quo behavior of linking PDF form for requesting direct deposit updating.

Protects these `target=_blank` URLs with the `rel="noopener noreferrer"` invocation since this changeset is touching them anyway.

[HRSPLT-288](https://jira.doit.wisc.edu/jira/browse/HRSPLT-288).