### PR TITLE
HRSPLT-342 implement new UW_DYN_AM_PUNCH_TIME HRS role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ now granted by new portlet role `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES`).
 
 Migration path: to the extent that employees ought to continue to have all the
 privileges of the prior implementation of `ROLE_VIEW_ABSENCE_HISTORIES`, also
-grant those employees `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES`.
+grant those employees `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES`. ( #121 )
 
 New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ New features
 
 + Add new portlet role `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES`, granting access to
   the "Enter absence" and "Edit/cancel absence buttons". This access is a subset
-  of what `ROLE_VIEW_ABSENCE_HISTORIES` historically granted.
+  of what `ROLE_VIEW_ABSENCE_HISTORIES` historically granted. ( #121 )
 + Add role mapping for new `UW_DYN_AM_PUNCH_TIME` HRS role. This HRS role grants
   `ROLE_VIEW_ABSENCE_HISTORIES` portlet role but does *not* grant new
   `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES` portlet role. ( #121 )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,36 @@
 # MyUW hrs-portlets change log
 
-### Unreleased (2.2?)
+### Unreleased (3?)
+
+BREAKING CHANGE:
+
+The `ROLE_VIEW_ABSENCE_HISTORIES` portlet role now *only*
+grants access to view absence histories and does *not* grant access to the
+"Enter absence" and "Edit/cancel absence" buttons. (Access to those buttons is
+now granted by new portlet role `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES`).
+
+Migration path: to the extent that employees ought to continue to have all the
+privileges of the prior implementation of `ROLE_VIEW_ABSENCE_HISTORIES`, also
+grant those employees `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES`.
 
 New features
 
-+ Add mapping for new `UW_DYN_AM_PUNCH_TIME` HRS role. Split out from the
-  existing `ROLE_VIEW_ABSENCE_HISTORIES` portlet role a portlet role specific to
-  creating, editing, and canceling one's own absence requests
-  (`ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES`). Grant only the absence history
-  viewing (and not the entering, editing, canceling one's own absences) to the
-  new `UW_DYN_AM_PUNCH_TIME` HRS role. Grant
-  `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES` portlet role to employees with existing
-  `UW_DYN_AM_EMPLOYEE` HRS role so that their access is unchanged. ( #121 )
++ Add new portlet role `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES`, granting access to
+  the "Enter absence" and "Edit/cancel absence buttons". This access is a subset
+  of what `ROLE_VIEW_ABSENCE_HISTORIES` historically granted.
++ Add role mapping for new `UW_DYN_AM_PUNCH_TIME` HRS role. This HRS role grants
+  `ROLE_VIEW_ABSENCE_HISTORIES` portlet role but does *not* grant new
+  `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES` portlet role. ( #121 )
+
+Changes
+
++ Update role mapping for `UW_DYN_AM_EMPLOYEE` HRS role to grant the new
+  `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES` portlet role in addition to the
+  `ROLE_VIEW_ABSENCE_HISTORIES` portlet role it was already granting. This
+  yields *no functional change* for employees with the `UW_DYN_AM_EMPLOYEE` HRS
+  role. While `ROLE_VIEW_ABSENCE_HISTORIES` is losing privileges in this
+  release, these employees regain those very same privileges via the
+  `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES` role. ( #121 )
 
 ### 2.1.1 : Eagerly resolve leave reporting notice div conditional
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 New features
 
 + Add mapping for new `UW_DYN_AM_PUNCH_TIME` HRS role. Split out from the
-  existing `ROLE_VIEW_ABSENCE_HISTORIES` role a role specific to creating,
-  editing, and canceling one's own absence requests
+  existing `ROLE_VIEW_ABSENCE_HISTORIES` portlet role a portlet role specific to
+  creating, editing, and canceling one's own absence requests
   (`ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES`). Grant only the absence history
   viewing (and not the entering, editing, canceling one's own absences) to the
   new `UW_DYN_AM_PUNCH_TIME` HRS role. Grant
-  `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES` to existing `UW_DYN_AM_EMPLOYEE` role so
-  that its access is unchanged. ( #121 )
+  `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES` portlet role to employees with existing
+  `UW_DYN_AM_EMPLOYEE` HRS role so that their access is unchanged. ( #121 )
 
 ### 2.1.1 : Eagerly resolve leave reporting notice div conditional
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,17 @@
 # MyUW hrs-portlets change log
 
+### Unreleased (2.2?)
 
-### Unreleased
+New features
+
++ Add mapping for new `UW_DYN_AM_PUNCH_TIME` HRS role. Split out from the
+  existing `ROLE_VIEW_ABSENCE_HISTORIES` role a role specific to creating,
+  editing, and canceling one's own absence requests
+  (`ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES`). Grant only the absence history
+  viewing (and not the entering, editing, canceling one's own absences) to the
+  new `UW_DYN_AM_PUNCH_TIME` HRS role. Grant
+  `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES` to existing `UW_DYN_AM_EMPLOYEE` role so
+  that its access is unchanged. ( #121 )
 
 ### 2.1.1 : Eagerly resolve leave reporting notice div conditional
 

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -52,6 +52,12 @@
                 -->
             </set>
         </entry>
+        <entry key="UW_DYN_AM_PUNCH_TIME">
+          <set>
+            <value>ROLE_VIEW_ABSENCE_HISTORIES</value>
+            <!-- same role as above -->
+          </set>
+        </entry>
         <entry key="UW_DYN_TL_WEB_CLOCK">
             <set>
                 <value>ROLE_VIEW_WEB_CLOCK</value>

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -47,6 +47,10 @@
                   In Time and Absence
                     Allows rendering absenceHistories.json
                     Show the Absence tab
+                -->
+                <value>ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES</value>
+                <!--
+                  In Time and Absence
                     Show the Enter Absence link
                     Show the Edit Cancel Absence link, if link is configured
                 -->

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -59,7 +59,7 @@
                target="_blank"><spring:message code="label.yearEndLeaveBalance" text="Year End University Staff Leave Balance"/></a><br/>
         </div>
     </c:if>
-    <sec:authorize ifAnyGranted="ROLE_VIEW_ABSENCE_HISTORIES">
+    <sec:authorize ifAnyGranted="ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES">
       <div class="dl-link">
         <a class="btn btn-primary" href="${hrsUrls['Request Absence']}" target="_blank">Enter Absence</a>
       </div>


### PR DESCRIPTION
New `UW_DYN_AM_PUNCH_TIME` HRS role should grant access to view absence histories without granting access to the enter/edit/cancel absence request buttons.

Old `UW_DYN_AM_EMPLOYEE` should continue to have the same access it has status quo.

So 

* Invent new portlet-internal role `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES`, 
* Switch to require the new `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES` role rather than `ROLE_VIEW_ABSENCE_HISTORIES` to see the "Enter absence" and "Edit/cancel absence" buttons.
* Add to the mapping of the pre-existing `UW_DYN_AM_EMPLOYEE` role to now grant both `ROLE_VIEW_ABSENCE_HISTORIES` and `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES`, so no change for employees holding `UW_DYN_AM_EMPLOYEE` role.
* Add new mapping for the new `UW_DYN_AM_PUNCH_TIME` HRS role, mapping only to the `ROLE_VIEW_ABSENCE_HISTORIES` portlet role (and not to the `ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES` portlet role)