### PR TITLE
fix: rm stale `@version` annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Fixes:
 + Consistently refer to earnings statements as "earnings" statements, not
   "earning" statements. ( [HRSPLT-391][] )
 + Sort roles in troubleshooter ( [HRSPLT-390][] )
++ Remove `@version` annotations in code that had been populated with stale
+  metadata from the previous, no-longer-in-use versioning system (SVN). (
+  [#155][] )
 
 ### 5.5.0 - ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL, timeAndAbsenceFName
 
@@ -659,6 +662,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#150]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/150
 [#152]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/152
 [#153]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/153
+[#155]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/155
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/absbal/AbsenceBalanceDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/absbal/AbsenceBalanceDao.java
@@ -25,7 +25,6 @@ import edu.wisc.hr.dm.absbal.AbsenceBalance;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public interface AbsenceBalanceDao {
     public List<AbsenceBalance> getAbsenceBalance(String emplId);

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/abshis/AbsenceHistoryDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/abshis/AbsenceHistoryDao.java
@@ -25,7 +25,6 @@ import edu.wisc.hr.dm.abshis.AbsenceHistory;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public interface AbsenceHistoryDao {
     public List<AbsenceHistory> getAbsenceHistory(String emplId);

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/benstmt/BenefitStatementDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/benstmt/BenefitStatementDao.java
@@ -25,7 +25,6 @@ import edu.wisc.hr.dm.benstmt.BenefitStatements;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public interface BenefitStatementDao {
     /**

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/bnsemail/BusinessEmailUpdateDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/bnsemail/BusinessEmailUpdateDao.java
@@ -25,7 +25,6 @@ import edu.wisc.hr.dm.bnsemail.PreferredEmail;
  * Interface for getting and updating the current buisness contact email info for a user.
  * 
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public interface BusinessEmailUpdateDao {
 

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/bnsemail/BusinessEmailUpdateNotifier.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/bnsemail/BusinessEmailUpdateNotifier.java
@@ -23,7 +23,6 @@ package edu.wisc.hr.dao.bnsemail;
  * Used to notify a user that their email address has been changed
  * 
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public interface BusinessEmailUpdateNotifier {
 

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/bnsumm/BenefitSummaryDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/bnsumm/BenefitSummaryDao.java
@@ -23,7 +23,6 @@ import edu.wisc.hr.dm.bnsumm.BenefitSummary;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public interface BenefitSummaryDao {
     public BenefitSummary getBenefitSummary(String emplId);

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/ernstmt/EarningStatementDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/ernstmt/EarningStatementDao.java
@@ -25,7 +25,6 @@ import edu.wisc.hr.dm.ernstmt.EarningStatements;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public interface EarningStatementDao {
     /**

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/levstmt/LeaveStatementDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/levstmt/LeaveStatementDao.java
@@ -26,7 +26,6 @@ import edu.wisc.hr.dm.levstmt.SummarizedLeaveStatement;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public interface LeaveStatementDao {
     /**

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/mssabs/ManagerAbsenceDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/mssabs/ManagerAbsenceDao.java
@@ -25,7 +25,6 @@ import edu.wisc.hr.dm.mssabs.ManagedAbsence;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public interface ManagerAbsenceDao {
     public List<ManagedAbsence> getManagedAbsences(String emplId);

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/msstime/ManagerTimeDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/msstime/ManagerTimeDao.java
@@ -25,7 +25,6 @@ import edu.wisc.hr.dm.msstime.ManagedTime;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public interface ManagerTimeDao {
     public List<ManagedTime> getManagedTimes(String emplId);

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/person/ContactInfoDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/person/ContactInfoDao.java
@@ -25,7 +25,6 @@ import edu.wisc.hr.dm.person.PersonInformation;
  * Get Contact Information for a specific user
  * 
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public interface ContactInfoDao {
 

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/sabstmt/SabbaticalStatementDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/sabstmt/SabbaticalStatementDao.java
@@ -25,7 +25,6 @@ import edu.wisc.hr.dm.sabstmt.SabbaticalReports;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public interface SabbaticalStatementDao {
     /**

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/taxstmt/TaxStatementDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/taxstmt/TaxStatementDao.java
@@ -25,7 +25,6 @@ import edu.wisc.hr.dm.taxstmt.TaxStatements;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public interface TaxStatementDao {
     /**

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/tlpayable/TimeSheetDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/tlpayable/TimeSheetDao.java
@@ -25,7 +25,6 @@ import edu.wisc.hr.dm.tlpayable.TimeSheet;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public interface TimeSheetDao {
     public List<TimeSheet> getTimeSheets(String emplId);

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/url/HrsUrlDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/url/HrsUrlDao.java
@@ -25,7 +25,6 @@ import java.util.Map;
  * Gets a set of deep-links into the HRS system
  *
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public interface HrsUrlDao {
     public Map<String, String> getHrsUrls();

--- a/hrs-portlets-bnsemail-impl/src/main/java/edu/wisc/bnsemail/dao/JdbcBusinessEmailUpdateDao.java
+++ b/hrs-portlets-bnsemail-impl/src/main/java/edu/wisc/bnsemail/dao/JdbcBusinessEmailUpdateDao.java
@@ -38,7 +38,6 @@ import edu.wisc.hr.dm.person.PersonInformation;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.2 $
  */
 @Repository
 public class JdbcBusinessEmailUpdateDao implements BusinessEmailUpdateDao {

--- a/hrs-portlets-bnsemail-impl/src/main/java/edu/wisc/bnsemail/dao/PreferredEmailRowMapper.java
+++ b/hrs-portlets-bnsemail-impl/src/main/java/edu/wisc/bnsemail/dao/PreferredEmailRowMapper.java
@@ -27,7 +27,6 @@ import edu.wisc.hr.dm.bnsemail.PreferredEmail;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 final class PreferredEmailRowMapper implements RowMapper {
     public static final PreferredEmailRowMapper INTANCE = new PreferredEmailRowMapper();

--- a/hrs-portlets-bnsemail-impl/src/main/java/edu/wisc/bnsemail/dao/SmtpBusinessEmailUpdateNotifier.java
+++ b/hrs-portlets-bnsemail-impl/src/main/java/edu/wisc/bnsemail/dao/SmtpBusinessEmailUpdateNotifier.java
@@ -55,7 +55,6 @@ import edu.wisc.hr.dao.bnsemail.BusinessEmailUpdateNotifier;
 /**
  * 
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 @Service("businessEmailUpdateNotifier")
 public class SmtpBusinessEmailUpdateNotifier implements InitializingBean, BusinessEmailUpdateNotifier {

--- a/hrs-portlets-bnsemail-impl/src/main/java/edu/wisc/bnsemail/dao/UpdatePreferredEmailProcedure.java
+++ b/hrs-portlets-bnsemail-impl/src/main/java/edu/wisc/bnsemail/dao/UpdatePreferredEmailProcedure.java
@@ -36,7 +36,6 @@ msnhremail.UPDATE_FROM_PORTAL(p_email_i IN msn_hr_email.email_address%TYPE
                                              )
 
  * @author Eric Dalquist
- * @version $Revision: 1.2 $
  */
 public class UpdatePreferredEmailProcedure extends StoredProcedure {
 

--- a/hrs-portlets-bnsemail-impl/src/test/java/edu/wisc/bnsemail/dao/BusinessEmailUpdateNotifierTest.java
+++ b/hrs-portlets-bnsemail-impl/src/test/java/edu/wisc/bnsemail/dao/BusinessEmailUpdateNotifierTest.java
@@ -30,7 +30,6 @@ import edu.wisc.hr.dao.bnsemail.BusinessEmailUpdateNotifier;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 @Ignore
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/hrs-portlets-bnsemail-impl/src/test/java/edu/wisc/bnsemail/dao/JdbcBusinessEmailUpdateDaoTest.java
+++ b/hrs-portlets-bnsemail-impl/src/test/java/edu/wisc/bnsemail/dao/JdbcBusinessEmailUpdateDaoTest.java
@@ -35,7 +35,6 @@ import edu.wisc.hr.dm.bnsemail.PreferredEmail;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 @Ignore
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/benstmt/RestBenefitStatementDao.java
+++ b/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/benstmt/RestBenefitStatementDao.java
@@ -43,7 +43,6 @@ import edu.wisc.hr.dm.benstmt.BenefitStatements;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.2 $
  */
 @Repository("restBenefitStatementDao")
 public class RestBenefitStatementDao implements BenefitStatementDao {

--- a/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/levstmt/RestLeaveStatementDao.java
+++ b/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/levstmt/RestLeaveStatementDao.java
@@ -45,7 +45,6 @@ import edu.wisc.hr.dm.levstmt.SummarizedLeaveStatement;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.2 $
  */
 @Repository("restLeaveStatementDao")
 public class RestLeaveStatementDao implements LeaveStatementDao {

--- a/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/sabstmt/RestSabbaticalStatementDao.java
+++ b/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/sabstmt/RestSabbaticalStatementDao.java
@@ -42,7 +42,6 @@ import edu.wisc.hr.dm.sabstmt.SabbaticalReports;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.2 $
  */
 @Repository("restSabbaticalStatementDao")
 public class RestSabbaticalStatementDao implements SabbaticalStatementDao {

--- a/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/taxstmt/RestTaxStatementDao.java
+++ b/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/taxstmt/RestTaxStatementDao.java
@@ -42,7 +42,6 @@ import edu.wisc.hr.dm.taxstmt.TaxStatements;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.2 $
  */
 @Repository("restTaxStatementDao")
 public class RestTaxStatementDao implements TaxStatementDao {

--- a/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/bnstmt/RestBenefitStatementDaoIT.java
+++ b/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/bnstmt/RestBenefitStatementDaoIT.java
@@ -37,7 +37,6 @@ import edu.wisc.hr.dm.benstmt.BenefitStatements;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/integrationCypressTestContext.xml")

--- a/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/bnstmt/RestBenefitStatementDaoTest.java
+++ b/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/bnstmt/RestBenefitStatementDaoTest.java
@@ -47,7 +47,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * 
- * @version $Id: RestBenefitStatementDaoTest.java,v 1.1 2011/12/04 06:11:05 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/mockCypressTestContext.xml")

--- a/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/ernstmt/RestEarningStatementDaoIT.java
+++ b/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/ernstmt/RestEarningStatementDaoIT.java
@@ -36,7 +36,6 @@ import edu.wisc.hr.dm.ernstmt.EarningStatements;
 
 /**
  * 
- * @version $Id: RestEarningStatementDaoIT.java,v 1.1 2011/12/04 06:11:05 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/integrationCypressTestContext.xml")

--- a/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/ernstmt/RestEarningStatementDaoTest.java
+++ b/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/ernstmt/RestEarningStatementDaoTest.java
@@ -48,7 +48,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/mockCypressTestContext.xml")

--- a/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/levstmt/RestLeaveStatementDaoIT.java
+++ b/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/levstmt/RestLeaveStatementDaoIT.java
@@ -33,7 +33,6 @@ import edu.wisc.hr.dm.levstmt.SummarizedLeaveStatement;
 
 /**
  * 
- * @version $Id: RestLeaveStatementDaoIT.java,v 1.1 2011/12/04 06:11:03 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/integrationCypressTestContext.xml")

--- a/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/levstmt/RestLeaveStatementDaoTest.java
+++ b/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/levstmt/RestLeaveStatementDaoTest.java
@@ -48,7 +48,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/mockCypressTestContext.xml")

--- a/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/sabstmt/RestSabbaticalStatementDaoIT.java
+++ b/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/sabstmt/RestSabbaticalStatementDaoIT.java
@@ -36,7 +36,6 @@ import edu.wisc.hr.dm.sabstmt.SabbaticalReports;
 
 /**
  * 
- * @version $Id: RestSabbaticalStatementDaoIT.java,v 1.1 2011/12/04 06:11:04 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/integrationCypressTestContext.xml")

--- a/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/sabstmt/RestSabbaticalStatementDaoTest.java
+++ b/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/sabstmt/RestSabbaticalStatementDaoTest.java
@@ -49,7 +49,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/mockCypressTestContext.xml")

--- a/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/taxstmt/RestTaxStatementDaoIT.java
+++ b/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/taxstmt/RestTaxStatementDaoIT.java
@@ -35,7 +35,6 @@ import edu.wisc.hr.dm.taxstmt.TaxStatements;
 
 /**
  * 
- * @version $Id: RestTaxStatementDaoIT.java,v 1.1 2011/12/04 06:11:05 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/integrationCypressTestContext.xml")

--- a/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/taxstmt/RestTaxStatementDaoTest.java
+++ b/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/taxstmt/RestTaxStatementDaoTest.java
@@ -48,7 +48,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/mockCypressTestContext.xml")

--- a/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dm/CypressJaxbTest.java
+++ b/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dm/CypressJaxbTest.java
@@ -42,7 +42,6 @@ import edu.wisc.cypress.xdm.taxstmt.XmlTaxStatements;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public class CypressJaxbTest {
     @Test

--- a/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dm/MockitoFactoryBean.java
+++ b/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dm/MockitoFactoryBean.java
@@ -28,7 +28,6 @@ import org.springframework.beans.factory.config.AbstractFactoryBean;
  * Factory for creating Mocktio objects as beans.
  * 
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public class MockitoFactoryBean<T> extends AbstractFactoryBean<T> {
     private final Class<? extends T> type;

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/BaseHrsSoapDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/BaseHrsSoapDao.java
@@ -51,7 +51,6 @@ import org.jasig.springframework.ws.client.core.SetSoapActionCallback;
  * Base class for HRS Web Services. Provides common invocation and error handling logic
  * 
  * @author Eric Dalquist
- * @version $Revision: 1.2 $
  */
 public abstract class BaseHrsSoapDao {
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/HrsUtils.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/HrsUtils.java
@@ -26,7 +26,6 @@ import org.springframework.util.ReflectionUtils;
  * Utilities for parsing the PeopleSoft data model
  * 
  * @author Eric Dalquist
- * @version $Revision: 1.2 $
  */
 public class HrsUtils {
     /**

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/absbal/SoapAbsenceBalanceDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/absbal/SoapAbsenceBalanceDao.java
@@ -48,7 +48,6 @@ import edu.wisc.hrs.xdm.absbal.res.UwGpAbsBalVwTypeShape;
 /**
  * Spring {@link WebServiceOperations} backed implementation of {@link BaseHrsSoapDao}.
  * 
- * @version $Id: SoapAbsenceBalanceDao.java,v 1.3 2012/08/14 21:18:04 dalquist Exp $
  */
 @Repository("soapAbsenceBalanceDao")
 public class SoapAbsenceBalanceDao extends BaseHrsSoapDao implements AbsenceBalanceDao {

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/abshis/SoapAbsenceHistoryDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/abshis/SoapAbsenceHistoryDao.java
@@ -47,7 +47,6 @@ import edu.wisc.hrs.xdm.abshis.res.UwGpAbsHisVwTypeShape;
 /**
  * Spring {@link WebServiceOperations} backed implementation of {@link BaseHrsSoapDao}.
  * 
- * @version $Id: SoapAbsenceHistoryDao.java,v 1.3 2012/08/14 21:18:04 dalquist Exp $
  */
 @Repository("soapAbsenceHistoryDao")
 public class SoapAbsenceHistoryDao extends BaseHrsSoapDao implements AbsenceHistoryDao {

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/bnsumm/SoapBenefitSummaryDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/bnsumm/SoapBenefitSummaryDao.java
@@ -43,7 +43,6 @@ import edu.wisc.hrs.xdm.bnsumm.res.UwBnDpndntVwTypeShape;
 /**
  * Spring {@link WebServiceOperations} backed implementation of {@link BaseHrsSoapDao}.
  * 
- * @version $Id: SoapBenefitSummaryDao.java,v 1.2 2011/12/07 21:38:13 dalquist Exp $
  */
 @Repository("soapBenefitSummaryDao")
 public class SoapBenefitSummaryDao extends BaseHrsSoapDao implements BenefitSummaryDao {

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/mssabs/SoapManagerAbsenceDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/mssabs/SoapManagerAbsenceDao.java
@@ -42,7 +42,6 @@ import edu.wisc.hrs.xdm.mssabs.res.UwAmMssAbsVwTypeShape;
 /**
  * Spring {@link WebServiceOperations} backed implementation of {@link BaseHrsSoapDao}.
  * 
- * @version $Id: SoapManagerAbsenceDao.java,v 1.2 2011/12/07 21:38:13 dalquist Exp $
  */
 @Repository("soapManagerAbsenceDao")
 public class SoapManagerAbsenceDao extends BaseHrsSoapDao implements ManagerAbsenceDao {

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/msstime/SoapManagerTimeDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/msstime/SoapManagerTimeDao.java
@@ -42,7 +42,6 @@ import edu.wisc.hrs.xdm.msstime.res.UwTlEmpDtlVwTypeShape;
 /**
  * Spring {@link WebServiceOperations} backed implementation of {@link BaseHrsSoapDao}.
  * 
- * @version $Id: SoapManagerTimeDao.java,v 1.2 2011/12/07 21:38:12 dalquist Exp $
  */
 @Repository("soapManagerTimeDao")
 public class SoapManagerTimeDao extends BaseHrsSoapDao implements ManagerTimeDao {

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/person/SoapContactInfoDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/person/SoapContactInfoDao.java
@@ -49,7 +49,6 @@ import edu.wisc.hrs.xdm.person.res.UwHrSecDptVwTypeShape;
  * 
  * Requires a Spring {@link WebServiceOperations} be set.
  * 
- * @version $Id: SoapContactInfoDao.java,v 1.4 2012/08/14 21:18:04 dalquist Exp $
  */
 @Repository("soapContactInfoDao")
 public class SoapContactInfoDao extends BaseHrsSoapDao implements ContactInfoDao {

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/roles/SoapHrsRolesDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/roles/SoapHrsRolesDao.java
@@ -42,7 +42,6 @@ import org.springframework.ws.client.core.WebServiceOperations;
 /**
  * Spring {@link WebServiceOperations} backed implementation of {@link BaseHrsSoapDao}.
  *
- * @version $Id: SoapHrsRolesDao.java,v 1.3 2012/04/20 17:08:50 dalquist Exp $
  */
 @Repository("soapHrsRolesDao")
 public class SoapHrsRolesDao extends BaseHrsSoapDao implements HrsRolesDao {

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/tlpayable/SoapTimeLeavePayableDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/tlpayable/SoapTimeLeavePayableDao.java
@@ -48,7 +48,6 @@ import edu.wisc.hrs.xdm.tlpaybl.res.UwTlPayablVwTypeShape;
 /**
  * Spring {@link WebServiceOperations} backed implementation of {@link BaseHrsSoapDao}.
  * 
- * @version $Id: SoapTimeLeavePayableDao.java,v 1.3 2012/08/14 21:18:04 dalquist Exp $
  */
 @Repository("soapTimeLeavePayableDao")
 public class SoapTimeLeavePayableDao extends BaseHrsSoapDao implements TimeSheetDao {

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/url/SoapHrsUrlDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/url/SoapHrsUrlDao.java
@@ -40,7 +40,6 @@ import edu.wisc.hrs.xdm.url.res.InstallationTypeShape;
 /**
  * Spring {@link WebServiceOperations} backed implementation of {@link BaseHrsSoapDao}.
  * 
- * @version $Id: SoapHrsUrlDao.java,v 1.1 2011/12/07 21:38:11 dalquist Exp $
  */
 @Repository("soapHrsUrlDao")
 public class SoapHrsUrlDao extends BaseHrsSoapDao implements HrsUrlDao {

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/BaseSoapDaoTest.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/BaseSoapDaoTest.java
@@ -36,7 +36,6 @@ import org.springframework.ws.transport.WebServiceMessageSender;
  * Base class for SOAP dao tests (integration and mock)
  * 
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public class BaseSoapDaoTest {
     protected WebServiceMessageSender getWebServiceMessageSender() {

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/absbal/SoapAbsenceBalanceDaoIT.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/absbal/SoapAbsenceBalanceDaoIT.java
@@ -35,7 +35,6 @@ import edu.wisc.hrs.dao.BaseSoapDaoTest;
 
 /**
  * 
- * @version $Id: SoapAbsenceBalanceDaoIT.java,v 1.1 2011/12/04 06:11:04 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/integrationPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/absbal/SoapAbsenceBalanceDaoTest.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/absbal/SoapAbsenceBalanceDaoTest.java
@@ -47,7 +47,6 @@ import edu.wisc.hrs.xdm.absbal.res.GetCompIntfcUWPORTAL1ABSBALResponse;
 
 /**
  * 
- * @version $Id: SoapAbsenceBalanceDaoTest.java,v 1.2 2012/08/14 21:18:04 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/mockPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/abshis/SoapAbsenceHistoryDaoIT.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/abshis/SoapAbsenceHistoryDaoIT.java
@@ -35,7 +35,6 @@ import edu.wisc.hrs.dao.BaseSoapDaoTest;
 
 /**
  * 
- * @version $Id: SoapAbsenceHistoryDaoIT.java,v 1.1 2011/12/04 06:11:03 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/integrationPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/abshis/SoapAbsenceHistoryDaoTest.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/abshis/SoapAbsenceHistoryDaoTest.java
@@ -47,7 +47,6 @@ import edu.wisc.hrs.xdm.abshis.res.GetCompIntfcUWPORTAL1ABSHISResponse;
 
 /**
  * 
- * @version $Id: SoapAbsenceHistoryDaoTest.java,v 1.2 2012/08/14 21:18:04 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/mockPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/bnsumm/SoapBenefitSummaryDaoIT.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/bnsumm/SoapBenefitSummaryDaoIT.java
@@ -37,7 +37,6 @@ import edu.wisc.hrs.dao.BaseSoapDaoTest;
 
 /**
  * 
- * @version $Id: SoapBenefitSummaryDaoIT.java,v 1.1 2011/12/04 06:11:04 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/integrationPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/bnsumm/SoapBenefitSummaryDaoTest.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/bnsumm/SoapBenefitSummaryDaoTest.java
@@ -45,7 +45,6 @@ import edu.wisc.hrs.xdm.bnsumm.res.GetCompIntfcUWPORTAL1BNSUMMResponse;
 
 /**
  * 
- * @version $Id: SoapBenefitSummaryDaoTest.java,v 1.1 2011/12/04 06:11:04 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/mockPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/mssabs/SoapManagerAbsenceDaoIT.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/mssabs/SoapManagerAbsenceDaoIT.java
@@ -35,7 +35,6 @@ import edu.wisc.hrs.dao.BaseSoapDaoTest;
 
 /**
  * 
- * @version $Id: SoapManagerAbsenceDaoIT.java,v 1.1 2011/12/04 06:11:05 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/integrationPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/mssabs/SoapManagerAbsenceDaoTest.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/mssabs/SoapManagerAbsenceDaoTest.java
@@ -45,7 +45,6 @@ import edu.wisc.hrs.xdm.mssabs.res.GetCompIntfcUWPORTAL1MSSABSResponse;
 
 /**
  * 
- * @version $Id: SoapManagerAbsenceDaoTest.java,v 1.1 2011/12/04 06:11:05 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/mockPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/msstime/SoapManagerTimeDaoIT.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/msstime/SoapManagerTimeDaoIT.java
@@ -35,7 +35,6 @@ import edu.wisc.hrs.dao.BaseSoapDaoTest;
 
 /**
  * 
- * @version $Id: SoapManagerTimeDaoIT.java,v 1.1 2011/12/04 06:11:04 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/integrationPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/msstime/SoapManagerTimeDaoTest.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/msstime/SoapManagerTimeDaoTest.java
@@ -45,7 +45,6 @@ import edu.wisc.hrs.xdm.msstime.res.GetCompIntfcUWPORTAL1MSSTIMEResponse;
 
 /**
  * 
- * @version $Id: SoapManagerTimeDaoTest.java,v 1.1 2011/12/04 06:11:04 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/mockPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/person/SoapContactInfoDaoIT.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/person/SoapContactInfoDaoIT.java
@@ -32,7 +32,6 @@ import edu.wisc.hrs.dao.BaseSoapDaoTest;
 
 /**
  * 
- * @version $Id: SoapContactInfoDaoIT.java,v 1.1 2011/12/04 06:11:04 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/integrationPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/person/SoapContactInfoDaoTest.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/person/SoapContactInfoDaoTest.java
@@ -48,7 +48,6 @@ import edu.wisc.hrs.xdm.person.res.GetCompIntfcUWPORTAL1PERSONResponse;
 
 /**
  * 
- * @version $Id: SoapContactInfoDaoTest.java,v 1.2 2012/08/14 21:18:04 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/mockPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/roles/SoapHrsRolesDaoIT.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/roles/SoapHrsRolesDaoIT.java
@@ -34,7 +34,6 @@ import edu.wisc.hrs.dao.BaseSoapDaoTest;
 
 /**
  * 
- * @version $Id: SoapHrsRolesDaoIT.java,v 1.1 2011/12/04 06:11:02 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/integrationPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/roles/SoapHrsRolesDaoTest.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/roles/SoapHrsRolesDaoTest.java
@@ -44,7 +44,6 @@ import edu.wisc.hrs.xdm.roles.res.GetCompIntfcUWPORTAL1ROLESResponse;
 
 /**
  * 
- * @version $Id: SoapHrsRolesDaoTest.java,v 1.1 2011/12/04 06:11:02 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/mockPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/tlpayable/SoapTimeLeavePayableDaoIT.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/tlpayable/SoapTimeLeavePayableDaoIT.java
@@ -35,7 +35,6 @@ import edu.wisc.hrs.dao.BaseSoapDaoTest;
 
 /**
  * 
- * @version $Id: SoapTimeLeavePayableDaoIT.java,v 1.1 2011/12/04 06:11:04 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/integrationPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/tlpayable/SoapTimeLeavePayableDaoTest.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/tlpayable/SoapTimeLeavePayableDaoTest.java
@@ -47,7 +47,6 @@ import edu.wisc.hrs.xdm.tlpaybl.res.GetCompIntfcUWPORTAL1TLPAYBLResponse;
 
 /**
  * 
- * @version $Id: SoapTimeLeavePayableDaoTest.java,v 1.2 2012/08/14 21:18:04 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/mockPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/url/SoapHrsUrlDaoIT.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/url/SoapHrsUrlDaoIT.java
@@ -33,7 +33,6 @@ import edu.wisc.hrs.dao.BaseSoapDaoTest;
 
 /**
  * 
- * @version $Id: SoapHrsUrlDaoIT.java,v 1.1 2011/12/07 21:38:11 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/integrationPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/url/SoapHrsUrlDaoTest.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/dao/url/SoapHrsUrlDaoTest.java
@@ -45,7 +45,6 @@ import edu.wisc.hrs.xdm.url.res.GetCompIntfcUWPORTAL1URLResponse;
 
 /**
  * 
- * @version $Id: SoapHrsUrlDaoTest.java,v 1.1 2011/12/07 21:38:11 dalquist Exp $
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/mockPeopleSoftTestContext.xml")

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/util/MockitoFactoryBean.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/hrs/util/MockitoFactoryBean.java
@@ -28,7 +28,6 @@ import org.springframework.beans.factory.config.AbstractFactoryBean;
  * Factory for creating Mocktio objects as beans.
  * 
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public class MockitoFactoryBean<T> extends AbstractFactoryBean<T> {
     private final Class<? extends T> type;

--- a/hrs-portlets-ps-impl/src/test/java/edu/wisc/portlet/hrs/ws/dao/soap/UrIModificationTest.java
+++ b/hrs-portlets-ps-impl/src/test/java/edu/wisc/portlet/hrs/ws/dao/soap/UrIModificationTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public class UrIModificationTest {
     @Test

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/HrsControllerBase.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/HrsControllerBase.java
@@ -38,7 +38,6 @@ import edu.wisc.hr.dao.url.HrsUrlDao;
  * Common functions and dependencies for HRS controllers
  *
  * @author Eric Dalquist
- * @version $Revision: 1.2 $
  */
 public class HrsControllerBase {
     protected final Logger logger = LoggerFactory.getLogger(getClass());

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitInformationController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitInformationController.java
@@ -39,7 +39,6 @@ import edu.wisc.portlet.hrs.web.HrsControllerBase;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 @Controller
 @RequestMapping("VIEW")

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/bnsemail/BusinessEmailAdminController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/bnsemail/BusinessEmailAdminController.java
@@ -40,7 +40,6 @@ import edu.wisc.portlet.hrs.web.HrsControllerBase;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.2 $
  */
 @Controller
 @RequestMapping("VIEW")

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/contactinfo/ContactInfoController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/contactinfo/ContactInfoController.java
@@ -60,7 +60,6 @@ import edu.wisc.portlet.hrs.web.HrsControllerBase;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.3 $
  */
 @Controller
 @RequestMapping("VIEW")

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/manager/ManagerTimeApprovalController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/manager/ManagerTimeApprovalController.java
@@ -34,7 +34,6 @@ import edu.wisc.portlet.hrs.web.HrsControllerBase;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 @Controller
 @RequestMapping("VIEW")

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollInformationController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollInformationController.java
@@ -37,7 +37,6 @@ import edu.wisc.portlet.hrs.web.HrsControllerBase;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.2 $
  */
 @Controller
 @RequestMapping("VIEW")


### PR DESCRIPTION
The values are stale auto-generated metadata out of SVN, a versioning system this project is no longer using. These annotations are more distracting than they are helpful, remove them.

(This change is trivial, it's just me idly cleaning code while my brain works through the substantive changes I'm working on.)