### PR TITLE
Document roles where they're configured

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to hrs-portlets
+
+## This is not a community project
+
+This *is* open source software, in that source code is publicly available under 
+an OSI recognized genuine open source license. That's what "open source" means.
+You are entirely welcome to this source code and free to try to derive value
+from it locally, or learn from it, or whatever.
+
+However. **This is *not* a community project, in that the maintainers don't 
+expect you to successfully locally implement this software** and are not making 
+any effort to enable that. This project was once in Apereo (Jasig?) incubation 
+and failed incubation for precisely this reason: this product is not 
+architected to be locally realizable anywhere other than the one context where 
+it's already locally realized, that is, in MyUW. Sorry.
+
+The world would be a better place with viable community-driven free and open 
+source software projects to build services, adaptors, middleware, controllers, 
+user experiences enabling better self-service payroll, benefits, and time and 
+leave accounting experiences for higher education and beyond. Maybe this code 
+could inspire some of that, or even some of it could be harvested and re-worked 
+to be more modular and configurable in those ways. That'd be awesome. Please do 
+let the maintainers know if this starts coming together. We might well want to 
+be part of that and eventually retire this code too. Local ad-hoc one-off 
+solutions to generic higher education problems, they've got maintenance 
+downsides.
+
+# Maintaining documentation across change
+
+## Roles
+
+If your change 
+
++ Changes the set of roles, or
++ Changes what the roles let employees do
+
+be sure to update 
+`hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml` 
+to reflect.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## ReadMe
+# hrs-portlets README
 
-### Local Setup Instructions
+## Local Setup Instructions
 
 Several property files need to be configured for your local environment before the Portlet will run in your local uPortal server.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # hrs-portlets README
 
+## Roles
+
+hrs-portlets maps roles reported from a SOAP web service from HRS to role names local to hrs-portlets. This is to normalize roles and make them look like roles one might expect to use with Spring Security.
+
+Role mapping happens in `hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml`. That configuration is the authoritative documentation of what HRS roles map to what portlet roles, since that configuration is doing the mapping.
+
 ## Local Setup Instructions
 
 Several property files need to be configured for your local environment before the Portlet will run in your local uPortal server.

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 Several property files need to be configured for your local environment before the Portlet will run in your local uPortal server.
 
 * /hrs-portlets-webapp/src/main/resources/logback.xml
-	* Update paths in file to where HRS portlet should write it's log files to.
+  * Update paths in file to where HRS portlet should write it's log files to.
 * /hrs-portlets-bnsemail-impl/src/mail/resources/
-	* Copy EXAMPLE_bnsemail-placeholder.properties to **bnsemail-placeholder.properties**
-	* Copy **smime-keystore.jks** into directory
-	* Do Not add bnsemail-placeholder.properties OR smime-keystore.jks to source control (should be automatically ignored via local .gitignore)
+  * Copy EXAMPLE_bnsemail-placeholder.properties to **bnsemail-placeholder.properties**
+  * Copy **smime-keystore.jks** into directory
+  * Do Not add bnsemail-placeholder.properties OR smime-keystore.jks to source control (should be automatically ignored via local .gitignore)
 * /hrs-portlets-cypress-impl/src/mail/resources/
-	* Copy EXAMPLE_cypress-placeholder.properties to **cypress-placeholder.properties**
-	* Do Not add cypress-placeholder.properties to source control (should be automatically ignored via local .gitignore)
+  * Copy EXAMPLE_cypress-placeholder.properties to **cypress-placeholder.properties**
+  * Do Not add cypress-placeholder.properties to source control (should be automatically ignored via local .gitignore)
 * /hrs-portlets-ps-impl/src/mail/resources/
-	* Copy EXAMPLE_ps-placeholder.properties to **ps-placeholder.properties**
-	* Do Not add ps-placeholder.properties to source control (should be automatically ignored via local .gitignore)
+  * Copy EXAMPLE_ps-placeholder.properties to **ps-placeholder.properties**
+  * Do Not add ps-placeholder.properties to source control (should be automatically ignored via local .gitignore)

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -43,37 +43,90 @@
         <entry key="UW_DYN_AM_EMPLOYEE">
             <set>
                 <value>ROLE_VIEW_ABSENCE_HISTORIES</value>
