### PR TITLE
HRSPLT-359 map "UW_UNV_TL Supervisor" to ROLE_VIEW_HRS_APPROVALS_WIDGET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,15 +39,15 @@ Changes the meaning of:
 
 New features:
 
-+ Adds `ROLE_VIEW_HRS_APPROVALS_WIDGET`, initially mapped from HRS role `UW_DYN_PY_ADDL_PAY_APP` 
-  ([#128][])
++ Adds `ROLE_VIEW_HRS_APPROVALS_WIDGET`, initially mapped from HRS roles
+  `UW_DYN_PY_ADDL_PAY_APP` and `UW_UNV_TL Supervisor` ([#128][], [#132][])
 + As a *Servlet* in the HRSPortlets web application, adds `/go` redirector that takes a `urlKey`
   request parameter. When this maps to a URL known to the HrsUrlsDao, redirects to that URL. When
   this does not map to a URL known to that DAO, responds 404 not found. ([#126][])
 + Adds a JSON resource URL for asking whether the user has a specific HRS Portlets role. Intended
   for use in `switch` widget type to switch widget behavior on whether user has role. ([ #127][])
 + Adds a JSON resource URL for asking what portlet roles the user does and does not have. Intended
-  for use in uPortal App Framework message filtering. Structured similarly to `enrollmentFlag` for 
+  for use in uPortal App Framework message filtering. Structured similarly to `enrollmentFlag` for
   this reason. ([#129][])
 
 ### 3.1.0: targeted notifications and notices for PHIT
@@ -405,6 +405,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#127]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/127
 [#128]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/128
 [#129]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/129
+[#132]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/132
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -77,6 +77,11 @@
         <entry key="UW_DYN_PY_ADDL_PAY_APP">
             <set>
                 <value>ROLE_VIEW_HRS_APPROVALS_WIDGET</value>
+                <!-- indicates that the HRS Approvals widget is intended to
+                  be useful to the employee. Technically all employees can view
+                  the widget, it's just that it won't be useful to people
+                  without this role. In practice, MyUW targets an announcement
+                  about the widget depending on this role. -->
             </set>
         </entry>
         <entry key="UW_DYN_TL_WEB_CLOCK">
@@ -130,6 +135,8 @@
                     Show the Approve Absence link
                     Show the Approve Payable Time link
                 -->
+                <value>ROLE_VIEW_HRS_APPROVALS_WIDGET</value>
+                <!-- as above -->
             </set>
         </entry>
         <entry key="UW_UNV_TL Non Supervisor">


### PR DESCRIPTION
In practice drives audience for the mascot announcement about the availability of the "HRS Approvals" widget. Employees with this role may have relevant approvals in that widget and in the page it links.

May eventually also drive experience in the "HRS Approvals" widget itself, if the `switch` widget type comes together and there's a more usable error experience to be offered by switching widget content in the case where the employee lacks the necessary role.