### PR TITLE
feat: add HRS roles troubleshooter

### DIFF
--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/TroubleshootingController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/TroubleshootingController.java
@@ -1,0 +1,44 @@
+package edu.wisc.portlet.hrs.web.troubleshoot;
+
+import edu.wisc.hr.dao.roles.HrsRolesDao;
+import edu.wisc.portlet.hrs.web.HrsControllerBase;
+import edu.wisc.portlet.hrs.web.listoflinks.Link;
+import java.util.List;
+import java.util.Set;
+import javax.portlet.PortletRequest;
+import org.jasig.springframework.security.portlet.authentication.PrimaryAttributeUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("VIEW")
+public class TroubleshootingController
+  extends HrsControllerBase {
+
+  private HrsRolesDao rolesDao;
+
+  public HrsRolesDao getRolesDao() {
+    return rolesDao;
+  }
+
+  @Autowired
+  public void setRolesDao(HrsRolesDao rolesDao) {
+    this.rolesDao = rolesDao;
+  }
+
+  @RequestMapping
+  public String viewRoles( ModelMap modelMap, @RequestParam(required = false) String queriedEmplId){
+
+    if (null != queriedEmplId) {
+      modelMap.put("queriedEmplId", queriedEmplId);
+      final Set<String> roles = this.rolesDao.getHrsRoles(queriedEmplId);
+      modelMap.put("roles", roles);
+    }
+
+    return "troubleshooting";
+  }
+
+}

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/context/portlet/troubleshooting.xml
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/context/portlet/troubleshooting.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:aop="http://www.springframework.org/schema/aop"
+  xmlns:context="http://www.springframework.org/schema/context"
+  xmlns:util="http://www.springframework.org/schema/util"
+  xmlns:security="http://www.springframework.org/schema/security"
+  xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.1.xsd
+        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+  <context:annotation-config />
+  <aop:config proxy-target-class="true" />
+  <security:global-method-security secured-annotations="enabled" pre-post-annotations="enabled" proxy-target-class="true"/>
+  <context:component-scan base-package="edu.wisc.portlet.hrs.web.troubleshoot"/>
+  <bean class="org.springframework.web.portlet.mvc.annotation.DefaultAnnotationHandlerMapping">
+    <property name="interceptors" ref="defaultPortletInterceptors" />
+  </bean>
+</beans>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/troubleshooting.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/troubleshooting.jsp
@@ -1,0 +1,51 @@
+<%--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+<%@ page trimDirectiveWhitespaces="true" %>
+<%@ include file="/WEB-INF/jsp/include.jsp"%>
+<%@ include file="/WEB-INF/jsp/header.jsp"%>
+
+<div id="${n}dl-time-absence" class="fl-widget portlet dl-time-absence hrs">
+
+  <portlet:renderURL var="personLookupUrl"></portlet:renderURL>
+  <form class="user-email-search" action="${personLookupUrl}" method="post">
+    <fieldset>
+      <div>
+        <label for="queriedEmplId">HR EmplID: </label><input type="text" name="queriedEmplId" />
+      </div>
+      <input type="submit" value="Lookup roles for employee by emplId" />
+    </fieldset>
+  </form>
+
+<c:if test="${not empty queriedEmplId}">
+<p>empId ${queriedEmplId} has these roles:</p>
+<ul>
+<c:forEach var="role" items="${roles}">
+  <li>${role}</li>
+</c:forEach>
+<c:if test="${empty roles}">
+  <li>(none)</li>
+</c:if>
+</ul>
+</c:if>
+
+  <%@ include file="/WEB-INF/jsp/footer.jsp"%>
+
+</div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -291,6 +291,34 @@
     </portlet>
 
     <portlet>
+        <portlet-name>Troubleshooting</portlet-name>
+        <portlet-class>org.jasig.springframework.web.portlet.context.ContribDispatcherPortlet</portlet-class>
+        <init-param>
+            <name>contextConfigLocation</name>
+            <value>/WEB-INF/context/portlet/troubleshooting.xml</value>
+        </init-param>
+        <expiration-cache>0</expiration-cache>
+        <supports>
+            <mime-type>text/html</mime-type>
+            <portlet-mode>view</portlet-mode>
+        </supports>
+        <portlet-info>
+            <title>HRS Integration Troubleshooting Tool</title>
+            <short-title>HRS Troubleshooter</short-title>
+        </portlet-info>
+        <portlet-preferences>
+            <preference>
+                <name>emplidUserAttributes</name>
+                <value>eduWisconsinHRSEmplID</value>
+                <value>eduWisconsinHRPersonID</value>
+                <value>wiscEduHRSEmplid</value>
+                <value>wisceduhrpersonid</value>
+                <value>legacywisceduhrpersonid</value>
+            </preference>
+        </portlet-preferences>
+    </portlet>
+
+    <portlet>
         <portlet-name>Urls</portlet-name>
         <portlet-class>org.jasig.springframework.web.portlet.context.ContribDispatcherPortlet</portlet-class>
         <init-param>


### PR DESCRIPTION
Add administrative portlet for viewing HRS roles, as understood by HRS Portlets, of arbitrary emplIds.

Adds a new Portlet (so can be separately permissed) that

1. Renders a form for querying about an `emplId`
2. Handles submissions of the form by showing the roles for the requested `emplId`.

Scratches the immediate itch for a tool for querying employees' roles as understood by HRS Portlets and sets the stage for a richer troubleshooting tool (that might show more information about the queried emplid).