### PR TITLE
Document portlet preferences configuring HRS portlets

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,3 +37,12 @@ If your change
 be sure to update 
 `hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml` 
 to reflect.
+
+## Portlet preferences
+
+If your change
+
++ Changes the set of `portlet-preference`s
++ Changes the effect of `portlet-preference`s
+
+be sure to update `README.md` to reflect.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,100 @@ hrs-portlets maps roles reported from a SOAP web service from HRS to role names 
 
 Role mapping happens in `hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml`. That configuration is the authoritative documentation of what HRS roles map to what portlet roles, since that configuration is doing the mapping.
 
+## Configuring the portlets as published
+
+The hrs-portlets offer configuration opportunities at the portlet-definition ("publication") layer.
+
+### Applicable to all hrs-portlets
+
+#### `helpUrl` portlet preference
+
+Every HRS integration portlet, individually, supports this portlet preference.
+(That is, it can be configured differently for different publications of the portlets).
+
++ Sets the href of the "Help" link displayed within the portlet.
+
+#### `notification` portlet preference (optional)
+
+Every HRS integration portlet, individually, supports this portlet preference.
+(That is, it can be configured differently for different publications of the portlets).
+
++ For each value of this portlet preference, the configured portlet will render a user-facing message near the top of the portlet content.
++ When not set, this message block disappears from the UI.
+
+This is intended as a solution for 
+
++ Making employees aware of known issues or service degradations (e.g., Benefit Information is omitting some dependents.)
++ Service notices about e.g. upcoming outages (e.g. This app will be unavailable on Tuesday.)
++ Notes about recent changes to the app (e.g. Sabbatical is now termed Banked Leave.)
++ etc.
+
+### Specific to Benefit Information
+
+#### `benefitsSummaryUrl` portlet preference (optional)
+
++ When set, Benefit Information uses this URL as the href of the "View Benefits Summary Detail" link.
++ When not set, Benefit Information uses the URL from the HRS URLs SOAP web service as the href of the "View Benefits Summary Detail" link.
++ If the URL is available from neither source, Benefit Information drops this link from the UI.
+
+### Specific to Payroll Information
+
+#### `directDepositSelfServiceUrl` portlet preference (optional)
+
++ When set, configures the href of the "Update your Direct Deposit" link, as experienced by employees with the role required for this access.
++ When not set, all employees will use the hard-coded href linking to a PDF that employees without the role experience.
+
+#### `understandingEarningUrl` portlet preference (optional)
+
++ When set, configures the href of the "Understanding Your Earnings Statement" link.
++ When not set, the link does not display.
+
+### Specific to Personal Information
+
+While branded as "Personal Information" as published in MyUW,
+technically the underlying portlet name is `ContactInfo`.
+
+#### `notice` portlet preference (optional)
+
++ When set, Personal Information shows the value of this preference as a user-facing message in the context of editing preferred name. This is intended as a spot for documentation nuancing what edits are and are not permitted.
++ When not set, this message does not appear.
+
+#### `updateMyPersonalInfoUrl` portlet preference (optional)
+
++ When set, uses its value as the href for the link to HRS self-service management of personal information.
++ When set, turns on "PUM22 mode", which tweaks the display a bit. The deep links specific to self-service updating of ethnicity, disability, and veteran status reporting disappear (in favor of the linked UI being the omnibus UI for updating all personal information).
+
+### Specific to Time and Absence
+
+#### `editCancelAbsenceUrl` portlet preference (optional)
+
++ When set, adds a "Edit/Cancel Absence" link to this URL that shows to employees who see the nearby "Enter Absence" link.
++ When not set, the "Edit/Cancel Absence" link does not appear.
+
+#### `timesheetNotice` portlet preference (optional)
+
++ When set, adds text to the UI near the timesheet launch button.
++ When not set, omits this text.
+
+Intended for adding a reminder to employees who by policy are not to work so
+many hours that they must be offered health insurance. (This text shows to all)
+employees with a role to see the timesheet launch button, regardless of whether
+this hour limiting policy applies to them.)
+
+#### `UnclassifiedLeaveReportForSummerUrl` portlet preference (optional)
+
+(Note the PascalCase rather than camelCase capitalization.)
+
++ Configures the href of the "Unclassified Summer Session/Service Leave Report" link.
++ When not set, this link does not appear.
+
+#### `UnclassifiedLeaveReportUrl` portlet preference (REQUIRED)
+
+(Note the PascalCase rather than camelCase capitalization.)
+
++ Configures the href of the "Unclassified Leave Report" link.
++ If not set, this link will still appear but will be broken.
+
 ## Local Setup Instructions
 
 Several property files need to be configured for your local environment before the Portlet will run in your local uPortal server.


### PR DESCRIPTION
Add `README.md` documentation of the `portlet-preference`s available to configure the HRS portlets at the portlet publication layer.