### PR TITLE
HRSPLT-348 re-order leaveReportingNotice ahead of general hrs:notif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # MyUW hrs-portlets change log
 
+### Next release
+
+Changes:
+
++ In Time and Absence, the `leaveReportingNotice` when present is now ordered
+  ahead of general `hrs:notifications` in-app notifications when present.
+  ([HRSPLT-348][], [#122][])
+
 ### 3.0.0: split `ROLE_VIEW_ABSENCE_HISTORIES`
 
 BREAKING CHANGE:
@@ -323,3 +331,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 
 
 [releases in the GitHub repo]: https://github.com/UW-Madison-DoIT/hrs-portlets/releases
+
+[#122]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/122
+
+[HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -38,8 +38,6 @@
     </div>
   </div>
 
-  <hrs:notification/>
-
   <div id="${n}leaveReportingNotice" style="display: none;">
     <%-- style changes as side effect of Outstanding Missing Leave Report statement callback. --%>
     <c:if test="${not empty leaveReportingNotice}">
@@ -49,6 +47,7 @@
     </c:if>
   </div>
 
+  <hrs:notification/>
 
   </div>
 


### PR DESCRIPTION
The idea is that

+ In general reminding of leave reporting obligations is important and should be at top
+ In specific it may be useful for hrs:notifications to appear with nothing between them and the buttons they may be shortly notifying about.