### PR TITLE
HRSPLT-376 add "Update your Direct Deposit" button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ portlet-preference. (There's no harm in continuing to set this preference; it
 just no longer has any effect.)
 
 However, in HRS Portlets 5.2 the links to the W4 update form and the direct
-deposit intructions form were restored to service. (Each only appears on a
-single tab withing Payroll Information as of 5.2.)
+deposit intructions form were restored to service, with support for
+`ROLE_VIEW_DIRECT_DEPOSIT` and the `Direct Deposit` URL from the HRS URLs
+DAO. (Each of these links (tax withholdings, direct deposit) only appears on a
+single tab within Payroll Information as of 5.2.)
 
 ### Unreleased (5.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,18 @@ removing access to the direct deposit and W4 update forms, and with these the
 portlet-preference. (There's no harm in continuing to set this preference; it
 just no longer has any effect.)
 
-However, in HRS Portlets 5.2 the link to the W4 update form was restored to
-service.
+However, in HRS Portlets 5.2 the links to the W4 update form and the direct
+deposit intructions form were restored to service. (Each only appears on a
+single tab withing Payroll Information as of 5.2.)
 
 ### Unreleased (5.2.0)
 
++ "Update your Direct Deposit" link added to MyUW Payroll Information, on the
+  "Earnings Statements" tab, since this is the form for adjusting where those
+  earnings are deposited and so employees might expect to find it in an earnings
+  statements context. When the user has `ROLE_VIEW_DIRECT_DEPOSIT` and the HRS
+  URL `Direct Deposit` is present, links to that URL, otherwise links to static
+  PDF form. ( [HRSPLT-376][] )
 + "Update your W4" link added to MyUW Payroll Information, on the "Tax
   Statements" tab since W4 is the form for adjusting tax witholdings and so
   employees might expect to find it in a tax context. ( [#146][],
@@ -565,3 +572,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-370]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-370
 [HRSPLT-371]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-371
 [HRSPLT-375]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-375
+[HRSPLT-376]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-376

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -84,6 +84,18 @@
                   about the widget depending on this role. -->
             </set>
         </entry>
+        <entry key="UW_DYN_PY_DIRDEP_SS">
+          <set>
+              <value>ROLE_VIEW_DIRECT_DEPOSIT</value>
+              <!-- effects
+                In Payroll Information
+                  Changes the href of the Update your Direct Deposit link
+                  to the URL providing by the HRS URLs service for linking into
+                  self-service Direct Deposit editing, rather than linking to
+                  the static PDF form.
+              -->
+          </set>
+        </entry>
         <entry key="UW_DYN_TL_WEB_CLOCK">
             <set>
                 <value>ROLE_VIEW_WEB_CLOCK</value>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -103,10 +103,9 @@
         <sec:authorize ifAnyGranted="ROLE_VIEW_DIRECT_DEPOSIT">
           <!-- Only show the self-service direct deposit link if configured. -->
           <c:choose>
-            <c:when test="${not empty prefs['directDepositSelfServiceUrl']
-              && not empty prefs['directDepositSelfServiceUrl'][0]}">
+            <c:when test="${not empty hrsUrls['Direct Deposit']}">
               <a
-                href="${prefs['directDepositSelfServiceUrl'][0]}"
+                href="${hrsUrls['Direct Deposit']}"
                 target="_blank" rel="noopener noreferrer"
                 class="btn btn-default">
                 Update your Direct Deposit</a>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -97,6 +97,42 @@
             <a href="${understandingEarningUrl}" target="_blank">Understanding Your Earnings Statement</a>
           </div>
       </c:if>
+
+      <div class="dl-link">
+        <!-- show the self-service direct deposit link if authorized-->
+        <sec:authorize ifAnyGranted="ROLE_VIEW_DIRECT_DEPOSIT">
+          <!-- Only show the self-service direct deposit link if configured. -->
+          <c:choose>
+            <c:when test="${not empty prefs['directDepositSelfServiceUrl']
+              && not empty prefs['directDepositSelfServiceUrl'][0]}">
+              <a
+                href="${prefs['directDepositSelfServiceUrl'][0]}"
+                target="_blank" rel="noopener noreferrer"
+                class="btn btn-default">
+                Update your Direct Deposit</a>
+            </c:when>
+            <c:otherwise>
+              <!-- even if authorized for self-service, if that URL is not set
+                fall back on the PDF form. -->
+              <a
+                href="https://uwservice.wisc.edu/docs/forms/pay-direct-deposit.pdf"
+                target="_blank" rel="noopener noreferrer"
+                class="btn btn-default">
+                Update your Direct Deposit</a>
+            </c:otherwise>
+          </c:choose>
+        </sec:authorize>
+        <sec:authorize ifNotGranted="ROLE_VIEW_DIRECT_DEPOSIT">
+          <!-- show the link to the PDF form
+          if not authorized for self-service -->
+          <a
+            href="https://uwservice.wisc.edu/docs/forms/pay-direct-deposit.pdf"
+            target="_blank" rel="noopener noreferrer"
+            class="btn btn-default">
+            Update your Direct Deposit</a>
+        </sec:authorize>
+      </div>
+
     </div>
     <div id="${n}dl-tax-statements" class="dl-tax-statements ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
 


### PR DESCRIPTION
Restore button, this time 

+ confined to just the Earnings Statements tab of Payroll Information
+ linking only the hard coded URL to the static PDF form, or to the `Direct Deposit` URL read from HRS URLs if that's defined AND the employee has the role required to access it. That is, does not restore the feature whereby that URL could be set via `portlet-preference`.