+                <!-- effects
+                  In Time and Absence
+                    Allows rendering absenceHistories.json
+                    Show the Absence tab
+                    Show the Enter Absence link
+                    Show the Edit Cancel Absence link, if link is configured
+                -->
             </set>
         </entry>
         <entry key="UW_DYN_TL_WEB_CLOCK">
             <set>
                 <value>ROLE_VIEW_WEB_CLOCK</value>
+                <!-- effects (superset of 
+                  ROLE_VIEW_TIME_CLOCK or ROLE_VIEW_TIME_SHEET)
+                  In Time and Absence
+                    Allows rendering timeSheets.json
+                    Show the Time Entry tab
+                    Show the Timesheet link
+                    Show the Web Clock link (this is the difference from
+                      ROLE_VIEW_TIME_CLOCK and ROLE_VIEW_TIME_SHEET)
+                -->
             </set>
         </entry>
         <entry key="UW_DYN_TL_EMPLOYEE_TIMECLOCK">
             <set>
                 <value>ROLE_VIEW_TIME_CLOCK</value>
+                <!-- effects (same as ROLE_VIEW_TIME_SHEET,
+                  subset of ROLE_VIEW_WEB_CLOCK)
+                  Allows rendering timeSheets.json
+                  In Time and Absence
+                    Show the Time Entry tab
+                    Show the Timesheet link
+                -->
             </set>
         </entry>
         <entry key="UW_DYN_TL_CL_EMPL_TIMESHEET">
             <set>
                 <value>ROLE_VIEW_TIME_SHEET</value>
+                <!-- effects (same as ROLE_VIEW_TIME_CLOCK,
+                  subset of ROLE_VIEW_WEB_CLOCK)
+                  Allows rendering timeSheets.json
+                  In Time and Absence
+                    Show the Time Entry tab
+                    Show the Timesheet link
+                -->
             </set>
         </entry>
         <entry key="UW_UNV_TL Supervisor">
             <set>
                 <value>ROLE_VIEW_MANAGED_ABSENCES</value>
+                <!-- effects
+                  Allows rendering managedAbsences.json
+                  In Manager Time Approval
+                    Show the Absence tab
+                    Show the Manager Self Service - Time Management link
+                    Show the Approve Absence link
+                    Show the Approve Payable Time link
+                -->
                 <value>ROLE_VIEW_MANAGED_TIMES</value>
+                <!-- effects
+                  Allows rendering managedTimes.json
+                  In Manager Time Approval
+                    Show the Time tab
+                    Show the Manager Self Service - Time Management link
+                    Show the Approve Absence link
+                    Show the Approve Payable Time link
+                -->
             </set>
         </entry>
         <entry key="UW_UNV_TL Non Supervisor">
             <set>
                 <value>ROLE_VIEW_MANAGED_TIMES</value>
+                <!-- same role as above -->  
             </set>
         </entry>
         <entry key="UW_DYN_PY_DIRDEP_SS">
           <set>
               <value>ROLE_VIEW_DIRECT_DEPOSIT</value>
+              <!-- effects
+                In Payroll Information
+                  Changes the href of the Update your Direct Deposit link
+                  to the value of the directDepositSelfServiceUrl
+                  portlet-preference, if set.
+              -->
           </set>
         </entry>
     </util:map>


### PR DESCRIPTION
Intent:

+ Enhance the XML file where role mapping is actually configured to also document, with comments, everything there is to know about those roles *in the hrs-portlets product*.
  + Mappings from HRS role names to portlet-local role names
  + What effective permissions the roles grant
+ Greatly de-scope the (out of date, out of sync with reality) wiki page that was trying to document this.
  + Keep there the roster of HRS roles, what HRS self-service panes they grant access to, and example emplIDs, because those things are *about HRS* rather than *about the hrs-portlets product*

In this way the documentation about the roles gets closer to where the roles really happen, and so the documentation should naturally stay more correct and authoritative.

This changeset specifically:

+ Adds comments to the role mapping configuration XML capturing what the roles do.
+ Adds a pointer to this documentation in the `README.md`
+ Adds `CONTRIBUTING`.md documentation reminding to update this documentation when touching roles

and incidentally

+ Spiffs up `README.md` formatting
+ Clarifies in new `CONTRIBUTING.md` that if you're not in MyUW, you kind of just can't fruitfully contribute to this repo as such.