### PR TITLE
Add new manager links portlet

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,25 @@ this hour limiting policy applies to them.)
 + Configures the href of the "Unclassified Leave Report" link.
 + If not set, this link will still appear but will be broken.
 
+## JSON resource URLs
+
+(Not a comprehensive listing.)
+
+### Manager Links
+
++ `managerListOfLinks` : JSON suitable for driving a `list-of-links` widget representing links 
+  appropriate to the employee's roles for approving others' time and absences.
+
+### Roles
+
++ `rolesAsListOfLinks` : JSON suitable for driving a `list-of-links` widget representing the user's 
+  HRS roles. Useful for troubleshooting.
+
+### Urls
+
++ `hrsUrlsAsListOfLinks` : JSON suitable for driving a `list-of-links` widget representing the HRS 
+  URLs. Useful for troubleshooting.
+
 ## Local Setup Instructions
 
 Several property files need to be configured for your local environment before the Portlet will run in your local uPortal server.

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/url/HrsUrlDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/url/HrsUrlDao.java
@@ -29,4 +29,10 @@ import java.util.Map;
  */
 public interface HrsUrlDao {
     public Map<String, String> getHrsUrls();
+
+    /**
+     * The name of the key the value of which is the deep link into HRS to approve payable time.
+     * NB: Approve and Payable are capitalized; time isn't
+     */
+    public static String APPROVE_PAYABLE_TIME_KEY = "Approve Payable time";
 }

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/HrsControllerBase.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/HrsControllerBase.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
 
