### PR TITLE
HRSPLT-335 add detail to roles troubleshooter

### DIFF
--- a/hrs-portlets-api/pom.xml
+++ b/hrs-portlets-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>edu.wisc.my.portlet.hrs</groupId>
         <artifactId>hrs-portlets-parent</artifactId>
-        <version>1.12.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/roles/HrsRolesDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/roles/HrsRolesDao.java
@@ -28,22 +28,22 @@ import javax.annotation.Resource;
  */
 public interface HrsRolesDao {
 
-    public Set<String> getHrsRoles(String emplId);
+  public Set<String> getHrsRoles(String emplId);
 
-    /**
-     * Get the raw roles as delivered by HRS, before any within-app mapping.
-     * @param emplId
-     * @return potentially empty non-null Set of Strings representing HRS roles
-     * @since 2.0
-     */
-    public Set<String> rawHrsRolesForEmplid(String emplId);
+  /**
+   * Get the raw roles as delivered by HRS, before any within-app mapping.
+   * @param emplId
+   * @return potentially empty non-null Set of Strings representing HRS roles
+   * @since 2.0
+   */
+  public Set<String> rawHrsRolesForEmplid(String emplId);
 
 
-    /**
-     * Get the general (not-empl-specific) mapping from raw HRS role to porlet role(s).
-     * @return non-null Map of non-null Strings representing raw HRS roles to non-null non-empty
-     * Sets of Strings representing portlet roles.
-     * @since 2.0
-     */
-    public Map<String, Set<String>> getHrsRoleMappings();
+  /**
+   * Get the general (not-empl-specific) mapping from raw HRS role to porlet role(s).
+   * @return non-null Map of non-null Strings representing raw HRS roles to non-null non-empty
+   * Sets of Strings representing portlet roles.
+   * @since 2.0
+   */
+  public Map<String, Set<String>> getHrsRoleMappings();
 }

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/roles/HrsRolesDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/roles/HrsRolesDao.java
@@ -21,7 +21,6 @@ package edu.wisc.hr.dao.roles;
 
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Resource;
 
 /**
  * Gets the employee's roles as understood by this application.

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/roles/HrsRolesDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/roles/HrsRolesDao.java
@@ -19,7 +19,9 @@
 
 package edu.wisc.hr.dao.roles;
 
+import java.util.Map;
 import java.util.Set;
+import javax.annotation.Resource;
 
 /**
  * Gets the employee's roles as understood by this application.
@@ -27,4 +29,21 @@ import java.util.Set;
 public interface HrsRolesDao {
 
     public Set<String> getHrsRoles(String emplId);
+
+    /**
+     * Get the raw roles as delivered by HRS, before any within-app mapping.
+     * @param emplId
+     * @return potentially empty non-null Set of Strings representing HRS roles
+     * @since 2.0
+     */
+    public Set<String> rawHrsRolesForEmplid(String emplId);
+
+
+    /**
+     * Get the general (not-empl-specific) mapping from raw HRS role to porlet role(s).
+     * @return non-null Map of non-null Strings representing raw HRS roles to non-null non-empty
+     * Sets of Strings representing portlet roles.
+     * @since 2.0
+     */
+    public Map<String, Set<String>> getHrsRoleMappings();
 }

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/roles/HrsRolesDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/roles/HrsRolesDao.java
@@ -22,10 +22,7 @@ package edu.wisc.hr.dao.roles;
 import java.util.Set;
 
 /**
- * Gets a set of deep-links into the HRS system
- * 
- * @author Eric Dalquist
- * @version $Revision: 1.1 $
+ * Gets the employee's roles as understood by this application.
  */
 public interface HrsRolesDao {
 

--- a/hrs-portlets-bnsemail-impl/pom.xml
+++ b/hrs-portlets-bnsemail-impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>edu.wisc.my.portlet.hrs</groupId>
         <artifactId>hrs-portlets-parent</artifactId>
-        <version>1.12.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/hrs-portlets-cypress-impl/pom.xml
+++ b/hrs-portlets-cypress-impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>edu.wisc.my.portlet.hrs</groupId>
         <artifactId>hrs-portlets-parent</artifactId>
-        <version>1.12.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/hrs-portlets-ps-impl/pom.xml
+++ b/hrs-portlets-ps-impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>edu.wisc.my.portlet.hrs</groupId>
         <artifactId>hrs-portlets-parent</artifactId>
-        <version>1.12.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/roles/SoapHrsRolesDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/roles/SoapHrsRolesDao.java
@@ -18,23 +18,8 @@
  */
 package edu.wisc.hrs.dao.roles;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.annotation.Resource;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.stereotype.Repository;
-import org.springframework.ws.client.core.WebServiceOperations;
-
 import com.googlecode.ehcache.annotations.Cacheable;
 import com.googlecode.ehcache.annotations.DecoratedCacheType;
-
 import edu.wisc.hr.dao.roles.HrsRolesDao;
 import edu.wisc.hrs.dao.BaseHrsSoapDao;
 import edu.wisc.hrs.dao.HrsUtils;
@@ -42,6 +27,17 @@ import edu.wisc.hrs.xdm.roles.req.EmplidTypeShape;
 import edu.wisc.hrs.xdm.roles.req.GetCompIntfcUWPORTAL1ROLES;
 import edu.wisc.hrs.xdm.roles.res.GetCompIntfcUWPORTAL1ROLESResponse;
 import edu.wisc.hrs.xdm.roles.res.UwHrRolUsrVwTypeShape;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Resource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+import org.springframework.ws.client.core.WebServiceOperations;
 
 /**
  * Spring {@link WebServiceOperations} backed implementation of {@link BaseHrsSoapDao}.

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/roles/SoapHrsRolesDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/roles/SoapHrsRolesDao.java
@@ -19,6 +19,7 @@
 package edu.wisc.hrs.dao.roles;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -61,7 +62,12 @@ public class SoapHrsRolesDao extends BaseHrsSoapDao implements HrsRolesDao {
     public void setHrsRoleMappings(Map<String, Set<String>> hrsRolesMappings) {
         this.hrsRolesMappings = hrsRolesMappings;
     }
-    
+
+    @Override
+    public Map<String, Set<String>> getHrsRoleMappings() {
+        return this.hrsRolesMappings;
+    }
+
     @Override
     protected WebServiceOperations getWebServiceOperations() {
         return this.webServiceOperations;
@@ -74,6 +80,30 @@ public class SoapHrsRolesDao extends BaseHrsSoapDao implements HrsRolesDao {
         final GetCompIntfcUWPORTAL1ROLESResponse response = this.internalInvoke(request);
 
         return this.convertRoles(response);
+    }
+
+    @Override
+    public Set<String> rawHrsRolesForEmplid(String emplId) {
+
+        final GetCompIntfcUWPORTAL1ROLES request = this.createRequest(emplId);
+
+        final GetCompIntfcUWPORTAL1ROLESResponse response = this.internalInvoke(request);
+
+        if (response == null) {
+            logger.warn("Converted null roles web service SOAP response to empty role set.");
+            return Collections.emptySet();
+        }
+
+        final List<UwHrRolUsrVwTypeShape> uwHrRolUsrVws = response.getUwHrRolUsrVws();
+
+        final Set<String> roles = new HashSet<String>(uwHrRolUsrVws.size());
+
+        for (final UwHrRolUsrVwTypeShape uwHrRolUsrVwTypeShape : uwHrRolUsrVws) {
+            final String hrsRoleName = (String)HrsUtils.getValue(uwHrRolUsrVwTypeShape.getRoleName());
+            roles.add(hrsRoleName);
+        }
+
+        return roles;
     }
 
     protected GetCompIntfcUWPORTAL1ROLES createRequest(String emplId) {

--- a/hrs-portlets-webapp/pom.xml
+++ b/hrs-portlets-webapp/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>edu.wisc.my.portlet.hrs</groupId>
         <artifactId>hrs-portlets-parent</artifactId>
-        <version>1.12.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/HrsRoleMappingRule.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/HrsRoleMappingRule.java
@@ -1,7 +1,5 @@
 package edu.wisc.portlet.hrs.web.troubleshoot;
 
-import java.util.Set;
-
 /**
  * JavaBean for representing HRS role mapping rules for convenient use in a JSP articulating the
  * rules. Model object especially suited for presentation in view.

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/HrsRoleMappingRule.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/HrsRoleMappingRule.java
@@ -1,5 +1,13 @@
 package edu.wisc.portlet.hrs.web.troubleshoot;
 
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
 /**
  * JavaBean for representing HRS role mapping rules for convenient use in a JSP articulating the
  * rules. Model object especially suited for presentation in view.
@@ -8,49 +16,79 @@ public class HrsRoleMappingRule {
 
   private String hrsRole;
 
-  private String portletRolePhrase;
+  private Set<String> portletRoles;
+
+  public HrsRoleMappingRule(String hrs_role, String one_portlet_role) {
+
+    this.hrsRole = hrs_role;
+
+    if (null != one_portlet_role) {
+      this.portletRoles = new HashSet<String>(1);
+      this.portletRoles.add(one_portlet_role);
+    }
+
+  }
+
+  public HrsRoleMappingRule(String hrs_role, Set<String> portletRoles) {
+
+    this.hrsRole = hrs_role;
+
+    this.portletRoles = portletRoles;
+
+  }
 
   /**
-   * Get the String identifier of the HRS role this rule is about.
-   * This rule is a mapping from this HRS role to Portlet roles.
-   * @return String representing HRS role
+   * Get the String identifier of the HRS role this rule is about. This rule is a mapping from this
+   * HRS role to Portlet roles. Returns (none) if HRS role not set.
+   *
+   * @return non-null String representing HRS role
    */
   public String getHrsRole() {
-    return hrsRole;
-  }
 
-  public void setHrsRole(String hrsRole) {
-    this.hrsRole = hrsRole;
+    if (null == this.hrsRole) {
+      return "(none)";
+    } else {
+      return this.hrsRole;
+    }
   }
 
   /**
-   * Get the String representing one or more Portlet roles, as a phrase suitable for inclusion
-   * in an English language sentence.
-   * Example: one role: "SOME_PORTLET_ROLE"
-   * Example: several roles: "SOME_PORTLET_ROLE, SOME_OTHER_ROLE, YET_ANOTHER_ROLE"
-   * @return
+   * Get the String representing one or more Portlet roles, as a phrase suitable for inclusion in an
+   * English language sentence. Example: one role: "SOME_PORTLET_ROLE" Example: several roles:
+   * "SOME_PORTLET_ROLE, SOME_OTHER_ROLE, YET_ANOTHER_ROLE"
    */
   public String getPortletRolePhrase() {
-    return portletRolePhrase;
-  }
 
-  public void setPortletRolePhrase(String portletRolePhrase) {
-    this.portletRolePhrase = portletRolePhrase;
+    if (null == this.portletRoles || this.portletRoles.isEmpty()) {
+      return "(none)";
+    }
+
+    List<String> portletRolesList = new ArrayList(this.portletRoles);
+
+    Collections.sort(portletRolesList);
+
+    Iterator<String> alphabeticalPortletRoles = portletRolesList.iterator();
+
+    String portletRolePhrase = alphabeticalPortletRoles.next();
+
+    while(alphabeticalPortletRoles.hasNext()) {
+
+      portletRolePhrase = portletRolePhrase + ", " + alphabeticalPortletRoles.next();
+    }
+
+    return portletRolePhrase;
   }
 
   /**
    * True if the portletRolePhrase represents multiple roles, false otherwise.
-   * @return
    */
-  public boolean isPluralPortletRoles() {
-    return pluralPortletRoles;
+  public boolean isMultiplePortletRoles() {
+
+    // if portlet roles not set, or if it contains less than two items
+    // it's not multiple.
+    return !((null == this.portletRoles) || this.portletRoles.size() < 2);
   }
 
-  public void setPluralPortletRoles(boolean pluralPortletRoles) {
-    this.pluralPortletRoles = pluralPortletRoles;
-  }
-
-  private boolean pluralPortletRoles;
 
 
 }

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/HrsRoleMappingRule.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/HrsRoleMappingRule.java
@@ -53,5 +53,4 @@ public class HrsRoleMappingRule {
   private boolean pluralPortletRoles;
 
 
-
 }

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/HrsRoleMappingRule.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/HrsRoleMappingRule.java
@@ -63,6 +63,10 @@ public class HrsRoleMappingRule {
       return "(none)";
     }
 
+    if (1 == this.portletRoles.size()) {
+      return this.portletRoles.iterator().next();
+    }
+
     List<String> portletRolesList = new ArrayList(this.portletRoles);
 
     Collections.sort(portletRolesList);
@@ -71,10 +75,23 @@ public class HrsRoleMappingRule {
 
     String portletRolePhrase = alphabeticalPortletRoles.next();
 
-    while(alphabeticalPortletRoles.hasNext()) {
+    if (2 == this.portletRoles.size()) {
+
+      return portletRolePhrase + " and " + alphabeticalPortletRoles.next();
+
+    }
+
+    // there are three or more portlet roles.
+    // one of these is already read into portletRolePhrase from the iterator
+    // read all but one in with comma separation
+
+    for (int i = 2; i < portletRolesList.size(); i++) {
 
       portletRolePhrase = portletRolePhrase + ", " + alphabeticalPortletRoles.next();
     }
+
+    // read in the last role, separating with an Oxford comma and an and.
+    portletRolePhrase = portletRolePhrase + ", and " + alphabeticalPortletRoles.next();
 
     return portletRolePhrase;
   }

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/HrsRoleMappingRule.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/HrsRoleMappingRule.java
@@ -1,0 +1,59 @@
+package edu.wisc.portlet.hrs.web.troubleshoot;
+
+import java.util.Set;
+
+/**
+ * JavaBean for representing HRS role mapping rules for convenient use in a JSP articulating the
+ * rules. Model object especially suited for presentation in view.
+ */
+public class HrsRoleMappingRule {
+
+  private String hrsRole;
+
+  private String portletRolePhrase;
+
+  /**
+   * Get the String identifier of the HRS role this rule is about.
+   * This rule is a mapping from this HRS role to Portlet roles.
+   * @return String representing HRS role
+   */
+  public String getHrsRole() {
+    return hrsRole;
+  }
+
+  public void setHrsRole(String hrsRole) {
+    this.hrsRole = hrsRole;
+  }
+
+  /**
+   * Get the String representing one or more Portlet roles, as a phrase suitable for inclusion
+   * in an English language sentence.
+   * Example: one role: "SOME_PORTLET_ROLE"
+   * Example: several roles: "SOME_PORTLET_ROLE, SOME_OTHER_ROLE, YET_ANOTHER_ROLE"
+   * @return
+   */
+  public String getPortletRolePhrase() {
+    return portletRolePhrase;
+  }
+
+  public void setPortletRolePhrase(String portletRolePhrase) {
+    this.portletRolePhrase = portletRolePhrase;
+  }
+
+  /**
+   * True if the portletRolePhrase represents multiple roles, false otherwise.
+   * @return
+   */
+  public boolean isPluralPortletRoles() {
+    return pluralPortletRoles;
+  }
+
+  public void setPluralPortletRoles(boolean pluralPortletRoles) {
+    this.pluralPortletRoles = pluralPortletRoles;
+  }
+
+  private boolean pluralPortletRoles;
+
+
+
+}

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/TroubleshootingController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/TroubleshootingController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Controller
 @RequestMapping("VIEW")
 public class TroubleshootingController
-  extends HrsControllerBase {
+    extends HrsControllerBase {
 
   private HrsRolesDao rolesDao;
 

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/TroubleshootingController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/TroubleshootingController.java
@@ -30,7 +30,7 @@ public class TroubleshootingController
   }
 
   @RequestMapping
-  public String viewRoles( ModelMap modelMap, @RequestParam(required = false) String queriedEmplId){
+  public String viewRoles(ModelMap modelMap, @RequestParam(required = false) String queriedEmplId) {
 
     if (null != queriedEmplId) {
       modelMap.put("queriedEmplId", queriedEmplId);

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/TroubleshootingController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/TroubleshootingController.java
@@ -48,37 +48,13 @@ public class TroubleshootingController
 
       Set<String> portletRoles = hrsRoleMappings.get(hrsRole);
 
-      HrsRoleMappingRule rule = new HrsRoleMappingRule();
-      rule.setHrsRole(hrsRole);
+      HrsRoleMappingRule rule = new HrsRoleMappingRule(hrsRole, portletRoles);
 
-      if (portletRoles.size() == 0) {
-
-        logger.warn("HRS role {} mapped to no portlet roles. Bad mapping rule config?", hrsRole);
-        rule.setPluralPortletRoles(false);
-        rule.setPortletRolePhrase("(none)");
-
-      } else if (portletRoles.size() == 1) {
-
-        rule.setPluralPortletRoles(false);
-
-        String portletRole = portletRoles.iterator().next();
-        rule.setPortletRolePhrase(portletRole);
-
-      } else {
-
-        rule.setPluralPortletRoles(true);
-        String portletRolePhrase = "";
-
-        for (String portletRole : portletRoles) {
-          portletRolePhrase = portletRolePhrase + ", " + portletRole;
-        }
-
-        rule.setPortletRolePhrase(portletRolePhrase);
-      }
-
-      modelMap.put("rules", rules);
+      rules.add(rule);
 
     }
+
+    modelMap.put("rules", rules);
 
     return "troubleshooting";
   }

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/TroubleshootingController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/TroubleshootingController.java
@@ -34,6 +34,7 @@ public class TroubleshootingController
 
     if (null != queriedEmplId) {
       modelMap.put("queriedEmplId", queriedEmplId);
+
       final Set<String> roles = this.rolesDao.getHrsRoles(queriedEmplId);
       modelMap.put("roles", roles);
     }

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/troubleshooting.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/troubleshooting.jsp
@@ -67,7 +67,7 @@
      according to these rules:</p>
 
   <ul>
-    <c:forEach var="mappingRule" items="{$rules}">
+    <c:forEach var="mappingRule" items="${rules}">
       <c:choose>
         <c:when test="${mappingRule.pluralPortletRoles}">
           <li>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/troubleshooting.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/troubleshooting.jsp
@@ -35,7 +35,7 @@
   </form>
 
 <c:if test="${not empty queriedEmplId}">
-<p>empId ${queriedEmplId} has these roles:</p>
+<p>emlpId ${queriedEmplId} has these HRS Portlets (MyUW app) roles:</p>
 <ul>
 <c:forEach var="role" items="${roles}">
   <li>${role}</li>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/troubleshooting.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/troubleshooting.jsp
@@ -44,7 +44,41 @@
   <li>(none)</li>
 </c:if>
 </ul>
+
+<p>HRS Portlets are aware of these raw HRS roles for emplId ${queriedEmplId}:</p>
+
+<ul>
+<c:forEach var="rawRole" items="${rawRoles}">
+  <li>${rawRole}</li>
+</c:forEach>
+<c:if test="${empty rawRoles}">
+  <li>(none)</li>
 </c:if>
+</ul>
+
+
+</c:if>
+
+<p>In general, the HRS Portlets (MyUW app) map from raw HRS roles to MyUW HRS portlet app roles
+according to these rules:</p>
+
+<ul>
+<c:forEach var="mappingRule" items="{$rules}">
+  <c:choose>
+  <c:when test="${mappingRule.pluralPortletRoles}">
+  <li>HRS role ${mappingRule.hrsRole} grants Portlet roles ${mappingRule.portletRolePhrase}.</li>
+  </c:when>
+  <c:otherwise>
+    <li>HRS role ${mappingRule.hrsRole} grants Portlet role ${mappingRule.portletRolePhrase}.</li>
+  </c:otherwise>
+</c:forEach>
+</ul>
+
+<p>See also
+  <a href="https://github.com/UW-Madison-DoIT/hrs-portlets/blob/uw-master/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml">
+    Documentation about the effects of HRS Portlet roles.
+  </a>
+</p>
 
   <%@ include file="/WEB-INF/jsp/footer.jsp"%>
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/troubleshooting.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/troubleshooting.jsp
@@ -34,51 +34,60 @@
     </fieldset>
   </form>
 
-<c:if test="${not empty queriedEmplId}">
-<p>emlpId ${queriedEmplId} has these HRS Portlets (MyUW app) roles:</p>
-<ul>
-<c:forEach var="role" items="${roles}">
-  <li>${role}</li>
-</c:forEach>
-<c:if test="${empty roles}">
-  <li>(none)</li>
-</c:if>
-</ul>
+  <c:if test="${not empty queriedEmplId}">
+    <p>emlpId ${queriedEmplId} has these HRS Portlets (MyUW app) roles:</p>
+      <ul>
 
-<p>HRS Portlets are aware of these raw HRS roles for emplId ${queriedEmplId}:</p>
+        <c:forEach var="role" items="${roles}">
+          <li>${role}</li>
+        </c:forEach>
 
-<ul>
-<c:forEach var="rawRole" items="${rawRoles}">
-  <li>${rawRole}</li>
-</c:forEach>
-<c:if test="${empty rawRoles}">
-  <li>(none)</li>
-</c:if>
-</ul>
+        <c:if test="${empty roles}">
+          <li>(none)</li>
+        </c:if>
+      </ul>
 
+    <p>HRS Portlets are aware of these raw HRS roles for emplId ${queriedEmplId}:</p>
 
-</c:if>
+    <ul>
 
-<p>In general, the HRS Portlets (MyUW app) map from raw HRS roles to MyUW HRS portlet app roles
-according to these rules:</p>
+      <c:forEach var="rawRole" items="${rawRoles}">
+        <li>${rawRole}</li>
+      </c:forEach>
 
-<ul>
-<c:forEach var="mappingRule" items="{$rules}">
-  <c:choose>
-  <c:when test="${mappingRule.pluralPortletRoles}">
-  <li>HRS role ${mappingRule.hrsRole} grants Portlet roles ${mappingRule.portletRolePhrase}.</li>
-  </c:when>
-  <c:otherwise>
-    <li>HRS role ${mappingRule.hrsRole} grants Portlet role ${mappingRule.portletRolePhrase}.</li>
-  </c:otherwise>
-</c:forEach>
-</ul>
+      <c:if test="${empty rawRoles}">
+        <li>(none)</li>
+      </c:if>
 
-<p>See also
-  <a href="https://github.com/UW-Madison-DoIT/hrs-portlets/blob/uw-master/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml">
-    Documentation about the effects of HRS Portlet roles.
-  </a>
-</p>
+    </ul>
+
+  </c:if>
+
+  <p>In general, the HRS Portlets (MyUW app) map from raw HRS roles to MyUW HRS portlet app roles
+     according to these rules:</p>
+
+  <ul>
+    <c:forEach var="mappingRule" items="{$rules}">
+      <c:choose>
+        <c:when test="${mappingRule.pluralPortletRoles}">
+          <li>
+            HRS role ${mappingRule.hrsRole} grants Portlet roles ${mappingRule.portletRolePhrase}.
+          </li>
+        </c:when>
+        <c:otherwise>
+          <li>
+            HRS role ${mappingRule.hrsRole} grants Portlet role ${mappingRule.portletRolePhrase}.
+          </li>
+        </c:otherwise>
+      </c:choose>
+    </c:forEach>
+  </ul>
+
+  <p>See also
+    <a href="https://github.com/UW-Madison-DoIT/hrs-portlets/blob/uw-master/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml">
+      Documentation about the effects of HRS Portlet roles.
+    </a>
+  </p>
 
   <%@ include file="/WEB-INF/jsp/footer.jsp"%>
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/troubleshooting.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/troubleshooting.jsp
@@ -69,7 +69,7 @@
   <ul>
     <c:forEach var="mappingRule" items="${rules}">
       <c:choose>
-        <c:when test="${mappingRule.pluralPortletRoles}">
+        <c:when test="${mappingRule.multiplePortletRoles}">
           <li>
             HRS role ${mappingRule.hrsRole} grants Portlet roles ${mappingRule.portletRolePhrase}.
           </li>

--- a/hrs-portlets-webapp/src/test/java/edu/wisc/portlet/hrs/web/troubleshoot/HrsRoleMappingRuleTest.java
+++ b/hrs-portlets-webapp/src/test/java/edu/wisc/portlet/hrs/web/troubleshoot/HrsRoleMappingRuleTest.java
@@ -21,7 +21,7 @@ public class HrsRoleMappingRuleTest {
   }
 
   @Test
-  public void testMapsHrsRoleToMultiplePortletRoles() {
+  public void testMapsHrsRoleToTwoPortletRoles() {
 
     Set<String> portletRoles = new HashSet<String>();
     portletRoles.add("SOME_PORTLET_ROLE");
@@ -33,10 +33,32 @@ public class HrsRoleMappingRuleTest {
     assertEquals("HRS_ROLE", rule.getHrsRole());
 
     // alphabetical order
-    assertEquals("SOME_OTHER_PORTLET_ROLE, SOME_PORTLET_ROLE", rule.getPortletRolePhrase());
+    assertEquals("SOME_OTHER_PORTLET_ROLE and SOME_PORTLET_ROLE", rule.getPortletRolePhrase());
 
 
   }
+
+  @Test
+  public void testMapsHrsRoleToThreePortletRoles() {
+
+    Set<String> portletRoles = new HashSet<String>();
+    portletRoles.add("SOME_PORTLET_ROLE");
+    portletRoles.add("SOME_OTHER_PORTLET_ROLE");
+    portletRoles.add("YET_ANOTHER_PORTLET_ROLE");
+    HrsRoleMappingRule rule = new HrsRoleMappingRule("HRS_ROLE", portletRoles);
+
+    assertTrue(rule.isMultiplePortletRoles());
+
+    assertEquals("HRS_ROLE", rule.getHrsRole());
+
+    // alphabetical order
+    assertEquals(
+        "SOME_OTHER_PORTLET_ROLE, SOME_PORTLET_ROLE, and YET_ANOTHER_PORTLET_ROLE",
+        rule.getPortletRolePhrase());
+
+
+  }
+
 
 
   @Test

--- a/hrs-portlets-webapp/src/test/java/edu/wisc/portlet/hrs/web/troubleshoot/HrsRoleMappingRuleTest.java
+++ b/hrs-portlets-webapp/src/test/java/edu/wisc/portlet/hrs/web/troubleshoot/HrsRoleMappingRuleTest.java
@@ -1,0 +1,88 @@
+package edu.wisc.portlet.hrs.web.troubleshoot;
+
+import static org.junit.Assert.*;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+
+public class HrsRoleMappingRuleTest {
+
+  @Test
+  public void testMapsHrsRoleToSinglePortletRole() {
+
+    HrsRoleMappingRule rule =
+        new HrsRoleMappingRule("HRS_ROLE", "ONE_PORTLET_ROLE");
+
+    assertFalse(rule.isMultiplePortletRoles());
+    assertEquals("HRS_ROLE", rule.getHrsRole());
+    assertEquals("ONE_PORTLET_ROLE", rule.getPortletRolePhrase());
+
+  }
+
+  @Test
+  public void testMapsHrsRoleToMultiplePortletRoles() {
+
+    Set<String> portletRoles = new HashSet<String>();
+    portletRoles.add("SOME_PORTLET_ROLE");
+    portletRoles.add("SOME_OTHER_PORTLET_ROLE");
+    HrsRoleMappingRule rule = new HrsRoleMappingRule("HRS_ROLE", portletRoles);
+
+    assertTrue(rule.isMultiplePortletRoles());
+
+    assertEquals("HRS_ROLE", rule.getHrsRole());
+
+    // alphabetical order
+    assertEquals("SOME_OTHER_PORTLET_ROLE, SOME_PORTLET_ROLE", rule.getPortletRolePhrase());
+
+
+  }
+
+
+  @Test
+  public void testGracefullyHandlesNullHrsRole() {
+
+    HrsRoleMappingRule rule =
+        new HrsRoleMappingRule(null, "SOME_PORTLET_ROLE");
+
+    assertFalse(rule.isMultiplePortletRoles());
+    assertEquals("SOME_PORTLET_ROLE", rule.getPortletRolePhrase());
+    assertEquals("(none)", rule.getHrsRole());
+
+  }
+
+  @Test
+  public void testGracefullyHandlesNullPortletRoleString() {
+
+    String nullString = null;
+    HrsRoleMappingRule rule = new HrsRoleMappingRule("SOME_HRS_ROLE", nullString);
+
+    assertFalse(rule.isMultiplePortletRoles());
+    assertEquals("SOME_HRS_ROLE", rule.getHrsRole());
+    assertEquals("(none)", rule.getPortletRolePhrase());
+
+  }
+
+  @Test
+  public void testGracefullyHandlesNullPortletRoleSet() {
+
+    Set<String> nullSet = null;
+    HrsRoleMappingRule rule = new HrsRoleMappingRule("SOME_HRS_ROLE", nullSet);
+
+    assertFalse(rule.isMultiplePortletRoles());
+    assertEquals("SOME_HRS_ROLE", rule.getHrsRole());
+    assertEquals("(none)", rule.getPortletRolePhrase());
+
+  }
+
+  @Test
+  public void testGracefullyHandlesEmptyPortletRoleSet() {
+    Set<String> nullSet = new HashSet<String>();
+    HrsRoleMappingRule rule = new HrsRoleMappingRule("SOME_HRS_ROLE", nullSet);
+
+    assertFalse(rule.isMultiplePortletRoles());
+    assertEquals("SOME_HRS_ROLE", rule.getHrsRole());
+    assertEquals("(none)", rule.getPortletRolePhrase());
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.wisc.my.portlet.hrs</groupId>
     <artifactId>hrs-portlets-parent</artifactId>
-    <version>1.12.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <repositories>


### PR DESCRIPTION
Enhance recently added roles troubleshooter to also

+ Display the raw HRS roles (not just the translated roles as understood by the Portlet)
+ Display the rules whereby in general the HRS portlet translates from HRS roles to Portlet roles.
+ Hyperlink additional documentation about the roles and their effects.

Even before you query about any specific `emplid`:

![awesome-even-before-query](https://user-images.githubusercontent.com/952283/40130180-e5764ef8-58fb-11e8-93d3-0e1ee90dae8c.png)

After querying about a specific `emplid`:

![annotated-troubleshooter](https://user-images.githubusercontent.com/952283/40129911-2880c27e-58fb-11e8-9885-0c9a84cb753b.png)
