### PR TITLE
Expose roles as resourceURL for list-of-links

### DIFF
--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/contactinfo/RolesDataController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/contactinfo/RolesDataController.java
@@ -1,0 +1,58 @@
+package edu.wisc.portlet.hrs.web.contactinfo;
+
+import edu.wisc.hr.dao.roles.HrsRolesDao;
+import edu.wisc.portlet.hrs.web.HrsControllerBase;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Set;
+import javax.portlet.PortletRequest;
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+import org.jasig.springframework.security.portlet.authentication.PrimaryAttributeUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.portlet.bind.annotation.ResourceMapping;
+
+/**
+ * Exposes HRS roles as JSON suitable for rendering in a list-of-links widget.
+ */
+@Controller
+@RequestMapping("VIEW")
+public class RolesDataController
+  extends HrsControllerBase {
+
+  private HrsRolesDao rolesDao;
+
+  public HrsRolesDao getRolesDao() {
+    return rolesDao;
+  }
+
+  @Autowired
+  public void setRolesDao(HrsRolesDao rolesDao) {
+    this.rolesDao = rolesDao;
+  }
+
+  @ResourceMapping("roles")
+  public void rolesResource(ResourceResponse response) throws IOException {
+    final String emplId = PrimaryAttributeUtils.getPrimaryId();
+    final Set<String> roles = this.rolesDao.getHrsRoles(emplId);
+
+    response.setContentType("application/json;charset=UTF-8");
+    final PrintWriter writer = response.getWriter();
+
+    writer.append("[");
+
+    for (String role : roles) {
+      writer.append("{"
+          + "'title':'" + role + "',"
+          + "'href':'https://wiki.doit.wisc.edu/confluence/display/MUM/HRS+Roles+and+MyUW',"
+          + "'icon':'fa-user-circle',"
+          + "'target':'_blank'"
+          + "} ");
+    }
+
+    writer.append("]");
+  }
+}

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/contactinfo/RolesDataController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/contactinfo/RolesDataController.java
@@ -2,8 +2,11 @@ package edu.wisc.portlet.hrs.web.contactinfo;
 
 import edu.wisc.hr.dao.roles.HrsRolesDao;
 import edu.wisc.portlet.hrs.web.HrsControllerBase;
+import edu.wisc.portlet.hrs.web.listoflinks.Link;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import javax.portlet.PortletRequest;
 import javax.portlet.ResourceRequest;
@@ -11,6 +14,7 @@ import javax.portlet.ResourceResponse;
 import org.jasig.springframework.security.portlet.authentication.PrimaryAttributeUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.portlet.bind.annotation.ResourceMapping;
@@ -35,24 +39,22 @@ public class RolesDataController
   }
 
   @ResourceMapping("roles")
-  public void rolesResource(ResourceResponse response) throws IOException {
+  public String rolesAsListOfLinksResource(ModelMap modelMap) throws IOException {
     final String emplId = PrimaryAttributeUtils.getPrimaryId();
     final Set<String> roles = this.rolesDao.getHrsRoles(emplId);
 
-    response.setContentType("application/json;charset=UTF-8");
-    final PrintWriter writer = response.getWriter();
+    final List<Link> linkList = new ArrayList<Link>();
 
-    writer.append("[");
-
-    for (String role : roles) {
-      writer.append("{"
-          + "'title':'" + role + "',"
-          + "'href':'https://wiki.doit.wisc.edu/confluence/display/MUM/HRS+Roles+and+MyUW',"
-          + "'icon':'fa-user-circle',"
-          + "'target':'_blank'"
-          + "} ");
+    for (final String role : roles) {
+      final Link link = new Link();
+      link.setTitle(role);
+      link.setHref("https://wiki.doit.wisc.edu/confluence/display/MUM/HRS+Roles+and+MyUW");
+      link.setTarget("_blank");
+      link.setIcon("fa-user-circle");
+      linkList.add(link);
     }
 
-    writer.append("]");
+    modelMap.put("links", linkList.toArray());
+    return "linksAttrJsonView";
   }
 }

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/listoflinks/Link.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/listoflinks/Link.java
@@ -1,0 +1,45 @@
+package edu.wisc.portlet.hrs.web.listoflinks;
+
+/**
+ * Represents a link suitable for inclusion in a JSON array to feed the list-of-links widget type.
+ */
+public class Link {
+
+  private String title;
+  private String href;
+  private String target;
+  private String icon;
+
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  public String getHref() {
+    return href;
+  }
+
+  public void setHref(String href) {
+    this.href = href;
+  }
+
+  public String getTarget() {
+    return target;
+  }
+
+  public void setTarget(String target) {
+    this.target = target;
+  }
+
+  public String getIcon() {
+    return icon;
+  }
+
+  public void setIcon(String icon) {
+    this.icon = icon;
+  }
+}

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/views.xml
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/views.xml
@@ -40,6 +40,13 @@
         <property name="objectMapper" ref="objectMapper" />
         <property name="modelKey" value="quantity" />
     </bean>
+
+    <bean id="linksAttrJsonView"
+      class="org.springframework.web.servlet.view.json.MappingJackson2JsonView">
+      <property name="objectMapper" ref="objectMapper" />
+      <property name="modelKey" value="links" />
+      <property name="extractValueFromSingleKeyModel" value="true"/>
+    </bean>
     
     <bean id="objectMapper" class="com.fasterxml.jackson.databind.ObjectMapper" />
     


### PR DESCRIPTION
The idea here is to enable a developer-facing `list-of-links` widget that reports on the user's roles as understood by the HRS portlets, enabling troubleshooting and proving out the concept of a dynamic source of list-of-links URLs dependent upon runtime roles.

If all goes well this turns into a quick handy widget for understanding what HRS roles MyUW thinks one has.