+import org.jasig.springframework.security.portlet.authentication.PrimaryAttributeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,6 +93,11 @@ public class HrsControllerBase {
     @ModelAttribute("hrsUrls")
     public final Map<String, String> getHrsUrls() {
         return this.hrsUrlDao.getHrsUrls();
+    }
+
+    @ModelAttribute("emplid")
+    public final String emplidFromPortletRequest(PortletRequest request) {
+        return PrimaryAttributeUtils.getPrimaryId();
     }
 
     @ResourceMapping("getHrsUrlsJson")

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -104,6 +104,8 @@ public class ManagerLinksController
         final Link approveTime = new Link();
         approveTime.setTitle("Approve time");
         approveTime.setIcon("access_time");
+        approveTime.setTarget("_blank");
+        linkList.add(approveTime);
       } else {
         logger.error("HRS URL [" + HrsUrlDao.APPROVE_PAYABLE_TIME_KEY + "] expected but not found "
             + "and so could not be offered to emplid " + emplId);

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -99,13 +99,13 @@ public class ManagerLinksController
     }
 
     if (roles.contains("ROLE_VIEW_MANAGED_TIMES")) {
-      final String approveTimeUrl = getHrsUrls().get("Approve Payable time");
+      final String approveTimeUrl = getHrsUrls().get(HrsUrlDao.APPROVE_PAYABLE_TIME_KEY);
       if (StringUtils.isNotBlank(approveTimeUrl)) {
         final Link approveTime = new Link();
         approveTime.setTitle("Approve time");
         approveTime.setIcon("access_time");
       } else {
-        logger.error("HRS URL [Approve Payable time] expected but not found "
+        logger.error("HRS URL [" + HrsUrlDao.APPROVE_PAYABLE_TIME_KEY + "] expected but not found "
             + "and so could not be offered to emplid " + emplId);
       }
     }

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -1,4 +1,4 @@
-package edu.wisc.portlet.hrs.web.manager;
+package edu.wisc.portlet.hrs.web.managerlinks;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -29,7 +29,7 @@ import org.springframework.web.portlet.bind.annotation.ResourceMapping;
  */
 @Controller
 @RequestMapping("VIEW")
-public class ManagerLinksDataController
+public class ManagerLinksController
   extends HrsControllerBase {
 
   private static Set<String> ROLES_THAT_MANAGE_TIME_OR_ABSENCES;
@@ -145,6 +145,21 @@ public class ManagerLinksDataController
     modelMap.put("content", content);
 
     return "contentAttrJsonView";
+  }
+
+
+  @RequestMapping
+  public String viewLinks( ModelMap modelMap, PortletRequest request){
+
+    final String emplId = PrimaryAttributeUtils.getPrimaryId();
+
+    final PortletPreferences preferences = request.getPreferences();
+    final String approvalsDashboardUrl =
+        preferences.getValue("approvalsDashboardUrl", null);
+
+    modelMap.put("approvalsDashboardUrl", approvalsDashboardUrl);
+
+    return "managerLinks";
   }
 
 }

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -99,13 +99,13 @@ public class ManagerLinksController
     }
 
     if (roles.contains("ROLE_VIEW_MANAGED_TIMES")) {
-      final String approveTimeUrl = getHrsUrls().get("Approve Payable Time");
+      final String approveTimeUrl = getHrsUrls().get("Approve Payable time");
       if (StringUtils.isNotBlank(approveTimeUrl)) {
         final Link approveTime = new Link();
         approveTime.setTitle("Approve time");
         approveTime.setIcon("access_time");
       } else {
-        logger.error("HRS URL [Approve Payable Time] expected but not found "
+        logger.error("HRS URL [Approve Payable time] expected but not found "
             + "and so could not be offered to emplid " + emplId);
       }
     }

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/roles/RolesController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/roles/RolesController.java
@@ -1,23 +1,20 @@
-package edu.wisc.portlet.hrs.web.contactinfo;
+package edu.wisc.portlet.hrs.web.roles;
 
 import edu.wisc.hr.dao.roles.HrsRolesDao;
 import edu.wisc.portlet.hrs.web.HrsControllerBase;
 import edu.wisc.portlet.hrs.web.listoflinks.Link;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
-import javax.portlet.ResourceRequest;
-import javax.portlet.ResourceResponse;
 import org.jasig.springframework.security.portlet.authentication.PrimaryAttributeUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.portlet.bind.annotation.ResourceMapping;
 
@@ -26,7 +23,7 @@ import org.springframework.web.portlet.bind.annotation.ResourceMapping;
  */
 @Controller
 @RequestMapping("VIEW")
-public class RolesDataController
+public class RolesController
   extends HrsControllerBase {
 
   private HrsRolesDao rolesDao;
@@ -48,11 +45,34 @@ public class RolesDataController
    * @return String representing view
    * @throws IOException
    */
-  @ResourceMapping("roles")
+  @ResourceMapping("rolesAsListOfLinks")
   public String rolesAsListOfLinksResource(ModelMap modelMap) throws IOException {
     final String emplId = PrimaryAttributeUtils.getPrimaryId();
     final Set<String> roles = this.rolesDao.getHrsRoles(emplId);
 
+    final List<Link> linkList = rolesAsLinks(roles);
+
+    Map<String, Object[]> content = new HashMap<String, Object[]>();
+    content.put("links", linkList.toArray());
+
+    modelMap.put("content", content);
+
+    return "contentAttrJsonView";
+  }
+
+  @RequestMapping
+  public String viewRoles( ModelMap modelMap, PortletRequest request){
+
+    final String emplId = PrimaryAttributeUtils.getPrimaryId();
+    final Set<String> roles = this.rolesDao.getHrsRoles(emplId);
+
+    final List<Link> linkList = rolesAsLinks(roles);
+
+    modelMap.put("links", linkList);
+    return "listOfLinks";
+  }
+
+  protected List<Link> rolesAsLinks(Set<String> roles) {
     final List<Link> linkList = new ArrayList<Link>();
 
     for (final String role : roles) {
@@ -63,12 +83,6 @@ public class RolesDataController
       link.setIcon("fa-user-circle");
       linkList.add(link);
     }
-
-    Map<String, Object[]> content = new HashMap<String, Object[]>();
-    content.put("links", linkList.toArray());
-
-    modelMap.put("content", content);
-
-    return "contentAttrJsonView";
+    return linkList;
   }
 }

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/urls/UrlsController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/urls/UrlsController.java
@@ -1,0 +1,58 @@
+package edu.wisc.portlet.hrs.web.urls;
+
+import edu.wisc.portlet.hrs.web.HrsControllerBase;
+import edu.wisc.portlet.hrs.web.listoflinks.Link;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.portlet.PortletRequest;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.portlet.bind.annotation.ResourceMapping;
+
+@Controller
+@RequestMapping("VIEW")
+public class UrlsController
+  extends HrsControllerBase {
+
+  @ResourceMapping("hrsUrlsListOfLinks")
+  public String hrsUrlsAsListOfLinksJson(final ModelMap modelMap) {
+
+    final List<Link> linkList = hrsUrlsAsLinks();
+
+    final Map<String, Object[]> content = new HashMap<String, Object[]>();
+    content.put("links", linkList.toArray());
+
+    modelMap.put("content", content);
+
+    return "contentAttrJsonView";
+  }
+
+  @RequestMapping
+  public String viewHrsUrls(final ModelMap modelMap) {
+
+    final List<Link> linkList = hrsUrlsAsLinks();
+
+    modelMap.put("links", linkList);
+
+    return "listOfLinks";
+  }
+
+  protected List<Link> hrsUrlsAsLinks() {
+    Map<String, String> hrsUrls = this.getHrsUrls();
+
+    List<Link> linkList = new ArrayList<Link>();
+
+    for (String urlName : hrsUrls.keySet()) {
+      final Link link = new Link();
+      link.setTitle(urlName);
+      link.setHref(hrsUrls.get("link"));
+      link.setIcon("link");
+      linkList.add(link);
+    }
+    return linkList;
+  }
+
+}

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/context/portlet/manager-links.xml
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/context/portlet/manager-links.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:aop="http://www.springframework.org/schema/aop"
+  xmlns:context="http://www.springframework.org/schema/context"
+  xmlns:util="http://www.springframework.org/schema/util"
+  xmlns:security="http://www.springframework.org/schema/security"
+  xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.1.xsd
+        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:annotation-config />
+    <aop:config proxy-target-class="true" />
+    <security:global-method-security secured-annotations="enabled" pre-post-annotations="enabled" proxy-target-class="true"/>
+    <context:component-scan base-package="edu.wisc.portlet.hrs.web.managerlinks"/>
+    <bean class="org.springframework.web.portlet.mvc.annotation.DefaultAnnotationHandlerMapping">
+        <property name="interceptors" ref="defaultPortletInterceptors" />
+    </bean>
+</beans>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/context/portlet/roles.xml
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/context/portlet/roles.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:aop="http://www.springframework.org/schema/aop"
+  xmlns:context="http://www.springframework.org/schema/context"
+  xmlns:util="http://www.springframework.org/schema/util"
+  xmlns:security="http://www.springframework.org/schema/security"
+  xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.1.xsd
+        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:annotation-config />
+    <aop:config proxy-target-class="true" />
+    <security:global-method-security secured-annotations="enabled" pre-post-annotations="enabled" proxy-target-class="true"/>
+    <context:component-scan base-package="edu.wisc.portlet.hrs.web.roles"/>
+    <bean class="org.springframework.web.portlet.mvc.annotation.DefaultAnnotationHandlerMapping">
+        <property name="interceptors" ref="defaultPortletInterceptors" />
+    </bean>
+</beans>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/context/portlet/urls.xml
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/context/portlet/urls.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:aop="http://www.springframework.org/schema/aop"
+  xmlns:context="http://www.springframework.org/schema/context"
+  xmlns:util="http://www.springframework.org/schema/util"
+  xmlns:security="http://www.springframework.org/schema/security"
+  xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.1.xsd
+        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:annotation-config />
+    <aop:config proxy-target-class="true" />
+    <security:global-method-security secured-annotations="enabled" pre-post-annotations="enabled" proxy-target-class="true"/>
+    <context:component-scan base-package="edu.wisc.portlet.hrs.web.urls"/>
+    <bean class="org.springframework.web.portlet.mvc.annotation.DefaultAnnotationHandlerMapping">
+        <property name="interceptors" ref="defaultPortletInterceptors" />
+    </bean>
+</beans>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/listOfLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/listOfLinks.jsp
@@ -1,0 +1,39 @@
+<%--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+<%@ page trimDirectiveWhitespaces="true" %>
+<%@ include file="/WEB-INF/jsp/include.jsp"%>
+<%@ include file="/WEB-INF/jsp/header.jsp"%>
+
+<div id="${n}dl-time-absence" class="fl-widget portlet dl-time-absence hrs">
+
+<p>Your emplid is ${emplid}.</p>
+
+<table>
+<c:forEach var="link" items="${links}">
+  <tr>
+    <td>${link.title}</td><td>${link.url}</c></td>
+  </tr>
+</c:forEach>
+</table>
+
+  <%@ include file="/WEB-INF/jsp/footer.jsp"%>
+
+</div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/listOfLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/listOfLinks.jsp
@@ -26,13 +26,13 @@
 
 <p>Your emplid is ${emplid}.</p>
 
-<table>
+<ul>
 <c:forEach var="link" items="${links}">
-  <tr>
-    <td>${link.title}</td><td>${link.href}</c></td>
-  </tr>
+  <li>
+    <a href="${link.href}">${link.title}</a>
+  </li>
 </c:forEach>
-</table>
+</ul>
 
   <%@ include file="/WEB-INF/jsp/footer.jsp"%>
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/listOfLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/listOfLinks.jsp
@@ -29,7 +29,7 @@
 <table>
 <c:forEach var="link" items="${links}">
   <tr>
-    <td>${link.title}</td><td>${link.url}</c></td>
+    <td>${link.title}</td><td>${link.href}</c></td>
   </tr>
 </c:forEach>
 </table>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
@@ -71,6 +71,14 @@
 
 </p>
 
+<table>
+<c:forEach var="hrsUrl" items="${hrsUrls}">
+  <tr>
+    <td>${hrsUrl.key}</td><td>${hrsUrl.value}</c></td>
+  </tr>
+</c>
+</table>
+
   <%@ include file="/WEB-INF/jsp/footer.jsp"%>
 
 </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
@@ -76,7 +76,7 @@
   <tr>
     <td>${hrsUrl.key}</td><td>${hrsUrl.value}</c></td>
   </tr>
-</c>
+</c:forEach>
 </table>
 
   <%@ include file="/WEB-INF/jsp/footer.jsp"%>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
@@ -1,0 +1,76 @@
+<%--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+<%@ page trimDirectiveWhitespaces="true" %>
+<%@ include file="/WEB-INF/jsp/include.jsp"%>
+<%@ include file="/WEB-INF/jsp/header.jsp"%>
+
+<div id="${n}dl-time-absence" class="fl-widget portlet dl-time-absence hrs">
+
+<p>
+
+  <sec:authorize
+    ifNotGranted="ROLE_VIEW_MANAGED_ABSENCES,ROLE_VIEW_MANAGED_TIMES,ROLE_VIEW_TIME_ABS_DASHBOARD">
+    You do not appear to have any manager roles.
+  </sec>
+
+  <ul>
+
+    <sec:authorize ifAnyGranted="ROLE_VIEW_MANAGED_TIMES">
+      <li>
+        <a href="https://www.hrs.wisconsin.edu/psp/hrs-fd/EMPLOYEE/HRMS/c/ROLE_MANAGER.TL_SRCH_APPRV_GRP.GBL"
+          target="_blank" rel="noopener noreferrer">
+          Approve time
+        </a>
+      </li>
+    </sec>
+
+    <sec:authorize ifAnyGranted="ROLE_VIEW_MANAGED_ABSENCES">
+      <li>
+        <a href="https://www.hrs.wisconsin.edu/psp/hrs-fd/EMPLOYEE/HRMS/c/ROLE_MANAGER.GP_SS_ABS_APPR_L.GBL"
+          target="_blank" rel="noopener noreferrer">
+          Approve absence
+        </a>
+      </li>
+    </sec>
+
+    <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ABS_DASHBOARD">
+      <li>
+        <a href="${approvalsDashboardUrl}"
+          target="_blank" rel="noopener noreferrer">
+          Approvals dashboard
+        </a>
+      </li>
+    </sec>
+
+    <li>
+      <a href="${helpUrl}"
+        target="_blank" rel="noopener noreferrer">
+        Help
+      </a>
+    </li>
+  </ul>
+
+
+</p>
+
+  <%@ include file="/WEB-INF/jsp/footer.jsp"%>
+
+</div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
@@ -24,6 +24,8 @@
 
 <div id="${n}dl-time-absence" class="fl-widget portlet dl-time-absence hrs">
 
+<p>Your emplid is ${emplid}.</p>
+
 <p>
 
   <sec:authorize

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
@@ -73,14 +73,6 @@
 
 </p>
 
-<table>
-<c:forEach var="hrsUrl" items="${hrsUrls}">
-  <tr>
-    <td>${hrsUrl.key}</td><td>${hrsUrl.value}</c></td>
-  </tr>
-</c:forEach>
-</table>
-
   <%@ include file="/WEB-INF/jsp/footer.jsp"%>
 
 </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
@@ -29,7 +29,7 @@
   <sec:authorize
     ifNotGranted="ROLE_VIEW_MANAGED_ABSENCES,ROLE_VIEW_MANAGED_TIMES,ROLE_VIEW_TIME_ABS_DASHBOARD">
     You do not appear to have any manager roles.
-  </sec>
+  </sec:authorize>
 
   <ul>
 
@@ -40,7 +40,7 @@
           Approve time
         </a>
       </li>
-    </sec>
+    </sec:authorize>
 
     <sec:authorize ifAnyGranted="ROLE_VIEW_MANAGED_ABSENCES">
       <li>
@@ -49,7 +49,7 @@
           Approve absence
         </a>
       </li>
-    </sec>
+    </sec:authorize>
 
     <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ABS_DASHBOARD">
       <li>
@@ -58,7 +58,7 @@
           Approvals dashboard
         </a>
       </li>
-    </sec>
+    </sec:authorize>
 
     <li>
       <a href="${helpUrl}"

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
@@ -24,7 +24,7 @@
 
 <div id="${n}dl-time-absence" class="fl-widget portlet dl-time-absence hrs">
 
-<p>Your emplid is ${emplid}.</p>
+<!-- <p>Your emplid is ${emplid}.</p> -->
 
 <p>
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
@@ -35,7 +35,7 @@
 
     <sec:authorize ifAnyGranted="ROLE_VIEW_MANAGED_TIMES">
       <li>
-        <a href="https://www.hrs.wisconsin.edu/psp/hrs-fd/EMPLOYEE/HRMS/c/ROLE_MANAGER.TL_SRCH_APPRV_GRP.GBL"
+        <a href="${hrsUrls['Approve Payable time']}"
           target="_blank" rel="noopener noreferrer">
           Approve time
         </a>
@@ -44,7 +44,7 @@
 
     <sec:authorize ifAnyGranted="ROLE_VIEW_MANAGED_ABSENCES">
       <li>
-        <a href="https://www.hrs.wisconsin.edu/psp/hrs-fd/EMPLOYEE/HRMS/c/ROLE_MANAGER.GP_SS_ABS_APPR_L.GBL"
+        <a href="${hrsUrls['Approve Absence']}"
           target="_blank" rel="noopener noreferrer">
           Approve absence
         </a>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -261,6 +261,62 @@
             </preference>
         </portlet-preferences>
     </portlet>
+
+    <portlet>
+        <portlet-name>Roles</portlet-name>
+        <portlet-class>org.jasig.springframework.web.portlet.context.ContribDispatcherPortlet</portlet-class>
+        <init-param>
+            <name>contextConfigLocation</name>
+            <value>/WEB-INF/context/portlet/roles.xml</value>
+        </init-param>
+        <expiration-cache>0</expiration-cache>
+        <supports>
+            <mime-type>text/html</mime-type>
+            <portlet-mode>view</portlet-mode>
+        </supports>
+        <portlet-info>
+            <title>HRS Portlet Roles for Troubleshooting</title>
+            <short-title>HRS Portlet Roles</short-title>
+        </portlet-info>
+        <portlet-preferences>
+            <preference>
+                <name>emplidUserAttributes</name>
+                <value>eduWisconsinHRSEmplID</value>
+                <value>eduWisconsinHRPersonID</value>
+                <value>wiscEduHRSEmplid</value>
+                <value>wisceduhrpersonid</value>
+                <value>legacywisceduhrpersonid</value>
+            </preference>
+        </portlet-preferences>
+    </portlet>
+
+    <portlet>
+        <portlet-name>Urls</portlet-name>
+        <portlet-class>org.jasig.springframework.web.portlet.context.ContribDispatcherPortlet</portlet-class>
+        <init-param>
+            <name>contextConfigLocation</name>
+            <value>/WEB-INF/context/portlet/urls.xml</value>
+        </init-param>
+        <expiration-cache>0</expiration-cache>
+        <supports>
+            <mime-type>text/html</mime-type>
+            <portlet-mode>view</portlet-mode>
+        </supports>
+        <portlet-info>
+            <title>HRS Portlet URLs for Troubleshooting</title>
+            <short-title>HRS Portlet URLs</short-title>
+        </portlet-info>
+        <portlet-preferences>
+            <preference>
+                <name>emplidUserAttributes</name>
+                <value>eduWisconsinHRSEmplID</value>
+                <value>eduWisconsinHRPersonID</value>
+                <value>wiscEduHRSEmplid</value>
+                <value>wisceduhrpersonid</value>
+                <value>legacywisceduhrpersonid</value>
+            </preference>
+        </portlet-preferences>
+    </portlet>
     
     <user-attribute>
         <name>eduWisconsinHRSEmplID</name>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -232,6 +232,35 @@
             </preference>
         </portlet-preferences>
     </portlet>
+
+
+    <portlet>
+        <portlet-name>Approvals</portlet-name>
+        <portlet-class>org.jasig.springframework.web.portlet.context.ContribDispatcherPortlet</portlet-class>
+        <init-param>
+            <name>contextConfigLocation</name>
+            <value>/WEB-INF/context/portlet/manager-links.xml</value>
+        </init-param>
+        <expiration-cache>0</expiration-cache>
+        <supports>
+            <mime-type>text/html</mime-type>
+            <portlet-mode>view</portlet-mode>
+        </supports>
+        <portlet-info>
+            <title>Manager Links</title>
+            <short-title>Manager Links</short-title>
+        </portlet-info>
+        <portlet-preferences>
+            <preference>
+                <name>emplidUserAttributes</name>
+                <value>eduWisconsinHRSEmplID</value>
+                <value>eduWisconsinHRPersonID</value>
+                <value>wiscEduHRSEmplid</value>
+                <value>wisceduhrpersonid</value>
+                <value>legacywisceduhrpersonid</value>
+            </preference>
+        </portlet-preferences>
+    </portlet>
     
     <user-attribute>
         <name>eduWisconsinHRSEmplID</name>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -235,7 +235,7 @@
 
 
     <portlet>
-        <portlet-name>Approvals</portlet-name>
+        <portlet-name>ManagerLinks</portlet-name>
         <portlet-class>org.jasig.springframework.web.portlet.context.ContribDispatcherPortlet</portlet-class>
         <init-param>
             <name>contextConfigLocation</name>


### PR DESCRIPTION
More aggressive take on adding dynamic list-of-links for manager time approval.

Introduces new Portlet ala @vertein 's successful work on approvals counts. That worked. Maybe this will likewise work.

## Dynamic "Manager Time and Approval" widget

The functional point of this changeset is implementing a dynamic rather than static `list-of-links` widget for Manager Time and Approval in MyUW.

Adds a new Portlet with a new Resource URL providing JSON with the structure expected by the `list-of-links` widget.

![manager-time-and-approval](https://user-images.githubusercontent.com/952283/38041109-955fdc28-3276-11e8-8151-fcdf995f8a6a.png)

The page you get when you follow the link from the widget is now dynamic as well:

![manager-time-and-approval-now-dynamic](https://user-images.githubusercontent.com/952283/38041182-b4f5b3dc-3276-11e8-9fb7-59549f2699ba.png)

(There was a historical manager time approval Portlet -- this isn't that and instead is a new portlet. The old one was more ambitious and complicated whereas the new one is specific to this problem of presenting the right links to managers.)

## HRS Roles widget

The new Manager Time and Approval widget is fundamentally a matter of displaying different links to different users based on roles. Initially as a proof-of-concept of generating dynamic `list-of-links` content reflecting roles, added a Roles portlet with a roles resource URL. This becomes a useful tool for troubleshooting HRS roles as understood by HRS portlet.

![hrs-portlet-roles-widget](https://user-images.githubusercontent.com/952283/38040717-b359e9ea-3275-11e8-91fa-dc357651929d.png)

The widget links to a JSP page also showing the roles. The roles hyperlink to the wiki documentation about roles in the HRS Portlets in MyUW.

![roles-app](https://user-images.githubusercontent.com/952283/38040816-f754bc38-3275-11e8-9915-a5f0cd829ae3.png)

## HRS URLs widget

The new dynamic "Manager Time and Approval" widget is fundamentally a matter of displaying different links to different users based on roles. The URLs of some of those links are read from the HRS URLs web service. So it's useful to know what URLs are coming across via that channel. Adds Portlet and widget for this, again exercising `list-of-links`.

![hrs-urls-widget](https://user-images.githubusercontent.com/952283/38040872-1485635c-3276-11e8-87f4-37854e19d962.png)

The widget links to a page listing all the URLs.

![hrs-portlet-urls](https://user-images.githubusercontent.com/952283/38041014-5803751a-3276-11e8-9d20-4fa1ee411ddf.png)

