### PR TITLE
HRSPLT-372 add "View/Update Dependent Information" link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ removing access to the direct deposit and W4 update forms, and with these the
 portlet-preference. (There's no harm in continuing to set this preference; it
 just no longer has any effect.)
 
-### Unreleased
+### Unreleased (5.1.0)
 
-(No changes yet.)
+#### New features in 5.1.0
+
++ Adds "View/Update Dependent Information" link in Benefit Information, as the
+  preferred link that when present replaces the legacy "View Dependent Details"
+  link. The "View/Update Dependent Information" link appears iff the
+  "Dependent/Beneficiary Info" HRS URL is present (and links to that URL). (
+  [#145][], [HRSPLT-372][] )
 
 ### 5.0.0 - remove Direct Deposit and W4 links
 
@@ -521,6 +527,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#142]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/142
 [#143]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/143
 [#144]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/144
+[#145]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/145
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
@@ -165,7 +165,20 @@
       </div>
       <div class="container-fluid row">
         <div class='col-xs-3 col-xs-offset-2'>
-            <a href="${hrsUrls['Dependent Information']}" target="_blank" class="btn btn-default">View Dependent Details</a>
+          <c:choose>
+            <!-- if the new Dependent/Beneficiary Info URL is available,
+              use it -->
+            <c:when test="${not empty hrsUrls['Dependent/Beneficiary Info']}">
+              <a href="${hrsUrls['Dependent/Beneficiary Info']}"
+                target="_blank" rel="noopener noreferer"
+                class="btn btn-default">View/Update Dependent Information</a>
+            </c:when>
+            <!-- otherwise if the old read-only information URL is available,
+              use it -->
+            <c:when test="${not empty hrsUrls['Dependent Information']}">
+                <a href="${hrsUrls['Dependent Information']}" target="_blank" class="btn btn-default">View Dependent Details</a>
+            </c:when>
+          </c:choose>
         </div>
         <div class='col-xs-3 col-xs-offset-1'>
             <a href="${hrsUrls['Dependent Coverage']}" target="_blank" class="btn btn-default">View Dependent Coverage</a>


### PR DESCRIPTION
Iff the new `Dependent/Beneficiary Info` HRS URL is present, replace the existing "View Dependent Details" button with a new "View/Update Dependent Information" button, linking to that new `Dependent/Beneficiary Info` HRS URL.

Otherwise continue to show the legacy "View Dependent Details" button iff the URL it links is provided via the HRS URLs service.

Otherwise show neither link.