### PR TITLE
HRSPLT-362 link HRS self-service W-2 iff HRS URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ changing the meaning of `ROLE_VIEW_WEB_CLOCK`.
 
 #### New features in 4.1.0
 
++ Payroll Information shows links to `View W-2` and `W-2 Consent`, iff it reads
+  those URLs from the HRS URLs DAO. (No interdependency - each handled
+  individually.) ( [#136][], [HRSPLT-362][] )
 + Optionally deep link to a specific tab in Payroll Information by setting the
   `requestedContent` *Portlet* request parameter. Specifically, setting this to
   `Tax Statements` will select the "Tax Statements" tab, whereas omitting it or
@@ -468,6 +471,8 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#128]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/128
 [#129]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/129
 [#132]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/132
+[#136]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/136
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348
+[HRSPLT-362]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-362

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -32,6 +32,21 @@
     
       <hrs:notification/>
   </div>
+
+  <div class="dl-payroll-links">
+    <c:if test="${not empty hrsUrls['View W-2']}}"
+      <a class="btn btn-primary"
+        href="${hrsUrls['View W-2']}"
+        target="_blank" rel="noopener noreferrer">View W-2</a>
+    </c:if>
+    <c:if test="${not empty hrsUrls['W-2 Consent']}}"
+      <a class="btn btn-primary"
+        href="${hrsUrls['W-2 Consent']}"
+        target="_blank" rel="noopener noreferrer">
+        Consent to receive W-2 electronically</a>
+    </c:if>
+  </div>
+
   <div id="${n}dl-tabs" class="dl-tabs ui-tabs ui-widget ui-widget-content ui-corner-all inner-nav-container">
     <ul class="ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all inner-nav">
       <%--


### PR DESCRIPTION
Iff the "View W-2" and/or "W-2 Consent" HRS URLs are set, show buttons linking to them, individually.

<img width="829" alt="mockup-payroll-info-links-w2-in-hrs" src="https://user-images.githubusercontent.com/952283/46953488-9d9d6100-d053-11e8-83f3-635d5b9b309a.png">


[HRSPLT-362](https://jira.doit.wisc.edu/jira/browse/HRSPLT-362)