### PR TITLE
fix: set URL on "Approve time" link

### DIFF
--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -125,6 +125,7 @@ public class ManagerLinksController
         final Link approveTime = new Link();
         approveTime.setTitle("Approve time");
         approveTime.setIcon("access_time");
+        approveTime.setHref(approveTimeUrl);
         approveTime.setTarget("_blank");
         linkList.add(approveTime);
       } else {


### PR DESCRIPTION
Fix bug that had failed to set the URL on the "Approve time" link in the dynamic "Manager Time and Approval" widget, so the link didn't do anything.