### PR TITLE
HRSPLT-368 add latest_earnings_statement.pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@
 The HRS Portlets 4 major version was occasioned by the breaking change of
 changing the meaning of `ROLE_VIEW_WEB_CLOCK`.
 
-### Unreleased
+### Unreleased (4.2.0)
+
+#### New features in 4.2.0
+
++ Adds Payroll Information resource URL for an employee to download their latest earnings statement.
+  ( [#142][], [HRSPLT-368][] )
+
+#### Fixes in 4.2.0
 
 + Fix Payroll Information table of tax statements to stop offering a sort UI
   control to sort on the name of the statement. Sorting by name is more
@@ -490,9 +497,11 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#132]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/132
 [#137]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/137
 [#141]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/141
+[#142]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/142
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348
 [HRSPLT-362]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-362
 [HRSPLT-363]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-363
 [HRSPLT-365]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-363
+[HRSPLT-368]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-368

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dm/ernstmt/EarningStatementDateComparator.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dm/ernstmt/EarningStatementDateComparator.java
@@ -1,0 +1,45 @@
+package edu.wisc.hr.dm.ernstmt;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+/**
+ * Sorts EarningStatement Java beans by date paid.
+ * N.B. While the domain object here is called EarningStatement, the term is consistently
+ * "earnings statement" or "Earnings Statement" in employee-facing content on Service Center
+ * website.
+ */
+public class EarningStatementDateComparator
+  implements Comparator<EarningStatement> {
+
+  private SimpleDateFormat dateParser = new SimpleDateFormat("MM/dd/yy", Locale.ENGLISH);
+
+  @Override
+  int compare(final EarningStatement earningStatement1, final EarningStatement earningStatement2) {
+    if (null == earningStatement1 || null == earningStatement2) {
+      throw new NullPointerException("Cannot compare null EarningStatement objects.");
+    }
+
+    // extract dates
+    Date earningStatement1Date = parsePaidDate(earningStatement1);
+    Date earningStatement2Date = parsePaidDate(earningStatement2);
+
+    return earningStatement1Date.compareTo(earningStatement2Date);
+  }
+
+
+  private Date parsePaidDate(EarningStatement statement) {
+
+    if (null == statement) {
+      throw new NullPointerException("Cannot parse paid date from null statement");
+    }
+
+    if (null == statement.getPaid()) {
+      throw new NullPointerException("Cannot parse paid date from statement with null paid date.");
+    }
+
+    return dateParser.parse(statement.getPaid());
+  }
+
+}


### PR DESCRIPTION
Add a static URL for downloading the employee's most recent earnings statement, whatever the most recent is at that moment.

Intended use is for hyperlinking statically from the new Payroll Information widget. Also potentially useful in Time and Absence where latest earnings statement referenced.

Temporarily useful, until in 2019 HRS delivers earnings statements.