### PR TITLE
Add ability to supply link for your human resource contact

### DIFF
--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/contactinfo/ContactInfoController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/contactinfo/ContactInfoController.java
@@ -37,6 +37,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.ValidationUtils;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.portlet.bind.annotation.ActionMapping;
@@ -66,6 +67,7 @@ import edu.wisc.portlet.hrs.web.HrsControllerBase;
 public class ContactInfoController extends HrsControllerBase {
 	private final String PVI_ATTR = "wiscedupvi";
     private final EmailValidator emailValidator = EmailValidator.getInstance();
+    private static final String HR_CONTACT_URL_PREFERENCE_NAME="humanResourceContactUrl";
     
     private String businessEmailRolesPreferences = "businessEmailRoles";
     private ContactInfoDao contactInfoDao;
@@ -89,6 +91,17 @@ public class ContactInfoController extends HrsControllerBase {
     @Autowired
     public void setContactInfoDao(ContactInfoDao contactInfoDao) {
         this.contactInfoDao = contactInfoDao;
+    }
+    
+    /**
+     * Populate the ModelMap with the link of humanResourceOffice
+     * @param request
+     * @return
+     */
+    @ModelAttribute("humanResourceOfficeContactUrl")
+    public final String getHumanResourceOfficeContainLink(PortletRequest request) {
+        final PortletPreferences preferences = request.getPreferences();
+        return preferences.getValue(HR_CONTACT_URL_PREFERENCE_NAME, null);
     }
 
     @RenderMapping

--- a/hrs-portlets-webapp/src/main/resources/messages.properties
+++ b/hrs-portlets-webapp/src/main/resources/messages.properties
@@ -37,7 +37,9 @@ no=No
 yes=Yes
 
 bottomNotePart1=Please note that you can update Home Address, Phone, Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in HRS.
-bottomNotePart2=To update your Business/Office Address, please contact your human resources office.
+
+updateBusinessOfficeAddressInstructionsPart1=To update your Business/Office Address, please contact 
+updateBusinessOfficeAddressInstructionsPart2=your human resources office
 
 noEmplId=There is no employment record identifier available for your account.
 refresh=Refresh

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -206,8 +206,6 @@
     </c:choose>
   </div>
 
-
-
   <c:choose>
     <c:when test="${not empty prefs['updateMyPersonalInfoUrl']
       && not empty prefs['updateMyPersonalInfoUrl'][0]}">
@@ -241,8 +239,22 @@
           </p>
           <p>
             <strong>
-              <spring:message code="bottomNotePart2"
-                text="To update your Business/Office Address, contact your human resources office."/>
+              <spring:message code="updateBusinessOfficeAddressInstructionsPart1"
+                text="To update your Business/Office Address, please contact"/> 
+              <c:choose>
+                <c:when test="${not empty humanResourceOfficeContactUrl}">
+                  <a href="${humanResourceOfficeContactUrl}"
+                   target="_blank"
+                   rel="noopener noreferer">
+                    <spring:message code="updateBusinessOfficeAddressInstructionsPart2"
+                     text="your human resources office"/>
+                  </a>.
+                </c:when>
+                <c:otherwise>
+                  <spring:message code="updateBusinessOfficeAddressInstructionsPart2"
+                   text="your human resources office"/>.
+                </c:otherwise>
+              </c:choose>
             </strong>
           </p>
         </div>
@@ -335,8 +347,22 @@
           </p>
           <p>
             <strong>
-              <spring:message code="bottomNotePart2"
-                text="To update your Business/Office Address, please contact your human resources office."/>
+              <spring:message code="updateBusinessOfficeAddressInstructionsPart1"
+                text="To update your Business/Office Address, please contact "/> 
+              <c:choose>
+                <c:when test="${not empty humanResourceOfficeContactUrl}">
+                  <a href="${humanResourceOfficeContactUrl}"
+                   target="_blank"
+                   rel="noopener noreferer">
+                    <spring:message code="updateBusinessOfficeAddressInstructionsPart2"
+                     text="your human resources office"/>
+                  </a>.
+                </c:when>
+                <c:otherwise>
+                  <spring:message code="updateBusinessOfficeAddressInstructionsPart2"
+                   text="your human resources office"/>.
+                </c:otherwise>
+              </c:choose>
             </strong>
           </p>
         </div>


### PR DESCRIPTION
If you supply a portlet preference:
```xml
<portlet-preference>
        <name>humanResourceContactUrl</name>
        <value>https://www.wisconsin.edu/ohrwd/benefits/contact/</value>
    </portlet-preference>
```

the `your human resources contact` will be updated with a link in the Personal Information portlet.

Before screenshot:
![image](https://user-images.githubusercontent.com/5521429/36159641-ca1ff3ec-10a4-11e8-83e0-03e3be8b4954.png)


After supplying portlet preference screenshot:
![image](https://user-images.githubusercontent.com/5521429/36159597-b07eb7f2-10a4-11e8-8d1a-96751e5ab0e0.png)

After not supplying portlet preference screenshot:
![image](https://user-images.githubusercontent.com/5521429/36159640-c990cb0e-10a4-11e8-9605-7ac198270490.png)

