### PR TITLE
HRSPLT-361 enable deep link to tab within Payroll Information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,23 @@
 The HRS Portlets 4 major version was occasioned by the breaking change of
 changing the meaning of `ROLE_VIEW_WEB_CLOCK`.
 
-### 4.0.1 (Unreleased)
+### 4.1.0 (Unreleased)
 
-No changes yet.
+#### New features in 4.1.0
+
++ Optionally deep link to a specific tab in Payroll Information by setting the
+  `requestedContent` *Portlet* request parameter. Specifically, setting this to
+  `Tax Statements` will select the "Tax Statements" tab, whereas omitting it or
+  any other value will continue the default behavior of initially selecting the
+  "Earning Statements" tab. Note that this is only practically useful when
+  invoking the Portlet in a way that conveys portlet request parameters. i.e.
+  the status quo naive `/web/exclusive/{fname}` in uPortal App Framework does
+  not support this feature, whereas the legacy `/portal/p/{fname}` does *if* you
+  indulge a modest abstraction violation and rely on knowledge of how uPortal
+  names *Portlet* request parameters, i.e.
+  `/portal/p/{fname}?pP_requestedContent=Tax%20Statements` . This is all by way
+  of temporizing until the HRS Portlets can be replaced by implementations that
+  are not Portlets, e.g. uPortal Application Framework applications.
 
 ### 4.0.0: `ROLE_VIEW_HRS_APPROVALS_WIDGET`, role refactor and apis, redirector
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,18 @@ This is a handy way to statically refer in widgets, notifications, etc., to the 
 getting the tier-appropriate, potentially changing over time implementation of that URL, rather than
 peppering implementation details of HRS deep links into content.
 
+## Deep linking to content within Portlets
+
+The `Payroll Information` portlet supports an optional `requestedContent`
+*Portlet* request parameter (so, in practice, `pP_requestedContent` as uPortal
+*HTTP* request parameter) specifying which content within the portlet (tab) to
+initially select. The parameter value `Tax Statements` selects, well, tax
+statements. Omitting it or any other value accepts the default behavior of
+initially selecting the "Earning Statements" tab.
+
+If this goes well it will be feasible to extend this feature to other HRS
+Portlets as the need arises.
+
 ## Local Setup Instructions
 
 Several property files need to be configured for your local environment before the Portlet will run in your local uPortal server.

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/HrsControllerBase.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/HrsControllerBase.java
@@ -100,6 +100,11 @@ public class HrsControllerBase {
         return PrimaryAttributeUtils.getPrimaryId();
     }
 
+    @ModelAttribute("requestedContent")
+    public final String requestedContent(PortletRequest request) {
+      return (request.getParameter("requestedContent"));
+    }
+
     @ResourceMapping("getHrsUrlsJson")
     public String getURLRestService(ModelMap modelMap) {
       modelMap.addAttribute("report", this.hrsUrlDao.getHrsUrls());

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -39,13 +39,21 @@
       --%>
       <c:choose>
         <c:when test="${requestedContent equals 'Tax Statements'}">
-          <li class="ui-state-default ui-corner-top"><a href="#${n}dl-earning-statements">Earning Statements</a></li>
-          <li class="ui-state-default ui-corner-top ui-tabs-selected ui-state-active"><a href="#${n}dl-tax-statements">Tax Statements</a></li>
+          <li class="ui-state-default ui-corner-top">
+            <a href="#${n}dl-earning-statements">Earning Statements</a>
+          </li>
+          <li class="ui-state-default ui-corner-top ui-tabs-selected ui-state-active">
+            <a href="#${n}dl-tax-statements">Tax Statements</a>
+          </li>
         </c:when>
         <c:otherwise>
           <%-- default to Earnings Statements as default tab. --%>
-          <li class="ui-state-default ui-corner-top ui-tabs-selected ui-state-active"><a href="#${n}dl-earning-statements">Earning Statements</a></li>
-          <li class="ui-state-default ui-corner-top"><a href="#${n}dl-tax-statements">Tax Statements</a></li>
+          <li class="ui-state-default ui-corner-top ui-tabs-selected ui-state-active">
+            <a href="#${n}dl-earning-statements">Earning Statements</a>
+          </li>
+          <li class="ui-state-default ui-corner-top">
+            <a href="#${n}dl-tax-statements">Tax Statements</a>
+          </li>
         </c:otherwise>
     </c:choose>
     </ul>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -34,8 +34,20 @@
   </div>
   <div id="${n}dl-tabs" class="dl-tabs ui-tabs ui-widget ui-widget-content ui-corner-all inner-nav-container">
     <ul class="ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all inner-nav">
-      <li class="ui-state-default ui-corner-top ui-tabs-selected ui-state-active"><a href="#${n}dl-earning-statements">Earning Statements</a></li>
-      <li class="ui-state-default ui-corner-top"><a href="#${n}dl-tax-statements">Tax Statements</a></li>
+      <%--
+        set initial tab selection based on optional portlet request param
+      --%>
+      <c:choose>
+        <c:when test="${requestedContent equals 'Tax Statements'}">
+          <li class="ui-state-default ui-corner-top"><a href="#${n}dl-earning-statements">Earning Statements</a></li>
+          <li class="ui-state-default ui-corner-top ui-tabs-selected ui-state-active"><a href="#${n}dl-tax-statements">Tax Statements</a></li>
+        </c:when>
+        <c:otherwise>
+          <%-- default to Earnings Statements as default tab. --%>
+          <li class="ui-state-default ui-corner-top ui-tabs-selected ui-state-active"><a href="#${n}dl-earning-statements">Earning Statements</a></li>
+          <li class="ui-state-default ui-corner-top"><a href="#${n}dl-tax-statements">Tax Statements</a></li>
+        </c:otherwise>
+    </c:choose>
     </ul>
     <div id="${n}dl-earning-statements" class="dl-earning-statements ui-tabs-panel ui-widget-content ui-corner-bottom">
       <div class="data-table-description-header">


### PR DESCRIPTION
I don't fully understand this, but I think it might work.

HRS Portlets are using a `datalist` framework for tables and for tabs (no, not [that datalist](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist), [this one](https://github.com/UW-Madison-DoIT/datalist-portlet-utils)), in concert with an old version of [Fluid Infusion](https://fluidproject.org/infusion.html). I only vaguely understand this, but the punchline is there's some "magic" happening client-side. [datalist documentation](https://github.com/UW-Madison-DoIT/datalist-portlet-utils/blob/master/README.md) is a little sparse.

I *think* the way it determines which tab is selected is via the presence of the `ui-tabs-selected ui-state-active` classes.

So this solution brute force, server-side via JSTL, switches between a version of those two tab `<li>` elements that have the one tab selected, or the other selected, based on, server-side, the value of a new, optional `requestedContent` *Portlet* request parameter.

Strategically, it would be a wonderful thing to rebirth the front end of HRS Portlets as uPortal app framework applications or so. No datalist. No Fluid Infusion. Reasonable paths through some kind of reasonable router. That'll be grand. At that point deep linking to content within the app should just happen naturally. I took a quick stab at spinning up a uPortal App Framework app for this, and, well, that path wouldn't be quick for me. 😞 

Tactically, this may enable immediate-term deep linking to tabs within Payroll Information.