### PR TITLE
feat: shorten default dashboard link label

### DIFF
--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -35,7 +35,7 @@ public class ManagerLinksController
   /**
    * Default user-facing label for the approvals dashboard link.
    */
-  public static String DEFAULT_DASHBOARD_LABEL = "Time & Absence MSS Dashboard";
+  public static String DEFAULT_DASHBOARD_LABEL = "Time & Absence Dashboard";
 
   private static Set<String> ROLES_THAT_MANAGE_TIME_OR_ABSENCES;
 


### PR DESCRIPTION
Gets it to 24 characters, which should avoid truncation and allow the full label to display.

Per [feedback from today's meeting](https://jira.doit.wisc.edu/jira/browse/HRS-48945?focusedCommentId=906948&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-906948).