### PR TITLE
!refactor(roles): Invent roles that more literally map to hrs-portlets functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 This release refactors roles in "Time and Absence", inventing in-hrs-portlets
 roles more explicitly mapping to UI controls and functions in hrs-portlets.
+([#125][])
 
 This is a breaking change in the sense that some previous roles disappear or
 or change meaning, and new roles appear.
@@ -386,6 +387,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 
 [#122]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/122
 [#123]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/123
+[#125]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/125
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,40 @@
 # MyUW hrs-portlets change log
 
-### Next release
+### Next release (4.0.0)
+
+**Breaking changes**
+
+This release refactors roles in "Time and Absence", inventing in-hrs-portlets
+roles more explicitly mapping to UI controls and functions in hrs-portlets.
+
+This is a breaking change in the sense that some previous roles disappear or
+or change meaning, and new roles appear.
+
+This is a non-breaking change, indeed a
+no-discernible-impact-to-HRS-or-to-employees change in the sense that the
+mapping from PeopleSoft roles to portlet roles is carefully ported forward such
+that the same PeopleSoft roles result in the same privileges and experiences in
+hrs-portlets.
+
+Invents:
+
++ `ROLE_TIMESHEET_BUTTON`, gating display of the Timesheet button
++ `ROLE_VIEW_TIME_ENTRY_HISTORY`, gating access to Time Entry history data and
+  display of this tab in Time and Absence
+
+Removes:
+
++ `ROLE_VIEW_TIME_SHEET`
++ `ROLE_VIEW_TIME_CLOCK`
+
+both of which had previously granted both access to the Timesheet button and
+access to time entry history.
+
+Changes the meaning of:
+
++ `ROLE_VIEW_WEB_CLOCK`, which now only grants the "Web Clock" link, but
+  previously had also granted access to the Timesheet button and time entry
+  history.
 
 ### 3.1.0: targeted notifications and notices for PHIT
 

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -68,7 +68,7 @@
         <entry key="UW_DYN_TL_WEB_CLOCK">
             <set>
                 <value>ROLE_VIEW_WEB_CLOCK</value>
-                <!-- effects (superset of ROLE_VIEW_TIME_CLOCK)
+                <!-- effects
                   In Time and Absence
                     Show the Web Clock link
                 -->
@@ -86,9 +86,6 @@
         </entry>
         <entry key="UW_DYN_TL_EMPLOYEE_TIMECLOCK">
             <set>
-                <value>ROLE_VIEW_TIME_CLOCK</value>
-                <!-- effects (subset of ROLE_VIEW_WEB_CLOCK)
-                -->
                 <value>ROLE_TIMESHEET_BUTTON</value>
                 <value>ROLE_VIEW_TIME_ENTRY_HISTORY</value>
             </set>

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -92,6 +92,7 @@
                     Show the Timesheet link
                 -->
                 <value>ROLE_TIMESHEET_BUTTON</value>
+                <value>ROLE_VIEW_TIME_ENTRY_HISTORY</value>
             </set>
         </entry>
         <entry key="UW_DYN_TL_CL_EMPL_TIMESHEET">

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -68,12 +68,12 @@
         <entry key="UW_DYN_TL_WEB_CLOCK">
             <set>
                 <value>ROLE_VIEW_WEB_CLOCK</value>
-                <!-- effects
+                <!-- effect
                   In Time and Absence
                     Show the Web Clock link
                 -->
                 <value>ROLE_TIMESHEET_BUTTON</value>
-                <!-- effects:
+                <!-- effect
                   In Time and Absence
                     Displays the Timesheet button -->
                 <value>ROLE_VIEW_TIME_ENTRY_HISTORY</value>

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -68,14 +68,12 @@
         <entry key="UW_DYN_TL_WEB_CLOCK">
             <set>
                 <value>ROLE_VIEW_WEB_CLOCK</value>
-                <!-- effects (superset of 
-                  ROLE_VIEW_TIME_CLOCK or ROLE_VIEW_TIME_SHEET)
+                <!-- effects (superset of ROLE_VIEW_TIME_CLOCK)
                   In Time and Absence
                     Allows rendering timeSheets.json
                     Show the Time Entry tab
                     Show the Timesheet link
-                    Show the Web Clock link (this is the difference from
-                      ROLE_VIEW_TIME_CLOCK and ROLE_VIEW_TIME_SHEET)
+                    Show the Web Clock link
                 -->
                 <value>ROLE_TIMESHEET_BUTTON</value>
                 <value>ROLE_VIEW_TIME_ENTRY_HISTORY</value>
@@ -84,8 +82,7 @@
         <entry key="UW_DYN_TL_EMPLOYEE_TIMECLOCK">
             <set>
                 <value>ROLE_VIEW_TIME_CLOCK</value>
-                <!-- effects (same as ROLE_VIEW_TIME_SHEET,
-                  subset of ROLE_VIEW_WEB_CLOCK)
+                <!-- effects (subset of ROLE_VIEW_WEB_CLOCK)
                   Allows rendering timeSheets.json
                   In Time and Absence
                     Show the Time Entry tab
@@ -97,14 +94,6 @@
         </entry>
         <entry key="UW_DYN_TL_CL_EMPL_TIMESHEET">
             <set>
-                <value>ROLE_VIEW_TIME_SHEET</value>
-                <!-- effects (same as ROLE_VIEW_TIME_CLOCK,
-                  subset of ROLE_VIEW_WEB_CLOCK)
-                  Allows rendering timeSheets.json
-                  In Time and Absence
-                    Show the Time Entry tab
-                    Show the Timesheet link
-                -->
                 <value>ROLE_TIMESHEET_BUTTON</value>
                 <value>ROLE_VIEW_TIME_ENTRY_HISTORY</value>
             </set>

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -78,6 +78,7 @@
                       ROLE_VIEW_TIME_CLOCK and ROLE_VIEW_TIME_SHEET)
                 -->
                 <value>ROLE_TIMESHEET_BUTTON</value>
+                <value>ROLE_VIEW_TIME_ENTRY_HISTORY</value>
             </set>
         </entry>
         <entry key="UW_DYN_TL_EMPLOYEE_TIMECLOCK">

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -106,6 +106,7 @@
                     Show the Timesheet link
                 -->
                 <value>ROLE_TIMESHEET_BUTTON</value>
+                <value>ROLE_VIEW_TIME_ENTRY_HISTORY</value>
             </set>
         </entry>
         <entry key="UW_UNV_TL Supervisor">

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -72,10 +72,12 @@
                   In Time and Absence
                     Allows rendering timeSheets.json
                     Show the Time Entry tab
-                    Show the Timesheet link
                     Show the Web Clock link
                 -->
                 <value>ROLE_TIMESHEET_BUTTON</value>
+                <!-- effects:
+                  In Time and Absence
+                    Displays the Timesheet button -->
                 <value>ROLE_VIEW_TIME_ENTRY_HISTORY</value>
             </set>
         </entry>
@@ -86,7 +88,6 @@
                   Allows rendering timeSheets.json
                   In Time and Absence
                     Show the Time Entry tab
-                    Show the Timesheet link
                 -->
                 <value>ROLE_TIMESHEET_BUTTON</value>
                 <value>ROLE_VIEW_TIME_ENTRY_HISTORY</value>

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -70,8 +70,6 @@
                 <value>ROLE_VIEW_WEB_CLOCK</value>
                 <!-- effects (superset of ROLE_VIEW_TIME_CLOCK)
                   In Time and Absence
-                    Allows rendering timeSheets.json
-                    Show the Time Entry tab
                     Show the Web Clock link
                 -->
                 <value>ROLE_TIMESHEET_BUTTON</value>
@@ -79,15 +77,17 @@
                   In Time and Absence
                     Displays the Timesheet button -->
                 <value>ROLE_VIEW_TIME_ENTRY_HISTORY</value>
+                <!-- effects:
+                  In Time and Absence
+                    Allows rendering timeSheets.json resource URL
+                    Show the Time Entry tab
+                -->
             </set>
         </entry>
         <entry key="UW_DYN_TL_EMPLOYEE_TIMECLOCK">
             <set>
                 <value>ROLE_VIEW_TIME_CLOCK</value>
                 <!-- effects (subset of ROLE_VIEW_WEB_CLOCK)
-                  Allows rendering timeSheets.json
-                  In Time and Absence
-                    Show the Time Entry tab
                 -->
                 <value>ROLE_TIMESHEET_BUTTON</value>
                 <value>ROLE_VIEW_TIME_ENTRY_HISTORY</value>

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -101,6 +101,7 @@
                     Show the Time Entry tab
                     Show the Timesheet link
                 -->
+                <value>ROLE_TIMESHEET_BUTTON</value>
             </set>
         </entry>
         <entry key="UW_UNV_TL Supervisor">

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -90,6 +90,7 @@
                     Show the Time Entry tab
                     Show the Timesheet link
                 -->
+                <value>ROLE_TIMESHEET_BUTTON</value>
             </set>
         </entry>
         <entry key="UW_DYN_TL_CL_EMPL_TIMESHEET">

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -77,6 +77,7 @@
                     Show the Web Clock link (this is the difference from
                       ROLE_VIEW_TIME_CLOCK and ROLE_VIEW_TIME_SHEET)
                 -->
+                <value>ROLE_TIMESHEET_BUTTON</value>
             </set>
         </entry>
         <entry key="UW_DYN_TL_EMPLOYEE_TIMECLOCK">

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeSheetDataController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeSheetDataController.java
@@ -55,7 +55,7 @@ public class TimeSheetDataController {
      * @param modelMap
      * @return the most recent timesheets, limited to 80
      */
-    @Secured({"ROLE_VIEW_WEB_CLOCK", "ROLE_VIEW_TIME_CLOCK", "ROLE_VIEW_TIME_SHEET"})
+    @Secured({"ROLE_VIEW_TIME_ENTRY_HISTORY"})
     @ResourceMapping("timeSheets")
     public String getTimeSheets(ModelMap modelMap) {
         final String emplid = PrimaryAttributeUtils.getPrimaryId();

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -145,7 +145,7 @@
         <c:set var="activeTabStyle" value=""/>
       </sec:authorize>
       <li class="ui-state-default ui-corner-top ${activeTabStyle}"><a href="#${n}dl-leave-balance">Leave Balances</a></li>
-      <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET">
+      <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET">
         <li class="ui-state-default ui-corner-top"><a href="#${n}dl-time-entry">Time Entry</a></li>
       </sec:authorize>
       <li class="ui-state-default ui-corner-top"><a href="#${n}dl-absence-statements">Leave Reports</a></li>
@@ -219,7 +219,7 @@
         <hrs:pagerNavBar position="bottom" />
       </div>
     </div>
-    <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET">
+    <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET">
       <div id="${n}dl-time-entry" class="dl-time-entry ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />
@@ -478,7 +478,7 @@
             }
           });
 
-        <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET">
+        <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET">
           dl.pager.init("#${n}dl-time-entry", {
             model: {
                 sortKey: "date",

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -145,7 +145,7 @@
         <c:set var="activeTabStyle" value=""/>
       </sec:authorize>
       <li class="ui-state-default ui-corner-top ${activeTabStyle}"><a href="#${n}dl-leave-balance">Leave Balances</a></li>
-      <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET">
+      <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY,ROLE_VIEW_TIME_SHEET">
         <li class="ui-state-default ui-corner-top"><a href="#${n}dl-time-entry">Time Entry</a></li>
       </sec:authorize>
       <li class="ui-state-default ui-corner-top"><a href="#${n}dl-absence-statements">Leave Reports</a></li>
@@ -219,7 +219,7 @@
         <hrs:pagerNavBar position="bottom" />
       </div>
     </div>
-    <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET">
+    <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY,ROLE_VIEW_TIME_SHEET">
       <div id="${n}dl-time-entry" class="dl-time-entry ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />
@@ -478,7 +478,7 @@
             }
           });
 
-        <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY,ROLE_VIEW_TIME_CLOCK,ROLE_VIEW_TIME_SHEET">
+        <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY,ROLE_VIEW_TIME_SHEET">
           dl.pager.init("#${n}dl-time-entry", {
             model: {
                 sortKey: "date",

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -108,7 +108,7 @@
       </c:if>
 
     </sec:authorize>
-    <sec:authorize ifAnyGranted="ROLE_TIMESHEET_BUTTON,ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK">
+    <sec:authorize ifAnyGranted="ROLE_TIMESHEET_BUTTON,ROLE_VIEW_TIME_CLOCK">
       <div class="dl-link">
         <div style='display: inline-block;'>
           <a class="btn btn-primary" href="${hrsUrls['Timesheet']}" target="_blank">Timesheet</a>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -108,7 +108,7 @@
       </c:if>
 
     </sec:authorize>
-    <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_SHEET,ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK">
+    <sec:authorize ifAnyGranted="ROLE_TIMESHEET_BUTTON,ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK">
       <div class="dl-link">
         <div style='display: inline-block;'>
           <a class="btn btn-primary" href="${hrsUrls['Timesheet']}" target="_blank">Timesheet</a>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -52,8 +52,7 @@
     <hrs:notification/>
 
     <sec:authorize
-      ifAnyGranted=
-        "ROLE_VIEW_TIME_SHEET,ROLE_VIEW_WEB_CLOCK,ROLE_VIEW_TIME_CLOCK"
+      ifAnyGranted="ROLE_TIMESHEET_BUTTON"
       ifNotGranted="ROLE_UW_DYN_AM_PUNCH_TIME">
       <%-- sec:authorize attributes are ANDed, as in user must fulfill all of
         them. So this targets users who see the timesheet button but who do not

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -108,7 +108,7 @@
       </c:if>
 
     </sec:authorize>
-    <sec:authorize ifAnyGranted="ROLE_TIMESHEET_BUTTON,ROLE_VIEW_TIME_CLOCK">
+    <sec:authorize ifAnyGranted="ROLE_TIMESHEET_BUTTON">
       <div class="dl-link">
         <div style='display: inline-block;'>
           <a class="btn btn-primary" href="${hrsUrls['Timesheet']}" target="_blank">Timesheet</a>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -145,7 +145,7 @@
         <c:set var="activeTabStyle" value=""/>
       </sec:authorize>
       <li class="ui-state-default ui-corner-top ${activeTabStyle}"><a href="#${n}dl-leave-balance">Leave Balances</a></li>
-      <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY,ROLE_VIEW_TIME_SHEET">
+      <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY">
         <li class="ui-state-default ui-corner-top"><a href="#${n}dl-time-entry">Time Entry</a></li>
       </sec:authorize>
       <li class="ui-state-default ui-corner-top"><a href="#${n}dl-absence-statements">Leave Reports</a></li>
@@ -219,7 +219,7 @@
         <hrs:pagerNavBar position="bottom" />
       </div>
     </div>
-    <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY,ROLE_VIEW_TIME_SHEET">
+    <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY">
       <div id="${n}dl-time-entry" class="dl-time-entry ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />
@@ -478,7 +478,7 @@
             }
           });
 
-        <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY,ROLE_VIEW_TIME_SHEET">
+        <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY">
           dl.pager.init("#${n}dl-time-entry", {
             model: {
                 sortKey: "date",


### PR DESCRIPTION
Invents:

+ `ROLE_TIMESHEET_BUTTON`, gating display of the Timesheet button
+ `ROLE_VIEW_TIME_ENTRY_HISTORY`, gating access to the Time Entry tab and its data

Removes:

+ `ROLE_VIEW_TIME_SHEET`, which granted the button and the time entry history
+ `ROLE_VIEW_TIME_CLOCK`, which granted the timesheet and the time entry history

Retains, simplified:

+ `ROLE_VIEW_WEB_CLOCK`, which now only grants the "Web Clock" link and not also Timesheet button and time entry history.

The idea here is to make the JSP (view) layer less complex by moving more of the business rules of what roles mean what to the role mapping layer.

HRS itself already has roles that maybe better model the underlying nature and privileges of a given employee. We don't need to be so pure here. Here in hrs-portlets we just need to know what to show to whom. So let's have roles that are more literally about, what should this employee see.

And then the role mapping layer (and the roles troubleshooter tool) will be more expressive about who can see what. As in, there will be a role for seeing the timesheet button, employees with that role see the button, employees without the role don't see the button. Who sees the timesheet button? As the role troubleshooter whether the employee has and how one gets that timesheet-button-specific role, and skip the having to keep layers of mappings from documentation in your head.

Breaking change in the sense that roles aren't what they used to be. Non-breaking in the sense that PeopleSoft role mapping configuration is carefully migrated forward such that the same PeopleSoft roles result in the same privileges in the hrs-portlets, regardless of what we call those privileges locally.