### PR TITLE
HRSPLT-357 invent ROLE_VIEW_HRS_APPROVALS_WIDGET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Changes the meaning of:
 
 New features:
 
++ Adds `ROLE_VIEW_HRS_APPROVALS_WIDGET`, initially mapped from HRS role `UW_DYN_PY_ADDL_PAY_APP` 
+  ([#128][])
 + As a *Servlet* in the HRSPortlets web application, adds `/go` redirector that takes a `urlKey`
   request parameter. When this maps to a URL known to the HrsUrlsDao, redirects to that URL. When
   this does not map to a URL known to that DAO, responds 404 not found. ([#126][])
@@ -396,6 +398,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#123]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/123
 [#125]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/125
 [#126]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/126
+[#128]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/128
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -65,6 +65,11 @@
               messaging specifically to this role -->
           </set>
         </entry>
+        <entry key="UW_DYN_PY_ADDL_PAY_APP">
+            <set>
+                <value>ROLE_VIEW_HRS_APPROVALS_WIDGET</value>
+            </set>
+        </entry>
         <entry key="UW_DYN_TL_WEB_CLOCK">
             <set>
                 <value>ROLE_VIEW_WEB_CLOCK</value>


### PR DESCRIPTION
Grant this role from new `UW_DYN_PY_ADDL_PAY_APP` HRS role.

Intent is for the new HRS Approvals widget to `switch` its content based on whether employee has `ROLE_VIEW_HRS_APPROVALS_WIDGET`. If the employee has the role, the widget is meaningful for that employee. If not, show a this-widget-is-not-yet-for-you message.

As more approvals functions beyond approving additional pay grow into the HRS Approvals widget / the backing HRS functions, such that the widget becomes relevant to more roles, more HRS roles may grant `ROLE_VIEW_HRS_APPROVALS_WIDGET`.