### PR TITLE
HRSPLT-391 consistently "earnings" not "earning" statements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ it sources its URL from the HRS URLs web service.
 
 ### (Unreleased)
 
-(No changes yet)
+Fixes:
+
++ Consistently refer to earnings statements as "earnings" statements, not
+  "earning" statements. ( [HRSPLT-391][] )
 
 ### 5.5.0 - ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL, timeAndAbsenceFName
 
@@ -673,3 +676,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-382]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-382
 [HRSPLT-384]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-384
 [HRSPLT-386]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-386
+[HRSPLT-391]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-391

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ The `Payroll Information` portlet supports an optional `requestedContent`
 *HTTP* request parameter) specifying which content within the portlet (tab) to
 initially select. The parameter value `Tax Statements` selects, well, tax
 statements. Omitting it or any other value accepts the default behavior of
-initially selecting the "Earning Statements" tab.
+initially selecting the "Earnings Statements" tab.
 
 If this goes well it will be feasible to extend this feature to other HRS
 Portlets as the need arises.

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -119,7 +119,7 @@
                 <value>ROLE_VIEW_OWN_GARNISHMENTS</value>
                 <!-- effect
                   in Payroll Information
-                    On Earning Statements tab
+                    On Earnings Statements tab
                       Show "Garnishments/Wage Assignments" link
                 -->
             </set>

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollInformationController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollInformationController.java
@@ -50,7 +50,7 @@ public class PayrollInformationController extends HrsControllerBase {
     }
     
     /**
-     * Gets the URL to a page describing your earning statement
+     * Gets the URL to a page describing your earnings statement
      * @param request the request
      * @return the value of the portlet preference
      */

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -41,7 +41,7 @@
       <c:choose>
         <c:when test="${requestedContent eq 'Tax Statements'}">
           <li class="ui-state-default ui-corner-top">
-            <a href="#${n}dl-earning-statements">Earning Statements</a>
+            <a href="#${n}dl-earning-statements">Earnings Statements</a>
           </li>
           <li class="ui-state-default ui-corner-top ui-tabs-selected ui-state-active">
             <a href="#${n}dl-tax-statements">Tax Statements</a>
@@ -50,7 +50,7 @@
         <c:otherwise>
           <%-- default to Earnings Statements as default tab. --%>
           <li class="ui-state-default ui-corner-top ui-tabs-selected ui-state-active">
-            <a href="#${n}dl-earning-statements">Earning Statements</a>
+            <a href="#${n}dl-earning-statements">Earnings Statements</a>
           </li>
           <li class="ui-state-default ui-corner-top">
             <a href="#${n}dl-tax-statements">Tax Statements</a>
@@ -90,7 +90,7 @@
       <div class="fl-pager">
         <hrs:pagerNavBar position="top" showSummary="${true}"/>
         <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
-          <table class="dl-table table" tabindex="0" aria-label="Earning Statements detail table">
+          <table class="dl-table table" tabindex="0" aria-label="Earnings Statements detail table">
             <thead>
               <tr rsf:id="header:">
                 <th scope="col" class="flc-pager-sort-header dl-col-25p" rsf:id="paid"><a href="javascript:;">Paid</a></th>


### PR DESCRIPTION
Service Center has clarified that they're "earnings" statements, not "earning" statements, so consistently use "earnings statements".