### PR TITLE
fix: order and label for new approval dashboard link

### DIFF
--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -98,6 +98,20 @@ public class ManagerLinksController
       }
     }
 
+    if (roles.contains("ROLE_VIEW_TIME_ABS_DASHBOARD")) {
+      if (StringUtils.isNotBlank(approvalsDashboardUrl)) {
+        final Link approvalsDashboard = new Link();
+        approvalsDashboard.setTitle("Approvals Dashboard");
+        approvalsDashboard.setIcon("check_circle");
+        approvalsDashboard.setHref(approvalsDashboardUrl);
+        approvalsDashboard.setTarget("_blank");
+        linkList.add(approvalsDashboard);
+      } else {
+        logger.error("Portlet preference [approvalsDashboardUrl] expected but not found "
+            + "and so could not be offered to " + emplId);
+      }
+    }
+
     if (roles.contains("ROLE_VIEW_MANAGED_TIMES")) {
       final String approveTimeUrl = getHrsUrls().get(HrsUrlDao.APPROVE_PAYABLE_TIME_KEY);
       if (StringUtils.isNotBlank(approveTimeUrl)) {
@@ -124,20 +138,6 @@ public class ManagerLinksController
       } else {
         logger.error("HRS URL [Approve Absence] expected but not found "
             + "and so could not be offered to emplid " + emplId);
-      }
-    }
-
-    if (roles.contains("ROLE_VIEW_TIME_ABS_DASHBOARD")) {
-      if (StringUtils.isNotBlank(approvalsDashboardUrl)) {
-        final Link approvalsDashboard = new Link();
-        approvalsDashboard.setTitle("Approvals Dashboard");
-        approvalsDashboard.setIcon("check_circle");
-        approvalsDashboard.setHref(approvalsDashboardUrl);
-        approvalsDashboard.setTarget("_blank");
-        linkList.add(approvalsDashboard);
-      } else {
-        logger.error("Portlet preference [approvalsDashboardUrl] expected but not found "
-            + "and so could not be offered to " + emplId);
       }
     }
 

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -101,7 +101,7 @@ public class ManagerLinksController
     if (roles.contains("ROLE_VIEW_TIME_ABS_DASHBOARD")) {
       if (StringUtils.isNotBlank(approvalsDashboardUrl)) {
         final Link approvalsDashboard = new Link();
-        approvalsDashboard.setTitle("Approvals Dashboard");
+        approvalsDashboard.setTitle("Time &amp; Absence MSS Dashboard");
         approvalsDashboard.setIcon("check_circle");
         approvalsDashboard.setHref(approvalsDashboardUrl);
         approvalsDashboard.setTarget("_blank");

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -101,7 +101,7 @@ public class ManagerLinksController
     if (roles.contains("ROLE_VIEW_TIME_ABS_DASHBOARD")) {
       if (StringUtils.isNotBlank(approvalsDashboardUrl)) {
         final Link approvalsDashboard = new Link();
-        approvalsDashboard.setTitle("Time &amp; Absence MSS Dashboard");
+        approvalsDashboard.setTitle("Time & Absence MSS Dashboard");
         approvalsDashboard.setIcon("check_circle");
         approvalsDashboard.setHref(approvalsDashboardUrl);
         approvalsDashboard.setTarget("_blank");

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
@@ -39,7 +39,7 @@
       <li>
         <a href="${approvalsDashboardUrl}"
           target="_blank" rel="noopener noreferrer">
-          Approvals dashboard
+          Time &amp; Absence MSS Dashboard
         </a>
       </li>
     </sec:authorize>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
@@ -35,6 +35,15 @@
 
   <ul>
 
+    <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ABS_DASHBOARD">
+      <li>
+        <a href="${approvalsDashboardUrl}"
+          target="_blank" rel="noopener noreferrer">
+          Approvals dashboard
+        </a>
+      </li>
+    </sec:authorize>
+
     <sec:authorize ifAnyGranted="ROLE_VIEW_MANAGED_TIMES">
       <li>
         <a href="${hrsUrls['Approve Payable time']}"
@@ -49,15 +58,6 @@
         <a href="${hrsUrls['Approve Absence']}"
           target="_blank" rel="noopener noreferrer">
           Approve absence
-        </a>
-      </li>
-    </sec:authorize>
-
-    <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ABS_DASHBOARD">
-      <li>
-        <a href="${approvalsDashboardUrl}"
-          target="_blank" rel="noopener noreferrer">
-          Approvals dashboard
         </a>
       </li>
     </sec:authorize>


### PR DESCRIPTION
+ Orders the new dashboard link, when included, first rather than last, in "Manager Time and Approval" widget and in app.
+ Labels the new dashboard link "Time & Absence MSS Dashboard"

~~I think it's right that the ampersand has to be escaped as below.~~

I think the ampersand doesn't need to be escaped in the `list-of-links` JSON that the portlet generates (c.f. https://github.com/uPortal-Project/uportal-app-framework/pull/729 ), but it does need to be escaped inline in the JSP page.