### PR TITLE
HRSPLT-386 Cue leave balances in Payroll Information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ it sources its URL from the HRS URLs web service.
 
 #### New features in 5.5.0
 
++ Add supporting text in Payroll Information cueing visiting Time and Absence to
+  view leave balances, since leave balances will no longer be available on
+  earnings statements starting in 2019. If the optional `portlet-preference`
+  `timeAndAbsenceFName` is set, this supporting text includes a hyperlink easing
+  employee navigation to Time and Absence. ( [HRSPLT-386][] )
 + Predicate the preference for the link to `Classic ESS Abs Bal` introduced in
   hrs-portlets 5.3.0 upon the employee holding a newly invented hrs-portlets
   role `ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL`. If the employee does not hold this
@@ -663,3 +668,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-381]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-381
 [HRSPLT-382]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-382
 [HRSPLT-384]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-384
+[HRSPLT-386]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-386

--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ This is intended as a solution for
 + When set, configures the href of the "Understanding Your Earnings Statement" link.
 + When not set, the link does not display.
 
+#### `timeAndAbsenceFName` portlet preference (optional)
+
++ When set, allows "Payroll Information" to include a hyperlink to the
+  corresponding "Time and Absence" to ease employee navigating to check on leave
+  balances, since leave balances will no longer be available in earnings
+  statements starting in 2019. When not set, the supporting text that explains
+  that leave balances are only available in Time and Absence and no longer on
+  earnings statements themselves does not include a convenient hyperlink.
+
 ### Specific to Personal Information
 
 While branded as "Personal Information" as published in MyUW,

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -66,7 +66,18 @@
         <div class="data-table-description"
           style="color:black;">
           2019 and after Earnings Statements will no longer have leave balances.
-          Navigate to Time and Absence to view leave balances.
+          <c:choose>
+            <c:when test="${not empty prefs['timeAndAbsenceFName']
+              && not empty prefs['timeAndAbsenceFName'][0]}">
+              <a href="/web/exclusive/${prefs['timeAndAbsenceFName'][0]}"
+                style="color:blue; text-decoration:underline;">
+                Navigate to Time and Absence</a>
+                to view leave balances.
+            </c:when>
+            <c:otherwise>
+              Navigate to Time and Absence to view leave balances.
+            </c:otherwise>
+          </c:choose>
         </div>
         <div class="data-table-details">
           <form action="#">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -61,7 +61,12 @@
     <div id="${n}dl-earning-statements" class="dl-earning-statements ui-tabs-panel ui-widget-content ui-corner-bottom">
       <div class="data-table-description-header">
         <div class="data-table-description">
-          Your Net Pay Check amount is reflected on each individual Earnings Statement
+          Your Net Pay Check amount is reflected on each individual Earnings Statement.
+        </div>
+        <div class="data-table-description"
+          style="color:black;">
+          2019 and after Earnings Statements will no longer have leave balances.
+          Navigate to Time and Absence to view leave balances.
         </div>
         <div class="data-table-details">
           <form action="#">


### PR DESCRIPTION
In 2019, earnings statements will no longer include leave balances right on the earnings statements.

This change adds text to "Payroll Information" --> "Earnings Statements" to cue this change, advising employees to visit "Time and Absence" to see those leave balances, including a hyperlink when the "Time and Absence" fname is known to "Payroll Information" (via a new `portlet-preference`).

Service Center was specific that the hyperlink needs to be blue and underlined if present, so, explicitly applies that style.

[HRSPLT-386](https://jira.doit.wisc.edu/jira/browse/HRSPLT-386)