### PR TITLE
fix: portlet-preferences are arrays of strings, not strings.

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -115,7 +115,7 @@
           <c:when test="${not empty prefs['directDepositSelfServiceUrl']
             && not empty prefs['directDepositSelfServiceUrl'][0]}">
             <a 
-              href="${prefs['directDepositSelfServiceUrl']}" 
+              href="${prefs['directDepositSelfServiceUrl'][0]}}" 
               target="_blank" rel="noopener noreferrer"
               class="btn btn-default">
               Update your Direct Deposit</a>


### PR DESCRIPTION
So need the [0] indexing into the array to retrieve the configured URL.