### PR TITLE
feat: order "Approve absence" before "Approve time" in manager links

### DIFF
--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -119,21 +119,6 @@ public class ManagerLinksController
       }
     }
 
-    if (roles.contains("ROLE_VIEW_MANAGED_TIMES")) {
-      final String approveTimeUrl = getHrsUrls().get(HrsUrlDao.APPROVE_PAYABLE_TIME_KEY);
-      if (StringUtils.isNotBlank(approveTimeUrl)) {
-        final Link approveTime = new Link();
-        approveTime.setTitle("Approve time");
-        approveTime.setIcon("access_time");
-        approveTime.setHref(approveTimeUrl);
-        approveTime.setTarget("_blank");
-        linkList.add(approveTime);
-      } else {
-        logger.error("HRS URL [" + HrsUrlDao.APPROVE_PAYABLE_TIME_KEY + "] expected but not found "
-            + "and so could not be offered to emplid " + emplId);
-      }
-    }
-
     if (roles.contains("ROLE_VIEW_MANAGED_ABSENCES")) {
       final String approveAbsenceUrl = getHrsUrls().get("Approve Absence");
       if (StringUtils.isNotBlank(approveAbsenceUrl)) {
@@ -145,6 +130,21 @@ public class ManagerLinksController
         linkList.add(approveAbsence);
       } else {
         logger.error("HRS URL [Approve Absence] expected but not found "
+            + "and so could not be offered to emplid " + emplId);
+      }
+    }
+
+    if (roles.contains("ROLE_VIEW_MANAGED_TIMES")) {
+      final String approveTimeUrl = getHrsUrls().get(HrsUrlDao.APPROVE_PAYABLE_TIME_KEY);
+      if (StringUtils.isNotBlank(approveTimeUrl)) {
+        final Link approveTime = new Link();
+        approveTime.setTitle("Approve time");
+        approveTime.setIcon("access_time");
+        approveTime.setHref(approveTimeUrl);
+        approveTime.setTarget("_blank");
+        linkList.add(approveTime);
+      } else {
+        logger.error("HRS URL [" + HrsUrlDao.APPROVE_PAYABLE_TIME_KEY + "] expected but not found "
             + "and so could not be offered to emplid " + emplId);
       }
     }

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
@@ -44,20 +44,20 @@
       </li>
     </sec:authorize>
 
-    <sec:authorize ifAnyGranted="ROLE_VIEW_MANAGED_TIMES">
-      <li>
-        <a href="${hrsUrls['Approve Payable time']}"
-          target="_blank" rel="noopener noreferrer">
-          Approve time
-        </a>
-      </li>
-    </sec:authorize>
-
     <sec:authorize ifAnyGranted="ROLE_VIEW_MANAGED_ABSENCES">
       <li>
         <a href="${hrsUrls['Approve Absence']}"
           target="_blank" rel="noopener noreferrer">
           Approve absence
+        </a>
+      </li>
+    </sec:authorize>
+
+    <sec:authorize ifAnyGranted="ROLE_VIEW_MANAGED_TIMES">
+      <li>
+        <a href="${hrsUrls['Approve Payable time']}"
+          target="_blank" rel="noopener noreferrer">
+          Approve time
         </a>
       </li>
     </sec:authorize>


### PR DESCRIPTION
I'm told it's a workflow thing: that managers reliably first approve absences and then approve time, so it makes more sense for the links to be in the order in which managers typically do these activities.

This change parallels a customization made to the new within-HRS-self-service approvals dashboard to order approving absences ahead of approving time.

Since we're changing the Manager Time and Approval widget anyway, this is the moment to do this re-ordering.

cf. [comment on HRS-48945](https://jira.doit.wisc.edu/jira/browse/HRS-48945?focusedCommentId=907125&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-907125) memorializing conversation that followed on suggestion from Aaron Stern. Credit to Aaron for the idea, or at least for effectively conveying it so it could go into the hopper.