### PR TITLE
HRSPLT-377 replace leave balances with link to "Classic ESS Abs Bal"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ it sources its URL from the HRS URLs web service.
 
 ### (Unreleased) (5.3.0?)
 
++ Prefer to link new HRS URL `Classic ESS Abs Bal` rather than display leave
+  balances directly on "Leave Balances" tab in "Time and Absence" (
+  [HRSPLT-377][] , [#148][])
 + Add new `Garnishments/Wage Assignments` link in Payroll Information -->
   Earnings Statements tab, to new HRS URL `Fluid Garnishments`, conditioned on
   that `Fluid Garnishments` URL being set and the viewing employee having
@@ -581,6 +584,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#145]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/145
 [#146]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/146
 [#147]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/147
+[#148]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/148
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348
@@ -592,5 +596,6 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-371]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-371
 [HRSPLT-375]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-375
 [HRSPLT-376]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-376
+[HRSPLT-377]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-377
 [HRSPLT-378]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-378
 [HRSPLT-379]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-379

--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ this hour limiting policy applies to them.)
 + Configures the href of the "Unclassified Leave Report" link.
 + If not set, this link will still appear but will be broken.
 
+#### `dynamicLeaveBalancesLearnMoreUrl` portlet preference (optional)
+
++ Configures the href of the "Learn more about dynamic leave balances" link.
++ If not set, this link will be hidden.
+
 ## JSON resource URLs
 
 (Not a comprehensive listing.)

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -192,6 +192,7 @@
          <c:when test="${not empty hrsUrls['Classic ESS Abs Bal']}">
           <p>
             <a href="${hrsUrls['Classic ESS Abs Bal']}"
+              class="btn btn-primary"
               target="_blank" rel="noopener noreferrer">
               View leave balances
             </a>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -190,12 +190,18 @@
     <div id="${n}dl-leave-balance" class="dl-leave-balance ui-tabs-panel ui-widget-content ui-corner-bottom ${hiddenTabStyle}">
        <c:choose>
          <c:when test="${not empty hrsUrls['Classic ESS Abs Bal']}">
-          <p>
+          <div>
             <a href="${hrsUrls['Classic ESS Abs Bal']}"
               class="btn btn-primary"
               target="_blank" rel="noopener noreferrer">
               View leave balances
             </a>
+          </div>
+          <p>
+            Leave balances are now at hrs.wisconsin.edu.  New in HRS: view
+            balances as of your most recent earnings statement and anticipated
+            balances that are not yet reflected in your earnings statement,
+            called dynamic leave balances.
           </p>
          </c:when>
          <c:otherwise>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -202,6 +202,11 @@
             balances as of your most recent earnings statement and anticipated
             balances that are not yet reflected in your earnings statement,
             called dynamic leave balances.
+            <c:if
+              test="${not empty prefs['dynamicLeaveBalancesLearnMoreUrl'] && not empty prefs['dynamicLeaveBalancesLearnMoreUrl'][0]}">
+              <a href="prefs['dynamicLeaveBalancesLearnMoreUrl'][0]">
+                  Learn more about dynamic leave balances</a>.
+            </c:if>
           </p>
          </c:when>
          <c:otherwise>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -188,35 +188,47 @@
       </div>
     </sec:authorize>
     <div id="${n}dl-leave-balance" class="dl-leave-balance ui-tabs-panel ui-widget-content ui-corner-bottom ${hiddenTabStyle}">
-      <div class="balance-header">
-        <span>Leave balances are also available on your current Earnings Statement.</span>
-      </div>
-      <div class="fl-pager">
-        <hrs:pagerNavBar position="top" showSummary="${true}" />
-        <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
-          <table class="dl-table table" tabindex="0" aria-label="Leave balance detail table">
-            <thead>
-              <tr rsf:id="header:">
-                <th scope="col" class="flc-pager-sort-header" rsf:id="entitlement"><a href="javascript:;">Entitlement</a></th>
-                <th scope="col" class="flc-pager-sort-header" rsf:id="balance"><a href="javascript:;">Balance</a></th>
-                <c:if test="${showJobTitle}">
-                  <th scope="col" class="flc-pager-sort-header" rsf:id="title"><a href="javascript:;">Job Title</a></th>
-                </c:if>
-              </tr>
-            </thead>
-            <tbody>
-                <tr rsf:id="row:">
-                  <td headers="entitlement" class="dl-data-text"><span rsf:id="entitlement"></span></td>
-                  <td headers="balance" class="dl-data-number"><span rsf:id="balance"></span></td>
-                  <c:if test="${showJobTitle}">
-                    <td headers="title" class="dl-data-text"><span rsf:id="title"></span></td>
-                  </c:if>
-                </tr>
-            </tbody>
-          </table>
-        </div>
-        <hrs:pagerNavBar position="bottom" />
-      </div>
+       <c:choose>
+         <c:when test="${not empty hrsUrls['Classic ESS Abs Bal']}">
+          <p>
+            <a href="${hrsUrls['Classic ESS Abs Bal']}"
+              target="_blank" rel="noopener noreferrer">
+              View leave balances
+            </a>
+          </p>
+         </c:when>
+         <c:otherwise>
+            <div class="balance-header">
+                <span>Leave balances are also available on your current Earnings Statement.</span>
+              </div>
+              <div class="fl-pager">
+                <hrs:pagerNavBar position="top" showSummary="${true}" />
+                <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
+                  <table class="dl-table table" tabindex="0" aria-label="Leave balance detail table">
+                    <thead>
+                      <tr rsf:id="header:">
+                        <th scope="col" class="flc-pager-sort-header" rsf:id="entitlement"><a href="javascript:;">Entitlement</a></th>
+                        <th scope="col" class="flc-pager-sort-header" rsf:id="balance"><a href="javascript:;">Balance</a></th>
+                        <c:if test="${showJobTitle}">
+                          <th scope="col" class="flc-pager-sort-header" rsf:id="title"><a href="javascript:;">Job Title</a></th>
+                        </c:if>
+                      </tr>
+                    </thead>
+                    <tbody>
+                        <tr rsf:id="row:">
+                          <td headers="entitlement" class="dl-data-text"><span rsf:id="entitlement"></span></td>
+                          <td headers="balance" class="dl-data-number"><span rsf:id="balance"></span></td>
+                          <c:if test="${showJobTitle}">
+                            <td headers="title" class="dl-data-text"><span rsf:id="title"></span></td>
+                          </c:if>
+                        </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <hrs:pagerNavBar position="bottom" />
+              </div>
+         </c:otherwise>
+       </c:choose>
     </div>
     <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY">
       <div id="${n}dl-time-entry" class="dl-time-entry ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">


### PR DESCRIPTION
iff `Classic ESS Abs Bal` HRS URL defined replace the table of stale leave balances with link to this fresh new UI.

If `Classic ESS Abs Bal` not defined continue status quo experience.

Downside: buries leave balances another click away for employees.
Upside: the leave balances table the employee eventually gets to may have fresher data in that it can consider changes since the employee's most recent earnings statement was issued.

Optionally, set a (documented!) `portlet-preference` with a URL to learn more to include a "Learn more about dynamic leave balances" link.

Before:

![before-leave-balances-as-stale-table](https://user-images.githubusercontent.com/952283/47733867-2f51c480-dc37-11e8-9cc7-1e6b8a06a174.png)

After:

![after-leave-balances-as-supported-link](https://user-images.githubusercontent.com/952283/47733782-fc0f3580-dc36-11e8-916b-da291c56fb55.png)


Credit to @mrdahman for input on the supporting text, UI, the learn more link feature.
