### PR TITLE
HRSPLT-283 literally implement requested markup.

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -220,17 +220,23 @@
             linked HRS self-service UI. -->
       
       <div class="dl-contact-info-update">
-        <a href="${prefs['updateMyPersonalInfoUrl'][0]}" 
-          target="_blank" rel="noopener noreferer">
-          <spring:message code="updateInfoLink"/>
-        </a>
+        <strong>
+          <a href="${prefs['updateMyPersonalInfoUrl'][0]}" 
+            target="_blank" rel="noopener noreferer">
+            Update My Personal Information
+          </a>
+        </strong>
         <br/>
         <div>
           <p class="padded-paragraph">
-            You can 
-            <a href="${prefs['updateMyPersonalInfoUrl'][0]}" 
-              target="_blank" rel="noopener noreferer">update personal information in the Human Resources System (HRS)</a> including:
-addresses (home &amp; mail), contact details (phone &amp; email), emergency contacts, home information release, marital status, coordination of benefits, Medicare information, ethnic groups, veteran status, and disability status.
+            <strong>
+              Please note that you can update the following personal information in HRS:
+            </strong>
+            <p class="padded-paragraph" style="padding-left: 2cm;">
+              <strong>
+                Addresses (Home &amp; Mail); Contact Details (Phone &amp; Email); Emergency Contacts; Release Home Information; Marital Status; Coordination of Benefits; Medicare Information; Ethnic Groups; Veteran Status; Disability.
+              </strong>
+            </p>
           </p>
           <p>
             <strong>


### PR DESCRIPTION
I'd applied a style polish pass to requested PUM22 "Personal Information" markup for launching the new HRS self-service personal information management UI.

Too much.

This changeset switches to an approach of literally implementing the requested change.

As previously implemented (sentence case, inline hyperlink, omit "please").

![update-personal-info-before](https://user-images.githubusercontent.com/952283/32066299-eb175d58-ba44-11e7-9fb9-c4108c586f0e.png)

As implemented with this changeset: (strong throughout, treat HRS content as proper nouns, single hyperlink, text as literally requested.)

![after-literally](https://user-images.githubusercontent.com/952283/32066294-e30dc962-ba44-11e7-8a48-113908b56d48.png)

As requested:

![proposed my uw personal information portlet 1](https://user-images.githubusercontent.com/952283/32066290-df4c8b6a-ba44-11e7-9845-95f21b917a0d.png)

