### PR TITLE
HRSPLT-362, HRSPLT-363 add links to HRS URLs for W-2 and 1095-C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ changing the meaning of `ROLE_VIEW_WEB_CLOCK`.
 
 #### New features in 4.1.0
 
++ Payroll Information shows links to `View 1095-C` and `1095-C Consent`, iff it
+  reads those URLs from the HRS URLs DAO. (No interdependency - each handled
+  individually.) ( [#137][], [HRSPLT-363][] )
 + Optionally deep link to a specific tab in Payroll Information by setting the
   `requestedContent` *Portlet* request parameter. Specifically, setting this to
   `Tax Statements` will select the "Tax Statements" tab, whereas omitting it or
@@ -468,6 +471,8 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#128]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/128
 [#129]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/129
 [#132]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/132
+[#137]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/137
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348
+[HRSPLT-363]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-363

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ changing the meaning of `ROLE_VIEW_WEB_CLOCK`.
 
 #### New features in 4.1.0
 
-+ Payroll Information shows links to `View 1095-C` and `1095-C Consent`, iff it
-  reads those URLs from the HRS URLs DAO. (No interdependency - each handled
-  individually.) ( [#137][], [HRSPLT-363][] )
++ Payroll Information shows links to `View W-2`, `View 1095-C`, `W-2 Consent`,
+  and `1095-C Consent`, iff it reads those URLs from the HRS URLs DAO. (No
+  interdependency - each handled individually.) ( [#137][], [HRSPLT-362][],
+  [HRSPLT-363][] )
 + Optionally deep link to a specific tab in Payroll Information by setting the
   `requestedContent` *Portlet* request parameter. Specifically, setting this to
   `Tax Statements` will select the "Tax Statements" tab, whereas omitting it or
@@ -475,4 +476,5 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348
+[HRSPLT-362]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-362
 [HRSPLT-363]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-363

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -32,6 +32,21 @@
     
       <hrs:notification/>
   </div>
+
+  <div class="dl-payroll-links">
+    <c:if test="${not empty hrsUrls['View 1095-C']}}"
+      <a class="btn btn-primary"
+        href="${hrsUrls['View 1095-C']}"
+        target="_blank" rel="noopener noreferrer">View 1095-C</a>
+    </c:if>
+    <c:if test="${not empty hrsUrls['1095-C Consent']}}"
+      <a class="btn btn-primary"
+        href="${hrsUrls['1095-C Consent']}"
+        target="_blank" rel="noopener noreferrer">
+        Consent to receive 1095-C electronically</a>
+    </c:if>
+  </div>
+
   <div id="${n}dl-tabs" class="dl-tabs ui-tabs ui-widget ui-widget-content ui-corner-all inner-nav-container">
     <ul class="ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all inner-nav">
       <%--

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -112,9 +112,6 @@
             target="_blank" rel="noopener noreferrer">
             Consent to receive W-2 electronically</a>
         </c:if>
-      </div>
-
-      <div class="dl-payroll-links">
         <c:if test="${not empty hrsUrls['View 1095-C']}}"
           <a class="btn btn-primary"
             href="${hrsUrls['View 1095-C']}"

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -107,7 +107,7 @@
             target="_blank" rel="noopener noreferrer">View W-2</a>
         </c:if>
         <c:if test="${not empty hrsUrls['W-2 Consent']}}"
-          <a class="btn btn-primary"
+          <a class="btn btn-default"
             href="${hrsUrls['W-2 Consent']}"
             target="_blank" rel="noopener noreferrer">
             Consent to receive W-2 electronically</a>
@@ -121,7 +121,7 @@
             target="_blank" rel="noopener noreferrer">View 1095-C</a>
         </c:if>
         <c:if test="${not empty hrsUrls['1095-C Consent']}}"
-          <a class="btn btn-primary"
+          <a class="btn btn-default"
             href="${hrsUrls['1095-C Consent']}"
             target="_blank" rel="noopener noreferrer">
             Consent to receive 1095-C electronically</a>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -33,20 +33,6 @@
       <hrs:notification/>
   </div>
 
-  <div class="dl-payroll-links">
-    <c:if test="${not empty hrsUrls['View W-2']}}"
-      <a class="btn btn-primary"
-        href="${hrsUrls['View W-2']}"
-        target="_blank" rel="noopener noreferrer">View W-2</a>
-    </c:if>
-    <c:if test="${not empty hrsUrls['W-2 Consent']}}"
-      <a class="btn btn-primary"
-        href="${hrsUrls['W-2 Consent']}"
-        target="_blank" rel="noopener noreferrer">
-        Consent to receive W-2 electronically</a>
-    </c:if>
-  </div>
-
   <div id="${n}dl-tabs" class="dl-tabs ui-tabs ui-widget ui-widget-content ui-corner-all inner-nav-container">
     <ul class="ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all inner-nav">
       <%--
@@ -113,6 +99,20 @@
       </c:if>
     </div>
     <div id="${n}dl-tax-statements" class="dl-tax-statements ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
+
+      <div class="dl-payroll-links">
+        <c:if test="${not empty hrsUrls['View W-2']}}"
+          <a class="btn btn-primary"
+            href="${hrsUrls['View W-2']}"
+            target="_blank" rel="noopener noreferrer">View W-2</a>
+        </c:if>
+        <c:if test="${not empty hrsUrls['W-2 Consent']}}"
+          <a class="btn btn-primary"
+            href="${hrsUrls['W-2 Consent']}"
+            target="_blank" rel="noopener noreferrer">
+            Consent to receive W-2 electronically</a>
+        </c:if>
+      </div>
 
       <div class="dl-payroll-links">
         <c:if test="${not empty hrsUrls['View 1095-C']}}"

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -33,6 +33,20 @@
       <hrs:notification/>
   </div>
 
+  <div class="dl-payroll-links">
+    <c:if test="${not empty hrsUrls['View W-2']}}"
+      <a class="btn btn-primary"
+        href="${hrsUrls['View W-2']}"
+        target="_blank" rel="noopener noreferrer">View W-2</a>
+    </c:if>
+    <c:if test="${not empty hrsUrls['W-2 Consent']}}"
+      <a class="btn btn-primary"
+        href="${hrsUrls['W-2 Consent']}"
+        target="_blank" rel="noopener noreferrer">
+        Consent to receive W-2 electronically</a>
+    </c:if>
+  </div>
+
   <div id="${n}dl-tabs" class="dl-tabs ui-tabs ui-widget ui-widget-content ui-corner-all inner-nav-container">
     <ul class="ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all inner-nav">
       <%--

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -99,9 +99,6 @@
       </c:if>
     </div>
     <div id="${n}dl-tax-statements" class="dl-tax-statements ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
-      <div class="tax-description">
-        Note: W-2 Forms will be available the last week of January
-      </div>
 
       <div class="dl-payroll-links">
         <c:if test="${not empty hrsUrls['View 1095-C']}}"

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -33,20 +33,6 @@
       <hrs:notification/>
   </div>
 
-  <div class="dl-payroll-links">
-    <c:if test="${not empty hrsUrls['View 1095-C']}}"
-      <a class="btn btn-primary"
-        href="${hrsUrls['View 1095-C']}"
-        target="_blank" rel="noopener noreferrer">View 1095-C</a>
-    </c:if>
-    <c:if test="${not empty hrsUrls['1095-C Consent']}}"
-      <a class="btn btn-primary"
-        href="${hrsUrls['1095-C Consent']}"
-        target="_blank" rel="noopener noreferrer">
-        Consent to receive 1095-C electronically</a>
-    </c:if>
-  </div>
-
   <div id="${n}dl-tabs" class="dl-tabs ui-tabs ui-widget ui-widget-content ui-corner-all inner-nav-container">
     <ul class="ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all inner-nav">
       <%--
@@ -116,6 +102,21 @@
       <div class="tax-description">
         Note: W-2 Forms will be available the last week of January
       </div>
+
+      <div class="dl-payroll-links">
+        <c:if test="${not empty hrsUrls['View 1095-C']}}"
+          <a class="btn btn-primary"
+            href="${hrsUrls['View 1095-C']}"
+            target="_blank" rel="noopener noreferrer">View 1095-C</a>
+        </c:if>
+        <c:if test="${not empty hrsUrls['1095-C Consent']}}"
+          <a class="btn btn-primary"
+            href="${hrsUrls['1095-C Consent']}"
+            target="_blank" rel="noopener noreferrer">
+            Consent to receive 1095-C electronically</a>
+        </c:if>
+      </div>
+
       <div class="fl-pager">
         <hrs:pagerNavBar position="top" showSummary="${true}" />
         <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -115,7 +115,6 @@
       </div>
 
       <div class="fl-pager">
-        <hrs:pagerNavBar position="top" showSummary="${true}" />
         <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
           <table class="dl-table table" tabindex="0" aria-label="Tax Statement table">
             <thead>


### PR DESCRIPTION
Iff HRS URLs DAO provide URLs for W-2,consent to receive W-2,  1095-C, and consent to receive 1095-C electronically, show those links.

<img width="873" alt="mockup-payroll-info-links-to-tax-stuff-in-hrs" src="https://user-images.githubusercontent.com/952283/46966845-799e4780-d074-11e8-88bc-6578203be3ce.png">


[HRSPLT-363](https://jira.doit.wisc.edu/jira/browse/HRSPLT-363)
