### PR TITLE
feat: add leaveReportingNotice feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 
 ? Date TBD
 
-New feature
+New features
 
++ Add `leaveReportingNotice` feature in Time and Absence ( #118 )
 + Style HRS roles as <em>emphasized</em> as used as sentences in Troubleshooter ( #116 )
 
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ technically the underlying portlet name is `ContactInfo`.
 + When set, adds a "Edit/Cancel Absence" link to this URL that shows to employees who see the nearby "Enter Absence" link.
 + When not set, the "Edit/Cancel Absence" link does not appear.
 
+#### `leaveReportingNotice` portlet preference (optional)
+
++ When set, adds an in-app-message near the top of Time and Absence showing to employees who see the 
+  Outstanding Missing Leave Reports link.
++ When not set, does not show. For employees who do not see the Outstanding Missing Leave Reports 
+  link, does not show.
++ Intended for messaging to employees subject to annual leave reporting requirements
+
 #### `timesheetNotice` portlet preference (optional)
 
 + When set, adds text to the UI near the timesheet launch button.

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeAbsenceController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeAbsenceController.java
@@ -55,6 +55,13 @@ public class TimeAbsenceController extends HrsControllerBase {
         return preferences.getValue("timesheetNotice", null);
     }
 
+    @ModelAttribute("leaveReportingNotice")
+    public final String leaveReportingNotice(PortletRequest request) {
+        final PortletPreferences preferences = request.getPreferences();
+
+        return preferences.getValue("leaveReportingNotice", null);
+    }
+
     @RequestMapping
     public String viewContactInfo(ModelMap model, PortletRequest request) {
         final String emplId = PrimaryAttributeUtils.getPrimaryId();

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -38,7 +38,18 @@
     </div>
   </div>
 
-      <hrs:notification/>
+  <hrs:notification/>
+
+  <div id="${n}leaveReportingNotice" style="display: none;">
+    <%-- style changes as side effect of Outstanding Missing Leave Report statement callback. --%>
+    <c:if test="${not empty leaveReportingNotice}">
+      <div class="fl-widget hrs-notification-wrapper alert alert-info">
+        <div class="hrs-notification-content">${leaveReportingNotice}</div>
+      </div>
+    </c:if>
+  </div>
+
+
   </div>
 
   <div>
@@ -520,6 +531,7 @@
       		        	var reportLink = "${missingLeaveReportPdfUrl}".replace("missingLeaveReportDocId", missingReport.docId);
                         $("#${n}oustandingMissingLeaveReports").attr("href",reportLink);
                         $("#${n}oustandingMissingLeaveReports").show();
+                        $("#${n}leaveReportingNotice").show();
   		        	}
   		          },
   		          error: function(e){


### PR DESCRIPTION
+ Add support for a `leaveReportingNotice` `portlet-preference` in Time and Absence
+ When set, the notice shows to employees who see the Outstanding Missing Leave Reports link.