### PR TITLE
HRSPLT-384 employees lacking `UW_DYN_AM_Employee` continue to see Leave Balances table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -653,3 +653,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-379]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-379
 [HRSPLT-381]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-381
 [HRSPLT-382]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-382
+[HRSPLT-384]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-384

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ it sources its URL from the HRS URLs web service.
   This is moot for employees also holding `ROLE_REDIRECT_TO_HRS_FLUID_TIME`
   iff the `Fluid Time` HRS URL is set, since they'll be redirected to HRS
   self-service `Fluid Time` anyway. ( [HRSPLT-384][], [#152][] )
-+ New buttion "View Leave Balances" in Time and Absence, implementing that link
++ New button "View Leave Balances" in Time and Absence, implementing that link
   to `Classic ESS Abs Bal`, and predicated on that URL being defined. This
   replaces the button and supporting text that had been included in the Leave
   Balances tab when `Classic ESS Abs Bal` was defined, as of 5.3.0. (

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ it sources its URL from the HRS URLs web service.
   this role continue to see leave balances as of their most recent earnings
   statement directly included in the "Leave Balances" tab in "Time and Absence".
   ( [HRSPLT-384][], [#152][] )
++ Adjusted supporting text on Leave Balances tab to no longer set expectation
+  as to whether earnings statements include leave balances, while continuting to
+  clarify as of when the leave balances shown in the table are current.
+  Enhanced with optional link to the corresponding Payroll Information iff a new
+  `portlet-preference` `payrollInformationFName` is set. ( [HRSPLT-384][],
+  [#152][] )
+
 
 #### Removed features in 5.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,37 @@ it sources its URL from the HRS URLs web service.
 
 (No changes yet)
 
+#### New features in 5.5.0
+
++ Predicate the preference for the link to `Classic ESS Abs Bal` introduced in
+  hrs-portlets 5.3.0 upon the employee holding a newly invented hrs-portlets
+  role `ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL`. If the employee does not hold this
+  role, show the status quo leave balances table.
+  This is moot for employees also holding `ROLE_REDIRECT_TO_HRS_FLUID_TIME`
+  iff the `Fluid Time` HRS URL is set, since they'll be redirected to HRS
+  self-service `Fluid Time` anyway. ( [HRSPLT-384][] )
++ New buttion "View Leave Balances" in Time and Absence, implementing that link
+  to `Classic ESS Abs Bal`, and predicated on that URL being defined. This
+  replaces the button and supporting text that had been included in the Leave
+  Balances tab when `Classic ESS Abs Bal` was defined, as of 5.3.0. (
+  [HRSPLT-384][] )
++ Map from HRS role `UW_DYN_AM_Employee` to newly invented hrs-portlets role
+  `ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL`. That is, the HRS role `UW_DYN_AM_EMPLOYEE`
+  is required to see the new link to `Classic ESS Abs Bal`. Employees lacking
+  this role continue to see leave balances as of their most recent earnings
+  statement directly included in the "Leave Balances" tab in "Time and Absence".
+  ( [HRSPLT-384][] )
+
+#### Removed features in 5.5.0
+
++ Employees with new `ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL` will no longer see the
+  Leave Balances tab in Time and Absence, so long as that role was actualized by
+  the URL for that link being set so the button rendered. ( [HRSPLT-384][] )
++ The portlet-preference `dynamicLeaveBalancesLearnMoreUrl` introduced in 5.3.0
+  to optionally define a supporting link for learning more about dynamic leave
+  balances no longer has any effect, since the explanatory text it had been
+  supporting has been removed from the UI. ( [HRSPLT-384][] )
+
 ### 5.4.0 - redirect UW_DYN_AM_ESS_FLU_MONTHLY to Fluid Time
 
 2018-11-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,28 +29,29 @@ it sources its URL from the HRS URLs web service.
   role, show the status quo leave balances table.
   This is moot for employees also holding `ROLE_REDIRECT_TO_HRS_FLUID_TIME`
   iff the `Fluid Time` HRS URL is set, since they'll be redirected to HRS
-  self-service `Fluid Time` anyway. ( [HRSPLT-384][] )
+  self-service `Fluid Time` anyway. ( [HRSPLT-384][], [#152][] )
 + New buttion "View Leave Balances" in Time and Absence, implementing that link
   to `Classic ESS Abs Bal`, and predicated on that URL being defined. This
   replaces the button and supporting text that had been included in the Leave
   Balances tab when `Classic ESS Abs Bal` was defined, as of 5.3.0. (
-  [HRSPLT-384][] )
+  [HRSPLT-384][], [#152][] )
 + Map from HRS role `UW_DYN_AM_Employee` to newly invented hrs-portlets role
   `ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL`. That is, the HRS role `UW_DYN_AM_EMPLOYEE`
   is required to see the new link to `Classic ESS Abs Bal`. Employees lacking
   this role continue to see leave balances as of their most recent earnings
   statement directly included in the "Leave Balances" tab in "Time and Absence".
-  ( [HRSPLT-384][] )
+  ( [HRSPLT-384][], [#152][] )
 
 #### Removed features in 5.5.0
 
 + Employees with new `ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL` will no longer see the
   Leave Balances tab in Time and Absence, so long as that role was actualized by
-  the URL for that link being set so the button rendered. ( [HRSPLT-384][] )
+  the URL for that link being set so the button rendered. ( [HRSPLT-384][],
+  [#152][] )
 + The portlet-preference `dynamicLeaveBalancesLearnMoreUrl` introduced in 5.3.0
   to optionally define a supporting link for learning more about dynamic leave
   balances no longer has any effect, since the explanatory text it had been
-  supporting has been removed from the UI. ( [HRSPLT-384][] )
+  supporting has been removed from the UI. ( [HRSPLT-384][], [#152][] )
 
 ### 5.4.0 - redirect UW_DYN_AM_ESS_FLU_MONTHLY to Fluid Time
 
@@ -637,6 +638,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#148]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/148
 [#149]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/149
 [#150]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/150
+[#152]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/152
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/README.md
+++ b/README.md
@@ -168,6 +168,13 @@ this hour limiting policy applies to them.)
 + Configures the href of the "Unclassified Leave Report" link.
 + If not set, this link will still appear but will be broken.
 
+#### `payrollInformationFName` (optional)
+
++ If set, Time and Absence links to the relevant Payroll Information to ease
+  employee navigation to take a look at what earnings statement the leave
+  balances is as of.
++ If not set, Time and Absence suppresses this hyperlink, no worries.
+
 ## JSON resource URLs
 
 (Not a comprehensive listing.)

--- a/README.md
+++ b/README.md
@@ -168,11 +168,6 @@ this hour limiting policy applies to them.)
 + Configures the href of the "Unclassified Leave Report" link.
 + If not set, this link will still appear but will be broken.
 
-#### `dynamicLeaveBalancesLearnMoreUrl` portlet preference (optional)
-
-+ Configures the href of the "Learn more about dynamic leave balances" link.
-+ If not set, this link will be hidden.
-
 ## JSON resource URLs
 
 (Not a comprehensive listing.)

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -63,6 +63,14 @@
                     Show the Enter Absence link
                     Show the Edit Cancel Absence link, if link is configured
                 -->
+                <value>ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL</value>
+                <!--
+                  In Time and Absence
+                    Prefer to show a link to `Classic ESS Abs Bal`
+                      instead of the  `Leave Balances` tab and its table of
+                      leave balances as of the most recent earnings statement,
+                      iff `Classic ESS Abs Bal` is set.
+                -->
             </set>
         </entry>
         <entry key="UW_DYN_AM_ESS_FLU_MONTHLY">

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeAbsenceController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeAbsenceController.java
@@ -19,6 +19,10 @@
 
 package edu.wisc.portlet.hrs.web.timeabs;
 
+import edu.wisc.hr.dao.roles.HrsRolesDao;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
 
@@ -43,9 +47,16 @@ import edu.wisc.portlet.hrs.web.HrsControllerBase;
 public class TimeAbsenceController extends HrsControllerBase {
     private ContactInfoDao contactInfoDao;
 
+    private HrsRolesDao rolesDao;
+
     @Autowired
     public void setContactInfoDao(ContactInfoDao contactInfoDao) {
         this.contactInfoDao = contactInfoDao;
+    }
+
+    @Autowired
+    public void setRolesDao(HrsRolesDao hrsRolesDao) {
+      this.rolesDao = hrsRolesDao;
     }
 
     @ModelAttribute("dynPunchTimesheetNotice")
@@ -94,6 +105,29 @@ public class TimeAbsenceController extends HrsControllerBase {
         final PortletPreferences preferences = request.getPreferences();
 
         return preferences.getValue("nonDynPunchTimesheetNotification", null);
+    }
+
+    /**
+     * Map from names of hrs-portlets roles held by the employee to the Boolean
+     * True indicating the employee holds the role. Useful for including roles * in conditional logic that considers things other than roles as well, so,
+     * more flexible than the sec authorize JSP tag.
+     *
+     * MAP DOES NOT CONTAIN ROLES NOT HELD BY EMPLOYEES. So it is important to
+     * check for the presence of a key, not just the value for a key.
+     */
+    @ModelAttribute("employeeRoles")
+    public final Map<String, Boolean> getEmployeeRoles(){
+
+      Map<String, Boolean> employeeRoles = new HashMap<String, Boolean>();
+
+      final String emplid  = PrimaryAttributeUtils.getPrimaryId();
+      Set<String> rolesHeldByEmployee = this.rolesDao.getHrsRoles(emplid);
+
+      for (String roleHeldByEmployee : rolesHeldByEmployee) {
+        employeeRoles.put(roleHeldByEmployee, Boolean.TRUE);
+      }
+
+      return employeeRoles;
     }
 
     @RequestMapping

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeAbsenceController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/timeabs/TimeAbsenceController.java
@@ -109,7 +109,8 @@ public class TimeAbsenceController extends HrsControllerBase {
 
     /**
      * Map from names of hrs-portlets roles held by the employee to the Boolean
-     * True indicating the employee holds the role. Useful for including roles * in conditional logic that considers things other than roles as well, so,
+     * True indicating the employee holds the role. Useful for including roles
+     * in conditional logic that considers things other than roles as well, so,
      * more flexible than the sec authorize JSP tag.
      *
      * MAP DOES NOT CONTAIN ROLES NOT HELD BY EMPLOYEES. So it is important to

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -244,28 +244,6 @@
     <c:if test="empty hrsUrls['Classic ESS Abs Bal']
       || empty employeeRoles['ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL']">
     <div id="${n}dl-leave-balance" class="dl-leave-balance ui-tabs-panel ui-widget-content ui-corner-bottom ${hiddenTabStyle}">
-       <c:choose>
-         <c:when test="${not empty hrsUrls['Classic ESS Abs Bal']}">
-          <div>
-            <a href="${hrsUrls['Classic ESS Abs Bal']}"
-              class="btn btn-primary"
-              target="_blank" rel="noopener noreferrer">
-              View leave balances
-            </a>
-          </div>
-          <p>
-            Leave balances are now at hrs.wisconsin.edu.  New in HRS: view
-            balances as of your most recent earnings statement and anticipated
-            balances that are not yet reflected in your earnings statement,
-            called dynamic leave balances.
-            <c:if
-              test="${not empty prefs['dynamicLeaveBalancesLearnMoreUrl'] && not empty prefs['dynamicLeaveBalancesLearnMoreUrl'][0]}">
-              <a href="prefs['dynamicLeaveBalancesLearnMoreUrl'][0]">
-                  Learn more about dynamic leave balances</a>.
-            </c:if>
-          </p>
-         </c:when>
-         <c:otherwise>
             <div class="balance-header">
                 <span>Leave balances are also available on your current Earnings Statement.</span>
               </div>
@@ -295,8 +273,6 @@
                 </div>
                 <hrs:pagerNavBar position="bottom" />
               </div>
-         </c:otherwise>
-       </c:choose>
     </div>
     </c:if>
     <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -259,7 +259,8 @@
 
       <div class="balance-header">
         <c:choose>
-          <c:when test="${prefs['payrollInformationFName'] && prefs['payrollInformationFName'][0]}">
+          <c:when test="${not empty prefs['payrollInformationFName']
+            && not empty prefs['payrollInformationFName'][0]}">
             <span>These leave balances are as of your most recent Earnings Statement in
               <a href="/web/exclusive/${prefs['payrollInformationFName'][0]}">
                 Payroll Information</a>.</span>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -258,7 +258,17 @@
       <c:set var="hiddenTabStyle" value="ui-tabs-hide"/>
 
       <div class="balance-header">
-        <span>These Leave balances are as of your most recent Earnings Statement.</span>
+        <c:choose>
+          <c:when test="${prefs['payrollInformationFName'] && prefs['payrollInformationFName'][0]}">
+            <span>These Leave balances are as of your most recent Earnings Statement in
+              <a href="/web/exclusive/${prefs['payrollInformationFName'][0]}">
+                Payroll Information</a>.</span>
+          </c:when>
+          <c:otherwise>
+            <span>These Leave balances are as of your most recent Earnings Statement.</span>
+          </c:otherwise>
+        </c:choose>
+
       </div>
       <div class="fl-pager">
         <hrs:pagerNavBar position="top" showSummary="${true}" />

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -117,7 +117,10 @@
       <div class="dl-link">
         <a class="btn btn-primary" href="${hrsUrls['Request Absence']}" target="_blank">Enter Absence</a>
       </div>
+    </sec:authorize>
 
+
+    <sec:authorize ifAnyGranted="ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES">
       <c:if test="${not empty prefs['editCancelAbsenceUrl']
         && not empty prefs['editCancelAbsenceUrl'][0]}">
         <div class="dl-link">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -179,8 +179,8 @@
         <c:set var="activeTabStyle" value=""/>
       </sec:authorize>
 
-      <c:if test="empty hrsUrls['Classic ESS Abs Bal']
-      || empty employeeRoles['ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL']">
+      <c:if test="${empty hrsUrls['Classic ESS Abs Bal']
+      || empty employeeRoles['ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL']}">
         <li class="ui-state-default ui-corner-top ${activeTabStyle}">
           <a href="#${n}dl-leave-balance">Leave Balances</a></li>
           <c:set var="activeTabStyle" value=""/>
@@ -249,8 +249,8 @@
       This is the opposite logic of that above to decide whether to include the
       `View Leave Balances` button.
     --%>
-    <c:if test="empty hrsUrls['Classic ESS Abs Bal']
-      || empty employeeRoles['ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL']">
+    <c:if test="${empty hrsUrls['Classic ESS Abs Bal']
+      || empty employeeRoles['ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL']}">
     <div id="${n}dl-leave-balance" class="dl-leave-balance ui-tabs-panel ui-widget-content ui-corner-bottom ${hiddenTabStyle}">
 
       <!-- style subsequent panels as hidden

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -260,12 +260,12 @@
       <div class="balance-header">
         <c:choose>
           <c:when test="${prefs['payrollInformationFName'] && prefs['payrollInformationFName'][0]}">
-            <span>These Leave balances are as of your most recent Earnings Statement in
+            <span>These leave balances are as of your most recent Earnings Statement in
               <a href="/web/exclusive/${prefs['payrollInformationFName'][0]}">
                 Payroll Information</a>.</span>
           </c:when>
           <c:otherwise>
-            <span>These Leave balances are as of your most recent Earnings Statement.</span>
+            <span>These leave balances are as of your most recent Earnings Statement.</span>
           </c:otherwise>
         </c:choose>
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -178,7 +178,13 @@
         <li class="ui-state-default ui-corner-top ${activeTabStyle}"><a href="#${n}dl-absence">Absence</a></li>
         <c:set var="activeTabStyle" value=""/>
       </sec:authorize>
-      <li class="ui-state-default ui-corner-top ${activeTabStyle}"><a href="#${n}dl-leave-balance">Leave Balances</a></li>
+
+      <c:if test="empty hrsUrls['Classic ESS Abs Bal']
+      || empty employeeRoles['ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL']">
+        <li class="ui-state-default ui-corner-top ${activeTabStyle}">
+          <a href="#${n}dl-leave-balance">Leave Balances</a></li>
+      </c:if>
+
       <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY">
         <li class="ui-state-default ui-corner-top"><a href="#${n}dl-time-entry">Time Entry</a></li>
       </sec:authorize>
@@ -222,6 +228,21 @@
         </div>
       </div>
     </sec:authorize>
+
+
+    <%-- There are two reasons the Leave Balances tab will be included in an
+      employee experience of Time and Absence. Either reason will do.
+      1. The HRS URL `Classic ESS Abs Bal` is not defined, and so Time and Absence would not know how to link the employee to the new implementation of leave balances anyway. OR
+      2. The employee lacks ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL
+
+      This is the identical logic (`test`) of that above for deciding whether to
+      include the Leave Balances tab label among the tab label list items.
+
+      This is the opposite logic of that above to decide whether to include the
+      `View Leave Balances` button.
+    --%>
+    <c:if test="empty hrsUrls['Classic ESS Abs Bal']
+      || empty employeeRoles['ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL']">
     <div id="${n}dl-leave-balance" class="dl-leave-balance ui-tabs-panel ui-widget-content ui-corner-bottom ${hiddenTabStyle}">
        <c:choose>
          <c:when test="${not empty hrsUrls['Classic ESS Abs Bal']}">
@@ -277,6 +298,7 @@
          </c:otherwise>
        </c:choose>
     </div>
+    </c:if>
     <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY">
       <div id="${n}dl-time-entry" class="dl-time-entry ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
         <div class="fl-pager">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -244,35 +244,35 @@
     <c:if test="empty hrsUrls['Classic ESS Abs Bal']
       || empty employeeRoles['ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL']">
     <div id="${n}dl-leave-balance" class="dl-leave-balance ui-tabs-panel ui-widget-content ui-corner-bottom ${hiddenTabStyle}">
-            <div class="balance-header">
-                <span>Leave balances are also available on your current Earnings Statement.</span>
-              </div>
-              <div class="fl-pager">
-                <hrs:pagerNavBar position="top" showSummary="${true}" />
-                <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
-                  <table class="dl-table table" tabindex="0" aria-label="Leave balance detail table">
-                    <thead>
-                      <tr rsf:id="header:">
-                        <th scope="col" class="flc-pager-sort-header" rsf:id="entitlement"><a href="javascript:;">Entitlement</a></th>
-                        <th scope="col" class="flc-pager-sort-header" rsf:id="balance"><a href="javascript:;">Balance</a></th>
-                        <c:if test="${showJobTitle}">
-                          <th scope="col" class="flc-pager-sort-header" rsf:id="title"><a href="javascript:;">Job Title</a></th>
-                        </c:if>
-                      </tr>
-                    </thead>
-                    <tbody>
-                        <tr rsf:id="row:">
-                          <td headers="entitlement" class="dl-data-text"><span rsf:id="entitlement"></span></td>
-                          <td headers="balance" class="dl-data-number"><span rsf:id="balance"></span></td>
-                          <c:if test="${showJobTitle}">
-                            <td headers="title" class="dl-data-text"><span rsf:id="title"></span></td>
-                          </c:if>
-                        </tr>
-                    </tbody>
-                  </table>
-                </div>
-                <hrs:pagerNavBar position="bottom" />
-              </div>
+      <div class="balance-header">
+        <span>Leave balances are also available on your current Earnings Statement.</span>
+      </div>
+      <div class="fl-pager">
+        <hrs:pagerNavBar position="top" showSummary="${true}" />
+        <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
+          <table class="dl-table table" tabindex="0" aria-label="Leave balance detail table">
+            <thead>
+              <tr rsf:id="header:">
+                <th scope="col" class="flc-pager-sort-header" rsf:id="entitlement"><a href="javascript:;">Entitlement</a></th>
+                <th scope="col" class="flc-pager-sort-header" rsf:id="balance"><a href="javascript:;">Balance</a></th>
+                <c:if test="${showJobTitle}">
+                  <th scope="col" class="flc-pager-sort-header" rsf:id="title"><a href="javascript:;">Job Title</a></th>
+                </c:if>
+              </tr>
+            </thead>
+            <tbody>
+              <tr rsf:id="row:">
+                <td headers="entitlement" class="dl-data-text"><span rsf:id="entitlement"></span></td>
+                <td headers="balance" class="dl-data-number"><span rsf:id="balance"></span></td>
+                <c:if test="${showJobTitle}">
+                  <td headers="title" class="dl-data-text"><span rsf:id="title"></span></td>
+                </c:if>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <hrs:pagerNavBar position="bottom" />
+      </div>
     </div>
     </c:if>
     <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -193,6 +193,7 @@
       <li class="ui-state-default ui-corner-top ${activeTabStyle}"><a href="#${n}dl-absence-statements">Leave Reports</a></li>
       <c:set var="activeTabStyle" value=""/>
     </ul>
+
     <c:set var="hiddenTabStyle" value=""/>
     <sec:authorize ifAllGranted="ROLE_VIEW_ABSENCE_HISTORIES">
       <c:set var="hiddenTabStyle" value="ui-tabs-hide"/>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -119,6 +119,15 @@
       </div>
     </sec:authorize>
 
+    <sec:authorize ifAnyGranted="ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL">
+      <c:if test="${not empty hrsUrls['Classic ESS Abs Bal']}">
+        <div class="dl-link">
+          <a class="btn btn-primary" href="${hrsUrls['Classic ESS Abs Bal']}"
+            target="_blank" rel="noopener noreferrer">
+            View Leave Balances</a>
+        </div>
+      </c:if>
+    </sec:authorize>
 
     <sec:authorize ifAnyGranted="ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES">
       <c:if test="${not empty prefs['editCancelAbsenceUrl']

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -190,7 +190,8 @@
         <li class="ui-state-default ui-corner-top ${activeTabStyle}"><a href="#${n}dl-time-entry">Time Entry</a></li>
         <c:set var="activeTabStyle" value=""/>
       </sec:authorize>
-      <li class="ui-state-default ui-corner-top"><a href="#${n}dl-absence-statements">Leave Reports</a></li>
+      <li class="ui-state-default ui-corner-top ${activeTabStyle}"><a href="#${n}dl-absence-statements">Leave Reports</a></li>
+      <c:set var="activeTabStyle" value=""/>
     </ul>
     <c:set var="hiddenTabStyle" value=""/>
     <sec:authorize ifAllGranted="ROLE_VIEW_ABSENCE_HISTORIES">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -183,10 +183,12 @@
       || empty employeeRoles['ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL']">
         <li class="ui-state-default ui-corner-top ${activeTabStyle}">
           <a href="#${n}dl-leave-balance">Leave Balances</a></li>
+          <c:set var="activeTabStyle" value=""/>
       </c:if>
 
       <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY">
-        <li class="ui-state-default ui-corner-top"><a href="#${n}dl-time-entry">Time Entry</a></li>
+        <li class="ui-state-default ui-corner-top ${activeTabStyle}"><a href="#${n}dl-time-entry">Time Entry</a></li>
+        <c:set var="activeTabStyle" value=""/>
       </sec:authorize>
       <li class="ui-state-default ui-corner-top"><a href="#${n}dl-absence-statements">Leave Reports</a></li>
     </ul>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -196,7 +196,11 @@
 
     <c:set var="hiddenTabStyle" value=""/>
     <sec:authorize ifAllGranted="ROLE_VIEW_ABSENCE_HISTORIES">
+
+      <!-- style subsequent panels as hidden
+        because this was the default active tab-->
       <c:set var="hiddenTabStyle" value="ui-tabs-hide"/>
+
       <div id="${n}dl-absence" class="dl-absence ui-tabs-panel ui-widget-content ui-corner-bottom">
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />
@@ -248,6 +252,11 @@
     <c:if test="empty hrsUrls['Classic ESS Abs Bal']
       || empty employeeRoles['ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL']">
     <div id="${n}dl-leave-balance" class="dl-leave-balance ui-tabs-panel ui-widget-content ui-corner-bottom ${hiddenTabStyle}">
+
+      <!-- style subsequent panels as hidden
+        if this was the default active tab-->
+      <c:set var="hiddenTabStyle" value="ui-tabs-hide"/>
+
       <div class="balance-header">
         <span>Leave balances are also available on your current Earnings Statement.</span>
       </div>
@@ -279,8 +288,14 @@
       </div>
     </div>
     </c:if>
+
     <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY">
-      <div id="${n}dl-time-entry" class="dl-time-entry ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
+      <div id="${n}dl-time-entry" class="dl-time-entry ui-tabs-panel ui-widget-content ui-corner-bottom ${hiddenTabStyle}">
+
+      <!-- style subsequent panels as hidden
+        if this was the default active tab-->
+        <c:set var="hiddenTabStyle" value="ui-tabs-hide"/>
+
         <div class="fl-pager">
           <hrs:pagerNavBar position="top" showSummary="${true}" />
           <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
@@ -320,7 +335,13 @@
         </div>
       </div>
     </sec:authorize>
-    <div id="${n}dl-absence-statements" class="dl-absence-statements ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
+
+    <div id="${n}dl-absence-statements" class="dl-absence-statements ui-tabs-panel ui-widget-content ui-corner-bottom ${hiddenTabStyle}">
+
+      <!-- style subsequent panels as hidden
+        if this was the default active tab -->
+        <c:set var="hiddenTabStyle" value="ui-tabs-hide"/>
+
       <div id="${n}dl-leave-statements">
       	<p class="padded-paragraph">
           <a id="${n}oustandingMissingLeaveReports" style="display: none;" target="_blank" ng-href="#" class="btn btn-default">My Unsubmitted Reports</a>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -258,7 +258,7 @@
       <c:set var="hiddenTabStyle" value="ui-tabs-hide"/>
 
       <div class="balance-header">
-        <span>Leave balances are also available on your current Earnings Statement.</span>
+        <span>These Leave balances are as of your most recent Earnings Statement.</span>
       </div>
       <div class="fl-pager">
         <hrs:pagerNavBar position="top" showSummary="${true}" />


### PR DESCRIPTION
It turns out there are some employees (like me!) who cannot see leave balances in HRS self-service, because we are not dynamic absence management employees. In these cases the leave balances printed on earnings statements and the leave balance table shown in MyUW Time and Absence is the employee's only way to self-service review leave balances. Linking the new in-HRS-self-service page for leave balances won't work.

So predicate on HRS role `UW_DYN_AM_Employee` the `5.3.0` change to replace the table in the "Leave Balances" tab of "TIme and Absence" with a link into HRS self-service.

Further, change to more literally implement the provided mockup, adding the "View Leave Balances" button between the "Enter Absence" and "Edit/Cancel Absence" buttons as requested and suppressing the "Leave Balances" tab for employees who see the new "View Leave Balances" button.

Implements this mockup:

<img width="1107" alt="view-leave-balances-button-request" src="https://user-images.githubusercontent.com/952283/48040663-7eb85900-e13f-11e8-81f9-d750953b39ee.png">

Updated text clarifying when the leave balances table entries are current as of, with optional link to Payroll Information to go look at that latest earnings statement.

<img width="889" alt="updated-leave-balance-table-supporting-text" src="https://user-images.githubusercontent.com/952283/48043838-600d8e80-e14e-11e8-96db-5786df889768.png">

