### PR TITLE
add rolesAsReport resourceUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ New features:
   this does not map to a URL known to that DAO, responds 404 not found. ([#126][])
 + Adds a JSON resource URL for asking whether the user has a specific HRS Portlets role. Intended
   for use in `switch` widget type to switch widget behavior on whether user has role. ([ #127][])
++ Adds a JSON resource URL for asking what portlet roles the user does and does not have. Intended
+  for use in uPortal App Framework message filtering. Structured similarly to `enrollmentFlag` for 
+  this reason. ([#129][])
 
 ### 3.1.0: targeted notifications and notices for PHIT
 
@@ -401,6 +404,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#126]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/126
 [#127]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/127
 [#128]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/128
+[#129]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/129
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ this hour limiting policy applies to them.)
   translates to an HTTP request parameter of `pP_role`.
 + `rolesAsListOfLinks` : JSON suitable for driving a `list-of-links` widget representing the user's
   HRS roles. Useful for troubleshooting.
++ `rolesAsReport` : JSON suitable for driving uPortal App Framework message filtering.
 
 ### Urls
 

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/roles/RolesController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/roles/RolesController.java
@@ -5,7 +5,9 @@ import edu.wisc.portlet.hrs.web.HrsControllerBase;
 import edu.wisc.portlet.hrs.web.listoflinks.Link;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -60,6 +62,44 @@ public class RolesController
     modelMap.put("content", content);
 
     return "contentAttrJsonView";
+  }
+
+  /**
+   * Model is "report" --> [ {"rolename", "true"}, {"anotherRoleName", "false"}, ... ]
+   * Suitable for predicating a uPortal Application Framework message on the employee having a role.
+   * @param modelMap
+   * @return
+   * @throws IOException
+   */
+  @ResourceMapping("rolesAsFlags")
+  public String rolesAsReport(ModelMap modelMap) throws IOException {
+
+    final String emplId = PrimaryAttributeUtils.getPrimaryId();
+
+    final Map<String, Set<String>> generalRoleMapping = this.rolesDao.getHrsRoleMappings();
+
+    Set<String> rolesThatPeopleMightHave = new HashSet<String>();
+
+    // collect all the mapped portlet roles
+    Collection<Set<String>> mappingValues = generalRoleMapping.values();
+    for (Set<String> portletRoles : mappingValues) {
+      rolesThatPeopleMightHave.addAll(portletRoles);
+    }
+
+    final Set<String> rolesHeldByEmployee = this.rolesDao.getHrsRoles(emplId);
+
+    List<Map<String, String>> report = new ArrayList<Map<String, String>>();
+
+    for (String portletRole : rolesThatPeopleMightHave) {
+      Map<String, String> rolesMap = new HashMap<String, String>();
+      rolesMap.put(portletRole,
+          Boolean.valueOf(rolesHeldByEmployee.contains(portletRole)).toString());
+      report.add(rolesMap);
+    }
+
+    modelMap.addAttribute("report", report);
+
+    return "jsonView";
   }
 
   /**

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/roles/RolesController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/roles/RolesController.java
@@ -71,7 +71,7 @@ public class RolesController
    * @return
    * @throws IOException
    */
-  @ResourceMapping("rolesAsFlags")
+  @ResourceMapping("rolesAsReport")
   public String rolesAsReport(ModelMap modelMap) throws IOException {
 
     final String emplId = PrimaryAttributeUtils.getPrimaryId();


### PR DESCRIPTION
While #127 added a resourceUrl suitable for `switch`ing on portlet roles, this would add a resourceUrl suitable for filtering uPortal App Framework messages to portlet roles. Alas, these two technologies don't yet have quite the same flexibilities. Message filtering wants to filter on the presence of an item with a matching characteristic in an array, whereas `switch` wants to filter on the value of an item at a path in the JSON.

It'd be good to make both more capable. In the meantime, this adds JSON that looks very much like the enrollmentFlag JSON successfully in use in production for message filtering, so it might work for filtering messages to roles, including for announcing the new HRS Approvals widget to the employees with roles that would allow their enjoying that widget.