### PR TITLE
HRSPLT-296: Clarify whose missing leave reports we're talking about

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -209,8 +209,9 @@
     <div id="${n}dl-absence-statements" class="dl-absence-statements ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
       <div id="${n}dl-leave-statements">
       	<p class="padded-paragraph">
-      		<a href="#" id="${n}oustandingMissingLeaveReports" target="_blank" style="display: none;">
-      		You have unfinished Monthly Leave Reports.</a>
+      		<a href="#" id="${n}oustandingMissingLeaveReports" target="_blank"
+      		  style="display: none; text-decoration: underline;">
+      		  You have unfinished Monthly Leave Reports.</a>
             Please download and print blank Monthly Leave Reports below.
       	</p>
         <div class="fl-pager">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -210,7 +210,8 @@
       <div id="${n}dl-leave-statements">
       	<p class="padded-paragraph">
       		<a href="#" id="${n}oustandingMissingLeaveReports" target="_blank" style="display: none;">
-      		You have missing Leave Reports. Submit them.</a>
+      		You have unfinished Monthly Leave Reports.</a>
+            Please download and print blank Monthly Leave Reports below.
       	</p>
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -209,7 +209,8 @@
     <div id="${n}dl-absence-statements" class="dl-absence-statements ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
       <div id="${n}dl-leave-statements">
       	<p class="padded-paragraph">
-      		<a href="#" id="${n}oustandingMissingLeaveReports" target="_blank" style="display: none;">Outstanding Missing Leave Reports</a>
+      		<a href="#" id="${n}oustandingMissingLeaveReports" target="_blank" style="display: none;">
+      		Outstanding Missing Leave Reports</a>
       	</p>
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -275,9 +275,9 @@
     </div>
      --%>
     <div class="dl-link">
-      <a href="${prefs['UnclassifiedLeaveReportUrl'][0]}" target="_blank" class='btn btn-default'>Unclassified Leave Report</a><c:if test="${not empty prefs['UnclassifiedLeaveReportForSummerUrl'][0]}">
+      <a href="${prefs['UnclassifiedLeaveReportUrl'][0]}" target="_blank" class='btn btn-default'>Blank Monthly Leave Report</a><c:if test="${not empty prefs['UnclassifiedLeaveReportForSummerUrl'][0]}">
       <span class="hidden-xs visible-xs">|</span>
-      <a href="${prefs['UnclassifiedLeaveReportForSummerUrl'][0]}" target="_blank"  class='btn btn-default'>Unclassified Summer Session/Service Leave Report</a></c:if>
+      <a href="${prefs['UnclassifiedLeaveReportForSummerUrl'][0]}" target="_blank"  class='btn btn-default'>Blank Summer Leave Report</a></c:if>
     </div>
   </div>
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -210,7 +210,7 @@
       <div id="${n}dl-leave-statements">
       	<p class="padded-paragraph">
       		<a href="#" id="${n}oustandingMissingLeaveReports" target="_blank" style="display: none;">
-      		Outstanding Missing Leave Reports</a>
+      		You have missing Leave Reports. Submit them.</a>
       	</p>
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />


### PR DESCRIPTION
This Pull Request tries to answer, what's the very least we could do that would clarify the experience of employees who are missing leave reports? We might be able to make this much progress while we figure out what more progress can be made.

So, minimally, we could tweak the text of the existing hyperlink to be less weird, less saying there's "Missing Leave Reports" in the world and they're "Outstanding". But we're not going to tell you what we're suggesting you do about that, we're not going to clarify how this relates to *you*. They just, like, exist, declaratively speaking.

Less with that. And more with, hey, *you* have these missing reports, and *you* ought to submit them.

Status quo (mockup):

![outstanding-missing-leave-reports](https://user-images.githubusercontent.com/952283/34164137-61b081c8-e49e-11e7-95d3-df0f19150d85.png)

This change (mockup):

![you-are-the-weakest-leave-report-link](https://user-images.githubusercontent.com/952283/34164151-6ca781c6-e49e-11e7-9283-7779890ed2ff.png)
