### PR TITLE
HRSPLT-325 map new UW_DYN_TIME_ABS_DASH_USER role to new portlet role

### DIFF
--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -129,6 +129,11 @@
               -->
           </set>
         </entry>
+        <entry key="UW_DYN_TIME_ABS_DASH_USER">
+          <set>
+            <value>ROLE_VIEW_TIME_ABS_DASHBOARD</value>
+          </set>
+        </entry>
     </util:map>
     
     <bean id="absenceBalanceDestinationProvider" class="org.jasig.springframework.ws.client.support.destination.FailSafeWsdl11DestinationProvider" />


### PR DESCRIPTION
HRS is introducing new role named `UW_DYN_TIME_ABS_DASH_USER`.

HRS Portlets will use this role to inform generating dynamic Manager Time and Approval `list-of-links` widget links, and in the legacy JSP representation of Manager Time and Approval links.