### PR TITLE
fix(manager-links): further shorten "Time/Absence Dashboard" label

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This is intended as a solution for
 #### `approvalsDashboardLabel` portlet preference (optional)
 
 + Sets the label for the approvals dashboard hyperlink.
-+ When not set, the label defaults to "Time & Absence Dashboard" (as defined in 
++ When not set, the label defaults to "Time/Absence Dashboard" (as defined in 
   `ManagerLinksController.DEFAULT_DASHBOARD_LABEL`).
 
 #### `approvalsDashboardUrl` portlet preference (optional)

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -35,7 +35,7 @@ public class ManagerLinksController
   /**
    * Default user-facing label for the approvals dashboard link.
    */
-  public static String DEFAULT_DASHBOARD_LABEL = "Time & Absence Dashboard";
+  public static String DEFAULT_DASHBOARD_LABEL = "Time/Absence Dashboard";
 
   /**
    * A strict reading of the MyUW style guidance wrt list-of-links apps would have this sentence


### PR DESCRIPTION
Trying to get it to stop clipping the T as rendered in the widget with 2-4 links.

Before:
![manager-time-and-approval-clips](https://user-images.githubusercontent.com/952283/38835242-9a2b3b3e-4190-11e8-8b7c-64fc2d732658.png)

Maybe two fewer characters will alleviate this.