### PR TITLE
HRSPLT-346: PHIT launch messaging support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 New features:
 
 + In Time and Absence, a new optional `portlet-preference`
-  `dynPunchTimesheetersNotice` drives a new in-HRS-app message (presented just
-  like `notification`) to employees with the new `ROLE_UW_DYN_AM_PUNCH_TIME`
-  role. ([HRSPLT-346][])
+  `dynPunchTimesheetNotification` drives a new in-HRS-app message (presented
+  just like `notification`) to employees with the new
+  `ROLE_UW_DYN_AM_PUNCH_TIME` role. ([HRSPLT-346][])
 + In Time and Absence, a new optional `portlet-preference`
-  `nonDynPunchTimesheetersNotice` drives a new in-HRS-app message (presented
+  `nonDynPunchTimesheetNotification` drives a new in-HRS-app message (presented
   just like `notification`) to employees who see the Timesheet button but who
   do not have the new `ROLE_UW_DYN_AM_PUNCH_TIME` role. ([HRSPLT-346][])
 + In Time and Absence, a new optional `portlet-preference`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,16 @@ New features:
 + In Time and Absence, a new optional `portlet-preference`
   `dynPunchTimesheetNotification` drives a new in-HRS-app message (presented
   just like `notification`) to employees with the new
-  `ROLE_UW_DYN_AM_PUNCH_TIME` role. ([HRSPLT-346][])
+  `ROLE_UW_DYN_AM_PUNCH_TIME` role. ([HRSPLT-346][], [#123][])
 + In Time and Absence, a new optional `portlet-preference`
   `nonDynPunchTimesheetNotification` drives a new in-HRS-app message (presented
   just like `notification`) to employees who see the Timesheet button but who
-  do not have the new `ROLE_UW_DYN_AM_PUNCH_TIME` role. ([HRSPLT-346][])
+  do not have the new `ROLE_UW_DYN_AM_PUNCH_TIME` role. ([HRSPLT-346][],
+  [#123][])
 + In Time and Absence, a new optional `portlet-preference`
   `dynPunchTimesheetNotice` drives a new message near the Timesheet button
   (presented similarly to `timesheetNotice`) to employees with the new
-  `ROLE_UW_DYN_AM_PUNCH_TIME` role. ([HRSPLT-346][])
+  `ROLE_UW_DYN_AM_PUNCH_TIME` role. ([HRSPLT-346][], [#123][])
 
 Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ New features:
   `dynPunchTimesheetersNotice` drives a new in-HRS-app message (presented just
   like `notification`) to employees with the new `ROLE_UW_DYN_AM_PUNCH_TIME`
   role. ([HRSPLT-346][])
++ In Time and Absence, a new optional `portlet-preference`
+  `nonDynPunchTimesheetersNotice` drives a new in-HRS-app message (presented
+  just like `notification`) to employees who see the Timesheet button but who
+  do not have the new `ROLE_UW_DYN_AM_PUNCH_TIME` role. ([HRSPLT-346][])
 
 Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,6 +349,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [releases in the GitHub repo]: https://github.com/UW-Madison-DoIT/hrs-portlets/releases
 
 [#122]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/122
+[#123]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/123
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ New features:
   `nonDynPunchTimesheetersNotice` drives a new in-HRS-app message (presented
   just like `notification`) to employees who see the Timesheet button but who
   do not have the new `ROLE_UW_DYN_AM_PUNCH_TIME` role. ([HRSPLT-346][])
++ In Time and Absence, a new optional `portlet-preference`
+  `dynPunchTimesheetNotice` drives a new message near the Timesheet button
+  (presented similarly to `timesheetNotice`) to employees with the new
+  `ROLE_UW_DYN_AM_PUNCH_TIME` role. ([HRSPLT-346][])
 
 Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### Next release
 
+New features:
+
++ In Time and Absence, a new optional `portlet-preference`
+  `dynPunchTimesheetersNotice` drives a new in-HRS-app message (presented just
+  like `notification`) to employees with the new `ROLE_UW_DYN_AM_PUNCH_TIME`
+  role. ([HRSPLT-346][])
+
 Changes:
 
 + In Time and Absence, the `leaveReportingNotice` when present is now ordered
@@ -334,4 +341,5 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 
 [#122]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/122
 
+[HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/README.md
+++ b/README.md
@@ -112,6 +112,17 @@ technically the underlying portlet name is `ContactInfo`.
   link, does not show.
 + Intended for messaging to employees subject to annual leave reporting requirements
 
+
+#### `dynPunchTimesheetersNotice` portlet preference (optional)
+
++ When set, adds an in-app-message near the top of Time and Absence showing to
+  employees with `ROLE_UW_DYN_AM_PUNCH_TIME`.
++ When not set, does not show. For employees who do not have
+  `ROLE_UW_DYN_AM_PUNCH_TIME`, does not show.
++ Intended for messaging to employees for whom the UI changed with the launch of
+  PHIT, such that the functions they previously accessed via purpose-specific
+  absence-related buttons they will now access via the timesheet button.
+
 #### `timesheetNotice` portlet preference (optional)
 
 + When set, adds text to the UI near the timesheet launch button.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ technically the underlying portlet name is `ContactInfo`.
 + Intended for messaging to employees subject to annual leave reporting requirements
 
 
-#### `dynPunchTimesheetersNotice` portlet preference (optional)
+#### `dynPunchTimesheetNotification` portlet preference (optional)
 
 + When set, adds an in-app-message near the top of Time and Absence showing to
   employees with `ROLE_UW_DYN_AM_PUNCH_TIME`.
@@ -123,7 +123,7 @@ technically the underlying portlet name is `ContactInfo`.
   PHIT, such that the functions they previously accessed via purpose-specific
   absence-related buttons they will now access via the timesheet button.
 
-#### `nonDynPunchTimesheetersNotice` portlet preference (optional)
+#### `nonDynPunchTimesheetNotification` portlet preference (optional)
 
 + When set, adds an in-app-message near the top of Time and Absence showing to
   employees who see the Timesheet button but who do not have

--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ technically the underlying portlet name is `ContactInfo`.
   the launch of PHIT, but for whom the experience they get when they click the
   Timesheet button may or may not have changed.
 
+#### `dynPunchTimesheetNotice` portlet preference (optional)
+
++ When set, adds text to the UI near the timesheet launch button, shown only
+  to employees with `ROLE_UW_DYN_AM_PUNCH_TIME`.
++ When not set, does not show.
++ For employees without `ROLE_UW_DYN_AM_PUNCH_TIME`, does not show.
++ When both this preference and `timesheetNotice` are set, this text appears
+  before and separated with a horizontal rule from the text specified in
+  `timesheetNotice`.
+
+Intended for easing the transition for employees who lose the absence-specific
+buttons and instead will now access absence-related functions directly in the
+HRS self-service timesheet linked via the Timesheet button.
+
 #### `timesheetNotice` portlet preference (optional)
 
 + When set, adds text to the UI near the timesheet launch button.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ technically the underlying portlet name is `ContactInfo`.
   PHIT, such that the functions they previously accessed via purpose-specific
   absence-related buttons they will now access via the timesheet button.
 
+#### `nonDynPunchTimesheetersNotice` portlet preference (optional)
+
++ When set, adds an in-app-message near the top of Time and Absence showing to
+  employees who see the Timesheet button but who do not have
+  `ROLE_UW_DYN_AM_PUNCH_TIME`.
++ When not set, does not show.
++ For employees who do have `ROLE_UW_DYN_AM_PUNCH_TIME`, does not show.
++ For employees who do not see the Timesheet button, does not show.
++ Intended for messaging to employees for whom the MyUW UI did not change with
+  the launch of PHIT, but for whom the experience they get when they click the
+  Timesheet button may or may not have changed.
+
 #### `timesheetNotice` portlet preference (optional)
 
 + When set, adds text to the UI near the timesheet launch button.

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -60,6 +60,9 @@
           <set>
             <value>ROLE_VIEW_ABSENCE_HISTORIES</value>
             <!-- same role as above -->
+            <value>ROLE_UW_DYN_AM_PUNCH_TIME</value>
+            <!-- pass through HRS role specifically to enable targeting
+              messaging specifically to this role -->
           </set>
         </entry>
         <entry key="UW_DYN_TL_WEB_CLOCK">

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeAbsenceController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeAbsenceController.java
@@ -62,6 +62,19 @@ public class TimeAbsenceController extends HrsControllerBase {
         return preferences.getValue("leaveReportingNotice", null);
     }
 
+    /**
+     * Optional message shown to employees with the dyn punch timesheet role.
+     * These users lost a couple buttons related to reporting absences (since)
+     * their timesheet now includes those functions integrated) and so are
+     * messaged in the Time and Absence UI about this change.
+     */
+    @ModelAttribute("dynPunchTimesheetersNotice")
+    public final String dynPunchTimesheetersNotice(PortletRequest request) {
+        final PortletPreferences preferences = request.getPreferences();
+
+        return preferences.getValue("dynPunchTimesheetersNotice", null);
+    }
+
     @RequestMapping
     public String viewContactInfo(ModelMap model, PortletRequest request) {
         final String emplId = PrimaryAttributeUtils.getPrimaryId();

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeAbsenceController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeAbsenceController.java
@@ -75,11 +75,11 @@ public class TimeAbsenceController extends HrsControllerBase {
      * their timesheet now includes those functions integrated) and so are
      * messaged in the Time and Absence UI about this change.
      */
-    @ModelAttribute("dynPunchTimesheetersNotice")
-    public final String dynPunchTimesheetersNotice(PortletRequest request) {
+    @ModelAttribute("dynPunchTimesheetNotification")
+    public final String dynPunchTimesheetNotification(PortletRequest request) {
         final PortletPreferences preferences = request.getPreferences();
 
-        return preferences.getValue("dynPunchTimesheetersNotice", null);
+        return preferences.getValue("dynPunchTimesheetNotification", null);
     }
 
     /**
@@ -88,11 +88,12 @@ public class TimeAbsenceController extends HrsControllerBase {
      * buttons, but their timesheet experience may (or may not) have changed
      * with the PHIT launch.
      */
-    @ModelAttribute("nonDynPunchTimesheetersNotice")
-    public final String nonDynPunchTimesheetersNotice(PortletRequest request) {
+    @ModelAttribute("nonDynPunchTimesheetNotification")
+    public final String nonDynPunchTimesheetNotification(
+        PortletRequest request) {
         final PortletPreferences preferences = request.getPreferences();
 
-        return preferences.getValue("nonDynPunchTimesheetersNotice", null);
+        return preferences.getValue("nonDynPunchTimesheetNotification", null);
     }
 
     @RequestMapping

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeAbsenceController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeAbsenceController.java
@@ -75,6 +75,19 @@ public class TimeAbsenceController extends HrsControllerBase {
         return preferences.getValue("dynPunchTimesheetersNotice", null);
     }
 
+    /**
+     * Optional message shown to employees who see the timesheet button
+     * but do not have the dyn punch timesheet role. These users did not lose
+     * buttons, but their timesheet experience may (or may not) have changed
+     * with the PHIT launch.
+     */
+    @ModelAttribute("nonDynPunchTimesheetersNotice")
+    public final String nonDynPunchTimesheetersNotice(PortletRequest request) {
+        final PortletPreferences preferences = request.getPreferences();
+
+        return preferences.getValue("nonDynPunchTimesheetersNotice", null);
+    }
+
     @RequestMapping
     public String viewContactInfo(ModelMap model, PortletRequest request) {
         final String emplId = PrimaryAttributeUtils.getPrimaryId();

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeAbsenceController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeAbsenceController.java
@@ -48,6 +48,13 @@ public class TimeAbsenceController extends HrsControllerBase {
         this.contactInfoDao = contactInfoDao;
     }
 
+    @ModelAttribute("dynPunchTimesheetNotice")
+    public final String dynPunchTimesheetNotice(PortletRequest request) {
+        final PortletPreferences preferences = request.getPreferences();
+
+        return preferences.getValue("dynPunchTimesheetNotice", null);
+    }
+
     @ModelAttribute("timesheetNotice")
     public final String getTimesheetNotice(PortletRequest request) {
         final PortletPreferences preferences = request.getPreferences();

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -58,11 +58,11 @@
       <%-- sec:authorize attributes are ANDed, as in user must fulfill all of
         them. So this targets users who see the timesheet button but who do not
         have UW_DYN_AM_PUNCH_TIME --%>
-      <div id="${n}nonDynPunchTimesheetersNotice">
-        <c:if test="${not empty nonDynPunchTimesheetersNotice}">
+      <div id="${n}nonDynPunchTimesheetNotification">
+        <c:if test="${not empty nonDynPunchTimesheetNotification}">
           <div class="fl-widget hrs-notification-wrapper alert alert-info">
             <div class="hrs-notification-content">
-              ${nonDynPunchTimesheetersNotice}
+              ${nonDynPunchTimesheetNotification}
             </div>
           </div>
         </c:if>
@@ -71,11 +71,11 @@
 
     <sec:authorize
       ifAllGranted="ROLE_UW_DYN_AM_PUNCH_TIME">
-      <div id="${n}dynPunchTimesheetersNotice">
-        <c:if test="${not empty dynPunchTimesheetersNotice}">
+      <div id="${n}dynPunchTimesheetNotification">
+        <c:if test="${not empty dynPunchTimesheetNotification">
           <div class="fl-widget hrs-notification-wrapper alert alert-info">
             <div class="hrs-notification-content">
-              ${dynPunchTimesheetersNotice}
+              ${dynPunchTimesheetNotification}
             </div>
           </div>
         </c:if>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -52,6 +52,24 @@
     <hrs:notification/>
 
     <sec:authorize
+      ifAnyGranted=
+        "ROLE_VIEW_TIME_SHEET,ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK"
+      ifNotGranted="ROLE_UW_DYN_AM_PUNCH_TIME">
+      <%-- sec:authorize attributes are ANDed, as in user must fulfill all of
+        them. So this targets users who see the timesheet button but who do not
+        have UW_DYN_AM_PUNCH_TIME --%>
+      <div id="${n}nonDynPunchTimesheetersNotice">
+        <c:if test="${not empty nonDynPunchTimesheetersNotice}">
+          <div class="fl-widget hrs-notification-wrapper alert alert-info">
+            <div class="hrs-notification-content">
+              ${nonDynPunchTimesheetersNotice}
+            </div>
+          </div>
+        </c:if>
+      </div>
+    </sec:authorize>
+
+    <sec:authorize
       ifAllGranted="ROLE_UW_DYN_AM_PUNCH_TIME">
       <div id="${n}dynPunchTimesheetersNotice">
         <c:if test="${not empty dynPunchTimesheetersNotice}">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -51,6 +51,19 @@
 
     <hrs:notification/>
 
+    <sec:authorize
+      ifAllGranted="ROLE_UW_DYN_AM_PUNCH_TIME">
+      <div id="${n}dynPunchTimesheetersNotice">
+        <c:if test="${not empty dynPunchTimesheetersNotice}">
+          <div class="fl-widget hrs-notification-wrapper alert alert-info">
+            <div class="hrs-notification-content">
+              ${dynPunchTimesheetersNotice}
+            </div>
+          </div>
+        </c:if>
+      </div>
+    </sec:authorize>
+
   </div>
 
   <div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -113,9 +113,20 @@
         <div style='display: inline-block;'>
           <a class="btn btn-primary" href="${hrsUrls['Timesheet']}" target="_blank">Timesheet</a>
         </div>
-        <c:if test="${not empty timesheetNotice}">
-          <div class="timesheet-notice">${timesheetNotice}</div>
-        </c:if>
+        <div class="timesheet-notice">
+          <sec:authorize
+            ifAllGranted="ROLE_UW_DYN_AM_PUNCH_TIME">
+            <c:if test="${not empty dynPunchTimesheetNotice}">
+              ${dynPunchTimesheetNotice}
+            </c:if>
+            <c:if test="${not empty timesheetNotice}">
+              <hr/>
+            </c:if>
+          </sec:authorize>
+          <c:if test="${not empty timesheetNotice}">
+            ${timesheetNotice}
+          </c:if>
+        </div>
         <br/>
       </div>
     </sec:authorize>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -26,28 +26,30 @@
 
 <div id="${n}dl-time-absence" class="fl-widget portlet dl-time-absence hrs">
   <div>
-  <div class="dl-banner-links">
-    <c:if test="${not empty hrsUrls['Benefits Enrollment']}">
-      <div class="dl-banner-link">
-        You have a benefit enrollment opportunity. Please enroll online by clicking the
-        following link. <a target="_blank" href="${hrsUrls['Benefits Enrollment']}">Benefits Enrollment</a>
+    <div class="dl-banner-links">
+      <c:if test="${not empty hrsUrls['Benefits Enrollment']}">
+        <div class="dl-banner-link">
+          You have a benefit enrollment opportunity. Please enroll online by clicking the
+          following link.
+          <a target="_blank" href="${hrsUrls['Benefits Enrollment']}">
+            Benefits Enrollment</a>
+        </div>
+      </c:if>
+      <div class="dl-help-link">
+        <a href="${helpUrl}" target="_blank">Help</a>
       </div>
-    </c:if>
-    <div class="dl-help-link">
-      <a href="${helpUrl}" target="_blank">Help</a>
     </div>
-  </div>
 
-  <div id="${n}leaveReportingNotice" style="display: none;">
-    <%-- style changes as side effect of Outstanding Missing Leave Report statement callback. --%>
-    <c:if test="${not empty leaveReportingNotice}">
-      <div class="fl-widget hrs-notification-wrapper alert alert-info">
-        <div class="hrs-notification-content">${leaveReportingNotice}</div>
-      </div>
-    </c:if>
-  </div>
+    <div id="${n}leaveReportingNotice" style="display: none;">
+      <%-- style changes as side effect of Outstanding Missing Leave Report statement callback. --%>
+      <c:if test="${not empty leaveReportingNotice}">
+        <div class="fl-widget hrs-notification-wrapper alert alert-info">
+          <div class="hrs-notification-content">${leaveReportingNotice}</div>
+        </div>
+      </c:if>
+    </div>
 
-  <hrs:notification/>
+    <hrs:notification/>
 
   </div>
 


### PR DESCRIPTION
+ Adds `dynPunchTimesheetNotice` for messaging to employees with the `UW_DYN_AM_PUNCH_TIME` role, ala the existing `timesheetNotice`.
+ Adds `dynPunchTimesheetNotification` for messaging to employees with the `UW_DYN_AM_PUNCH_TIME` HRS role, ala the existing `notification`.
+ Adds `nonDynPunchTimesheetNotification` for messaging employees who see the Timesheet button but who do not have the `UW_DYN_AM_PUNCH_TIME` HRS role, ala the existing `notification`.