### PR TITLE
fix: generate list-of-links JSON in expected format

### DIFF
--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/contactinfo/RolesDataController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/contactinfo/RolesDataController.java
@@ -6,7 +6,9 @@ import edu.wisc.portlet.hrs.web.listoflinks.Link;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.portlet.PortletRequest;
 import javax.portlet.ResourceRequest;
@@ -38,6 +40,14 @@ public class RolesDataController
     this.rolesDao = rolesDao;
   }
 
+  /**
+   * Model is "content" --> "links" --> Link[],
+   * suitable for (in JSON representation) use as the remote source for dynamic list-of-links
+   * widget in uPortal-app-framework.
+   * @param modelMap
+   * @return String representing view
+   * @throws IOException
+   */
   @ResourceMapping("roles")
   public String rolesAsListOfLinksResource(ModelMap modelMap) throws IOException {
     final String emplId = PrimaryAttributeUtils.getPrimaryId();
@@ -54,7 +64,11 @@ public class RolesDataController
       linkList.add(link);
     }
 
-    modelMap.put("links", linkList.toArray());
-    return "linksAttrJsonView";
+    Map<String, Object[]> content = new HashMap<String, Object[]>();
+    content.put("links", linkList.toArray());
+
+    modelMap.put("content", content);
+
+    return "contentAttrJsonView";
   }
 }

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/views.xml
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/views.xml
@@ -41,11 +41,10 @@
         <property name="modelKey" value="quantity" />
     </bean>
 
-    <bean id="linksAttrJsonView"
+    <bean id="contentAttrJsonView"
       class="org.springframework.web.servlet.view.json.MappingJackson2JsonView">
       <property name="objectMapper" ref="objectMapper" />
-      <property name="modelKey" value="links" />
-      <property name="extractValueFromSingleKeyModel" value="true"/>
+      <property name="modelKey" value="content" />
     </bean>
     
     <bean id="objectMapper" class="com.fasterxml.jackson.databind.ObjectMapper" />


### PR DESCRIPTION
[Turns out](https://github.com/uPortal-Project/uportal-app-framework/pull/717) `list-of-links` expects `content.links.Link[]`.

Fixes the not-correct JSON format implemented in #96 .