### PR TITLE
HRSPLT-309: Update address at generic local hr office

### DIFF
--- a/hrs-portlets-webapp/src/main/resources/messages.properties
+++ b/hrs-portlets-webapp/src/main/resources/messages.properties
@@ -37,7 +37,7 @@ no=No
 yes=Yes
 
 bottomNotePart1=Please note that you can update Home Address, Phone, Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in HRS.
-bottomNotePart2=To update your Business/Office Address, please contact your Payroll Office.
+bottomNotePart2=To update your Business/Office Address, please contact your human resources office.
 
 noEmplId=There is no employment record identifier available for your account.
 refresh=Refresh

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -241,7 +241,8 @@
           </p>
           <p>
             <strong>
-              <spring:message code="bottomNotePart2" text="To update your Business/Office Address, contact your human resources office."/>
+              <spring:message code="bottomNotePart2"
+                text="To update your Business/Office Address, contact your human resources office."/>
             </strong>
           </p>
         </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -335,7 +335,8 @@
           </p>
           <p>
             <strong>
-              <spring:message code="bottomNotePart2" text="To update your Business/Office Address, please contact your human resources office."/>
+              <spring:message code="bottomNotePart2"
+                text="To update your Business/Office Address, please contact your human resources office."/>
             </strong>
           </p>
         </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -335,7 +335,7 @@
           </p>
           <p>
             <strong>
-              <spring:message code="bottomNotePart2" text="To update your Business/Office Address, please contact your Payroll Office."/>
+              <spring:message code="bottomNotePart2" text="To update your Business/Office Address, please contact your human resources office."/>
             </strong>
           </p>
         </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -241,7 +241,7 @@
           </p>
           <p>
             <strong>
-              <spring:message code="bottomNotePart2" text="To update your Business/Office Address, contact your Payroll Office."/>
+              <spring:message code="bottomNotePart2" text="To update your Business/Office Address, contact your human resources office."/>
             </strong>
           </p>
         </div>


### PR DESCRIPTION
Rather than advising to update "Business/Office Address" at "your Payroll Office", instead advise "your human resources office", which is likely to be more relatable across the broad diversity of employees and departments across the university system and so should have better outcomes for employees sooner finding the right contact for their address updating needs.

Before: (screenshot)

![payroll-office](https://user-images.githubusercontent.com/952283/34733826-5616dd52-f52f-11e7-82de-8a0ddaa94a2b.png)

After: (mockup)

![human-resources-office](https://user-images.githubusercontent.com/952283/34733830-5875f380-f52f-11e7-9736-6580975eec9b.png)