### PR TITLE
Title case and make configurable Manager "Approve Absence" and "Approve Time" link labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ This is intended as a solution for
 
 (Published as "Manager Time and Approval" in MyUW.)
 
+#### `approveAbsenceLabel` portlet preference (optional)
+
++ Sets the label for the approve absence hyperlink.
++ When not set, the label defaults to "Approve Absence" (as defined in 
+  `ManagerLinksController.DEFAULT_APPROVE_ABSENCE_LABEL`).
+
+#### `approveTimeLabel` portlet preference (optional)
+
++ Sets the label for the approve time hyperlink.
++ When not set, the label defaults to "Approve Time" (as defined in 
+  `ManagerLinksController.DEFAULT_APPROVE_TIME_LABEL`).
+
 #### `approvalsDashboardLabel` portlet preference (optional)
 
 + Sets the label for the approvals dashboard hyperlink.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This is intended as a solution for
 #### `approvalsDashboardLabel` portlet preference (optional)
 
 + Sets the label for the approvals dashboard hyperlink.
-+ When not set, the label defaults to "Time & Absence MSS Dashboard" (as defined in 
++ When not set, the label defaults to "Time & Absence Dashboard" (as defined in 
   `ManagerLinksController.DEFAULT_DASHBOARD_LABEL`).
 
 #### `approvalsDashboardUrl` portlet preference (optional)

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -37,6 +37,18 @@ public class ManagerLinksController
    */
   public static String DEFAULT_DASHBOARD_LABEL = "Time & Absence Dashboard";
 
+  /**
+   * A strict reading of the MyUW style guidance wrt list-of-links apps would have this sentence
+   * case, but title case is as requested.
+   */
+  public static String DEFAULT_APPROVE_ABSENCE_LABEL = "Approve Absence";
+
+  /**
+   * A strict reading of the MyUW style guidance wrt list-of-links apps would have this sentence
+   * case, but title case is as requested.
+   */
+  public static String DEFAULT_APPROVE_TIME_LABEL = "Approve Time";
+
   private static Set<String> ROLES_THAT_MANAGE_TIME_OR_ABSENCES;
 
   static {
@@ -78,6 +90,10 @@ public class ManagerLinksController
         preferences.getValue("approvalsDashboardUrl", null);
     final String approvalsDashboardLabel =
         preferences.getValue("approvalsDashboardLabel", DEFAULT_DASHBOARD_LABEL);
+    final String approveAbsenceLabel =
+        preferences.getValue("approveAbsenceLabel", DEFAULT_APPROVE_ABSENCE_LABEL);
+    final String approveTimeLabel =
+        preferences.getValue("approveTimeLabel", DEFAULT_APPROVE_TIME_LABEL);
     final String helpUrl = preferences.getValue("helpUrl", null);
 
 
@@ -123,7 +139,7 @@ public class ManagerLinksController
       final String approveAbsenceUrl = getHrsUrls().get("Approve Absence");
       if (StringUtils.isNotBlank(approveAbsenceUrl)) {
         final Link approveAbsence = new Link();
-        approveAbsence.setTitle("Approve absence");
+        approveAbsence.setTitle(approveAbsenceLabel);
         approveAbsence.setIcon("perm_contact_calendar");
         approveAbsence.setHref(approveAbsenceUrl);
         approveAbsence.setTarget("_blank");
@@ -138,7 +154,7 @@ public class ManagerLinksController
       final String approveTimeUrl = getHrsUrls().get(HrsUrlDao.APPROVE_PAYABLE_TIME_KEY);
       if (StringUtils.isNotBlank(approveTimeUrl)) {
         final Link approveTime = new Link();
-        approveTime.setTitle("Approve time");
+        approveTime.setTitle(approveTimeLabel);
         approveTime.setIcon("access_time");
         approveTime.setHref(approveTimeUrl);
         approveTime.setTarget("_blank");
@@ -168,9 +184,15 @@ public class ManagerLinksController
         preferences.getValue("approvalsDashboardUrl", null);
     final String approvalsDashboardLabel =
         preferences.getValue("approvalsDashboardLabel", DEFAULT_DASHBOARD_LABEL);
+    final String approveAbsenceLabel =
+        preferences.getValue("approveAbsenceLabel", DEFAULT_APPROVE_ABSENCE_LABEL);
+    final String approveTimeLabel =
+        preferences.getValue("approveTimeLabel", DEFAULT_APPROVE_TIME_LABEL);
 
     modelMap.put("approvalsDashboardUrl", approvalsDashboardUrl);
     modelMap.put("approvalsDashboardLabel", approvalsDashboardLabel);
+    modelMap.put("approveAbsenceLabel", approveAbsenceLabel);
+    modelMap.put("approveTimeLabel", approveTimeLabel);
 
     return "managerLinks";
   }

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
@@ -48,7 +48,7 @@
       <li>
         <a href="${hrsUrls['Approve Absence']}"
           target="_blank" rel="noopener noreferrer">
-          Approve absence
+          ${approveAbsenceLabel}
         </a>
       </li>
     </sec:authorize>
@@ -57,7 +57,7 @@
       <li>
         <a href="${hrsUrls['Approve Payable time']}"
           target="_blank" rel="noopener noreferrer">
-          Approve time
+          ${approveTimeLabel}
         </a>
       </li>
     </sec:authorize>


### PR DESCRIPTION
Fulfills a [request to make these title case rather than sentence case](https://jira.doit.wisc.edu/jira/browse/HRS-48945?focusedCommentId=907721&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-907721).

Adds (documented!) configurability to override the now default-to-title-case labels via `portlet-preference`, so these labels are configurable as deployed in the future should these labels need to change.
