### PR TITLE
feat: emphasize HRS role names when used in sentence.

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/troubleshooting.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/troubleshooting.jsp
@@ -71,12 +71,14 @@
       <c:choose>
         <c:when test="${mappingRule.multiplePortletRoles}">
           <li>
-            HRS role ${mappingRule.hrsRole} grants Portlet roles ${mappingRule.portletRolePhrase}.
+            HRS role <em>${mappingRule.hrsRole}</em> grants
+            Portlet roles ${mappingRule.portletRolePhrase}.
           </li>
         </c:when>
         <c:otherwise>
           <li>
-            HRS role ${mappingRule.hrsRole} grants Portlet role ${mappingRule.portletRolePhrase}.
+            HRS role <em>${mappingRule.hrsRole}</em> grants
+            Portlet role ${mappingRule.portletRolePhrase}.
           </li>
         </c:otherwise>
       </c:choose>


### PR DESCRIPTION
Some HRS role names have internal whitespace. This stlying helps to convey what's part of the role name and what's the rest of the sentence.

![mockup-emphasize-roles](https://user-images.githubusercontent.com/952283/40188515-bb341048-59bf-11e8-9d16-7efa1558c47f.png)
