### PR TITLE
HRSPLT-362, HRSPLT-363 fix syntax error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ changing the meaning of `ROLE_VIEW_WEB_CLOCK`.
 
 (No changes yet.)
 
+### 4.1.1
+
+2018-10-15
+
++ Fix syntax error that caused the new Payroll Information links in 4.1.0 not
+  to show.
+
 ### 4.1.0 Payroll Information deep links to tabs and links into HRS
 
 2018-10-15

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -101,23 +101,23 @@
     <div id="${n}dl-tax-statements" class="dl-tax-statements ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
 
       <div class="dl-payroll-links">
-        <c:if test="${not empty hrsUrls['View W-2']}}">
+        <c:if test="${not empty hrsUrls['View W-2']}">
           <a class="btn btn-primary"
             href="${hrsUrls['View W-2']}"
             target="_blank" rel="noopener noreferrer">View W-2</a>
         </c:if>
-        <c:if test="${not empty hrsUrls['W-2 Consent']}}">
+        <c:if test="${not empty hrsUrls['W-2 Consent']}">
           <a class="btn btn-default"
             href="${hrsUrls['W-2 Consent']}"
             target="_blank" rel="noopener noreferrer">
             Consent to receive W-2 electronically</a>
         </c:if>
-        <c:if test="${not empty hrsUrls['View 1095-C']}}">
+        <c:if test="${not empty hrsUrls['View 1095-C']}">
           <a class="btn btn-primary"
             href="${hrsUrls['View 1095-C']}"
             target="_blank" rel="noopener noreferrer">View 1095-C</a>
         </c:if>
-        <c:if test="${not empty hrsUrls['1095-C Consent']}}">
+        <c:if test="${not empty hrsUrls['1095-C Consent']}">
           <a class="btn btn-default"
             href="${hrsUrls['1095-C Consent']}"
             target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
Stray `}` prevent the c:if tests from evaluating to true.