### PR TITLE
fix: eagerly resolve whether to show missing leave report notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ### Unreleased
 
+Fixed
+
++ Eagerly resolve whether to show leave reporting notice div ( #119 )
+
 ### 2.1.0
 
 2018-06-04

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -325,6 +325,28 @@
 (function($, fluid, dl) {
    $(function() {
 
+     // missing report ajax call
+     // resolving eagerly to determine soonest whether to show the {n}leaveReportingNotice div.
+
+     $.ajax({
+       type: "POST",
+       url: "${missingReportUrl}",
+       data: "",
+       success: function(response){
+         var missingReport = response.report;
+         if(missingReport != null || missingReport != undefined) {
+           var reportLink =
+             "${missingLeaveReportPdfUrl}".replace("missingLeaveReportDocId", missingReport.docId);
+           $("#${n}oustandingMissingLeaveReports").attr("href",reportLink);
+           $("#${n}oustandingMissingLeaveReports").show();
+           $("#${n}leaveReportingNotice").show();
+         }
+       },
+       error: function(e){
+         var response = jQuery.parseJSON(e.responseText);
+       }
+     });
+
         var formatDataArray = function(dataArray) {
             var startYear = dataArray[0];
             var startMonth = dataArray[1];
@@ -518,26 +540,6 @@
 
 
                 });
-
-              //missing report ajax call (doing it here so it uses the cached from call in leave report collection)
-
-            	$.ajax({
-  		          type: "POST",
-  		          url: "${missingReportUrl}",
-  		          data: "",
-  		          success: function(response){
-  		        	var missingReport = response.report;
-  		        	if(missingReport != null || missingReport != undefined) {
-      		        	var reportLink = "${missingLeaveReportPdfUrl}".replace("missingLeaveReportDocId", missingReport.docId);
-                        $("#${n}oustandingMissingLeaveReports").attr("href",reportLink);
-                        $("#${n}oustandingMissingLeaveReports").show();
-                        $("#${n}leaveReportingNotice").show();
-  		        	}
-  		          },
-  		          error: function(e){
-  		       	  	var response = jQuery.parseJSON(e.responseText);
-  		          }
-  		        });
 
                 return data;
             }


### PR DESCRIPTION
Eagerly rather than lazily resolve whether the employee has a PDF about missing leave reporting months.

Lazy resolution amounted to a bug such that the `leaveReportingNotice` div would start showing as a side effect of rendering the leave reports table (so, navigating to that tab).

This eliminated much of the value of a notice in helping employees realize they could navigate to the tab and view the PDF.

Credit to @mrdahman for heads up about this bug.