### PR TITLE
fix: rm stray brace breaking self-service direct dep link

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -115,7 +115,7 @@
           <c:when test="${not empty prefs['directDepositSelfServiceUrl']
             && not empty prefs['directDepositSelfServiceUrl'][0]}">
             <a 
-              href="${prefs['directDepositSelfServiceUrl'][0]}}" 
+              href="${prefs['directDepositSelfServiceUrl'][0]}" 
               target="_blank" rel="noopener noreferrer"
               class="btn btn-default">
               Update your Direct Deposit</a>


### PR DESCRIPTION
Still bugged. I think this is the last bug.

Good news: none of these bugs break backwards compatibility, so, so long as you don't need the new feature to work (and since no one will have the relevant role no one initially needs the feature to work), it's all fine.

PS: Yes, I feel bad about this.