### PR TITLE
Add optional approvalsDashboardLabel portlet-pref

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This is intended as a solution for
 
 + When set, Manager Time and Approval uses this URL as the href for a list-of-links link shown to
   to employees with a particular role.
++ When not set, this link is not shown.
 
 ### Specific to Payroll Information
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ This is intended as a solution for
 + When not set, Benefit Information uses the URL from the HRS URLs SOAP web service as the href of the "View Benefits Summary Detail" link.
 + If the URL is available from neither source, Benefit Information drops this link from the UI.
 
-### Specific to Manager Time and Approval
+### Specific to ManagerLinks
+
+(Published as "Manager Time and Approval" in MyUW.)
 
 #### `approvalsDashboardUrl` portlet preference (optional)
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ This is intended as a solution for
 
 (Published as "Manager Time and Approval" in MyUW.)
 
+#### `approvalsDashboardLabel` portlet preference (optional)
+
++ Sets the label for the approvals dashboard hyperlink.
++ When not set, the label defaults to "Time & Absence MSS Dashboard" (as defined in 
+  `ManagerLinksController.DEFAULT_DASHBOARD_LABEL`).
+
 #### `approvalsDashboardUrl` portlet preference (optional)
 
 + When set, Manager Time and Approval uses this URL as the href for a list-of-links link shown to

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -32,6 +32,11 @@ import org.springframework.web.portlet.bind.annotation.ResourceMapping;
 public class ManagerLinksController
   extends HrsControllerBase {
 
+  /**
+   * Default user-facing label for the approvals dashboard link.
+   */
+  public static String DEFAULT_DASHBOARD_LABEL = "Time & Absence MSS Dashboard";
+
   private static Set<String> ROLES_THAT_MANAGE_TIME_OR_ABSENCES;
 
   static {
@@ -71,6 +76,8 @@ public class ManagerLinksController
     final PortletPreferences preferences = request.getPreferences();
     final String approvalsDashboardUrl =
         preferences.getValue("approvalsDashboardUrl", null);
+    final String approvalsDashboardLabel =
+        preferences.getValue("approvalsDashboardLabel", DEFAULT_DASHBOARD_LABEL);
     final String helpUrl = preferences.getValue("helpUrl", null);
 
 
@@ -101,7 +108,7 @@ public class ManagerLinksController
     if (roles.contains("ROLE_VIEW_TIME_ABS_DASHBOARD")) {
       if (StringUtils.isNotBlank(approvalsDashboardUrl)) {
         final Link approvalsDashboard = new Link();
-        approvalsDashboard.setTitle("Time & Absence MSS Dashboard");
+        approvalsDashboard.setTitle(approvalsDashboardLabel);
         approvalsDashboard.setIcon("check_circle");
         approvalsDashboard.setHref(approvalsDashboardUrl);
         approvalsDashboard.setTarget("_blank");
@@ -158,8 +165,11 @@ public class ManagerLinksController
     final PortletPreferences preferences = request.getPreferences();
     final String approvalsDashboardUrl =
         preferences.getValue("approvalsDashboardUrl", null);
+    final String approvalsDashboardLabel =
+        preferences.getValue("approvalsDashboardLabel", DEFAULT_DASHBOARD_LABEL);
 
     modelMap.put("approvalsDashboardUrl", approvalsDashboardUrl);
+    modelMap.put("approvalsDashboardLabel", approvalsDashboardLabel);
 
     return "managerLinks";
   }

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
@@ -39,7 +39,7 @@
       <li>
         <a href="${approvalsDashboardUrl}"
           target="_blank" rel="noopener noreferrer">
-          Time &amp; Absence MSS Dashboard
+          ${approvalsDashboardLabel}
         </a>
       </li>
     </sec:authorize>


### PR DESCRIPTION
Add an optional way to override the default label for the new hyperlink, thereby adding flexibility to adjust the label via future configuration in migration rather than requiring a source code change and binary release to adjust this label.

Figuring we might need flexibility to navigate the evolution of the label in the face of truncation, potential evolving brand and defaultness of the thing it links to, etc.