### PR TITLE
fix: actually look up the value associated with each HRS URL key

### DIFF
--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/urls/UrlsController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/urls/UrlsController.java
@@ -48,7 +48,7 @@ public class UrlsController
     for (String urlName : hrsUrls.keySet()) {
       final Link link = new Link();
       link.setTitle(urlName);
-      link.setHref(hrsUrls.get("link"));
+      link.setHref(hrsUrls.get(urlName));
       link.setIcon("link");
       linkList.add(link);
     }


### PR DESCRIPTION
Troubleshooting functionality only helps if it actually works.

Had been successfully listing the keys from the HRS URLs service, but not successfully displaying the values.