### PR TITLE
Revert to stable

### DIFF
--- a/hrs-portlets-webapp/src/main/resources/messages.properties
+++ b/hrs-portlets-webapp/src/main/resources/messages.properties
@@ -41,7 +41,7 @@ bottomNotePart2=To update your Business/Office Address, please contact your Payr
 
 noEmplId=There is no employment record identifier available for your account.
 refresh=Refresh
-noLeaveOrSabbaticalStatements=You have no Monthly Leave Reports.
+noLeaveOrSabbaticalStatements=You have no Leave Reports or Banked Leave statements.
 
 label.official.name=Primary/Legal Name
 label.preferred.name=Preferred Name

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -235,10 +235,7 @@
     <div id="${n}dl-absence-statements" class="dl-absence-statements ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
       <div id="${n}dl-leave-statements">
       	<p class="padded-paragraph">
-      		<a href="#" id="${n}oustandingMissingLeaveReports" target="_blank"
-      		  style="display: none; text-decoration: underline;">
-      		  You have unfinished Monthly Leave Reports.</a>
-            Please download and print blank Monthly Leave Reports below.
+      		<a href="#" id="${n}oustandingMissingLeaveReports" target="_blank" style="display: none;">Outstanding Missing Leave Reports</a>
       	</p>
       	<div class="balance-header">
           <span>Banked Leave Statements if available now appear at the bottom of the Leave Balances tab.</span>
@@ -283,9 +280,9 @@
     </div>
      --%>
     <div class="dl-link">
-      <a href="${prefs['UnclassifiedLeaveReportUrl'][0]}" target="_blank" class='btn btn-default'>Blank Monthly Leave Report</a><c:if test="${not empty prefs['UnclassifiedLeaveReportForSummerUrl'][0]}">
+      <a href="${prefs['UnclassifiedLeaveReportUrl'][0]}" target="_blank" class='btn btn-default'>Unclassified Leave Report</a><c:if test="${not empty prefs['UnclassifiedLeaveReportForSummerUrl'][0]}">
       <span class="hidden-xs visible-xs">|</span>
-      <a href="${prefs['UnclassifiedLeaveReportForSummerUrl'][0]}" target="_blank"  class='btn btn-default'>Blank Summer Leave Report</a></c:if>
+      <a href="${prefs['UnclassifiedLeaveReportForSummerUrl'][0]}" target="_blank"  class='btn btn-default'>Unclassified Summer Session/Service Leave Report</a></c:if>
     </div>
   </div>
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -94,7 +94,7 @@
       <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET">
         <li class="ui-state-default ui-corner-top"><a href="#${n}dl-time-entry">Time Entry</a></li>
       </sec:authorize>
-      <li class="ui-state-default ui-corner-top"><a href="#${n}dl-absence-statements">Monthly Leave Reports</a></li>
+      <li class="ui-state-default ui-corner-top"><a href="#${n}dl-absence-statements">Leave Reports</a></li>
     </ul>
     <c:set var="hiddenTabStyle" value=""/>
     <sec:authorize ifAllGranted="ROLE_VIEW_ABSENCE_HISTORIES">
@@ -164,33 +164,7 @@
         </div>
         <hrs:pagerNavBar position="bottom" />
       </div>
-
-      <div id="${n}dl-sabbatical-reports">
-        <div class="fl-pager">
-          <hrs:pagerNavBar position="top" showSummary="${true}" />
-          <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
-            <table class="dl-table table">
-              <thead>
-                <tr rsf:id="header:">
-                  <th class="flc-pager-sort-header" rsf:id="year"><a href="javascript:;">Year</a></th>
-                  <th class="flc-pager-sort-header" rsf:id="fullTitle"><a href="javascript:;">Statement</a></th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="dl-clickable" rsf:id="row:">
-                  <td class="dl-data-text"><a href="#" target="_blank" rsf:id="year"></a></td>
-                  <td class="dl-data-text"><a href="#" target="_blank" rsf:id="fullTitle"></a></td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <hrs:pagerNavBar position="bottom" />
-        </div>
-      </div>
     </div>
-
-
-
     <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET">
       <div id="${n}dl-time-entry" class="dl-time-entry ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
         <div class="fl-pager">
@@ -237,9 +211,6 @@
       	<p class="padded-paragraph">
       		<a href="#" id="${n}oustandingMissingLeaveReports" target="_blank" style="display: none;">Outstanding Missing Leave Reports</a>
       	</p>
-      	<div class="balance-header">
-          <span>Banked Leave Statements if available now appear at the bottom of the Leave Balances tab.</span>
-        </div>
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />
           <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
@@ -256,6 +227,29 @@
                     <td headers="payPeriod" class="dl-data-text" rsf:id="payPeriod"></td>
                     <td headers="leaveStatementLink" class="dl-data-text" rsf:id="leaveStatementLink"></td>
                     <td headers="leaveFurloughReportLinks" class="dl-data-text" rsf:id="leaveFurloughReportLinks"></td>
+                  </tr>
+              </tbody>
+            </table>
+          </div>
+          <hrs:pagerNavBar position="bottom" />
+        </div>
+      </div>
+
+      <div id="${n}dl-sabbatical-reports">
+        <div class="fl-pager">
+          <hrs:pagerNavBar position="top" showSummary="${true}" />
+          <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
+            <table class="dl-table table">
+              <thead>
+                <tr rsf:id="header:">
+                  <th class="flc-pager-sort-header" rsf:id="year"><a href="javascript:;">Year</a></th>
+                  <th class="flc-pager-sort-header" rsf:id="fullTitle"><a href="javascript:;">Statement</a></th>
+                </tr>
+              </thead>
+              <tbody>
+                  <tr class="dl-clickable" rsf:id="row:">
+                    <td class="dl-data-text"><a href="#" target="_blank" rsf:id="year"></a></td>
+                    <td class="dl-data-text"><a href="#" target="_blank" rsf:id="fullTitle"></a></td>
                   </tr>
               </tbody>
             </table>
@@ -476,7 +470,12 @@
                     //Hide the leave reports block
                     $("#${n}dl-leave-statements").hide();
 
-                    noStatementsDiv.show();
+                    //Increment the show count on the no statements block, if result is 2 show the no statements block
+                    var showStatus = noStatementsDiv.data("showStatus");
+                    showStatus.statements = false;
+                    if (!showStatus.sabbatical && !showStatus.statements) {
+                        noStatementsDiv.show();
+                    }
                 }
                 else {
                     //Hide no statements block and decrement the show count
@@ -550,7 +549,17 @@
             		//Hide the sabbatical reports block
             		$("#${n}dl-sabbatical-reports").hide();
 
-            	} else {
+            		//Increment the show count on the no statements block, if result is 2 show the no statements block
+            		var showStatus = noStatementsDiv.data("showStatus");
+            		showStatus.sabbatical = false;
+            		if (!showStatus.sabbatical && !showStatus.statements) {
+            			noStatementsDiv.show();
+            		}
+            	}
+            	else {
+            		//Hide no statements block and decrement the show count
+            		noStatementsDiv.hide();
+            		noStatementsDiv.data("showStatus").sabbatical = true;
 
             		$("#${n}dl-sabbatical-reports").show();
             	}


### PR DESCRIPTION
Reverts partial progress on clarifying the unfinished aka "Outstanding" leave reports experience to clear way for more urgent (and preferably more stable) HRS portlets work.

That is, reverts #88 and #89 .

Keeps around the unstable attempt in an `unstable-feat-monthly-leave-reports` branch.
  