### PR TITLE
HRSPLT-398 open earnings statements via a href target _blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ it sources its URL from the HRS URLs web service.
 
 ### (Unreleased)
 
++ Fix Payroll Information earnings statements table to stop trying to open
+  earnings statements via `javascript:window.open({url})` and instead use a more
+  typical `<a href="{url}" target="_blank" rel="noopener noreferrer">`
+  ( [HRSPLT-398][], [#160][])
+
 ### 5.8.5 fix troubleshooter
 
 2018-11-09
@@ -755,6 +760,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#152]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/152
 [#153]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/153
 [#155]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/155
+[#160]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/160
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348
@@ -776,3 +782,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-390]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-390
 [HRSPLT-391]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-391
 [HRSPLT-394]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-394
+[HRSPLT-398]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-398

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -113,18 +113,21 @@
               <c:forEach var="earningsStatement" items="${earningsStatements}">
                 <tr>
                   <td headers="paid" class="dl-data-text">
-                    <a href="javascript:window.open('${earningsStatement.url}');">
+                    <a href="${earningsStatement.url}"
+                      target="_blank" rel="noopener noreferrer">
                       ${earningsStatement.paid}
                     </a>
                   </td>
                   <td headers="earned" class="dl-data-text">
-                    <a href="javascript:window.open('${earningsStatement.url}');">
+                    <a href="${earningsStatement.url}"
+                      target="_blank" rel="noopener noreferrer">
                       ${earningsStatement.earned}
                     </a>
                   </td>
                   <td headers="amount" class="dl-data-number">
                     <a class="dl-earning-amount"
-                      href="javascript:window.open('${earningsStatement.url}');">
+                      href="${earningsStatement.url}"
+                      target="_blank" rel="noopener noreferrer">
                       ${earningsStatement.amount}
                     </a>
                   </td>


### PR DESCRIPTION
Use a more typical `<a href="{url}" target="_blank" rel="noopener noreferer">` rather than `javascript:window.open(...)`

+ so that fewer browsers block as an apparent pop-up, and 
+ so that opened tab has less technical possibility to mess with the MyUW tab that opened it, which messing may be actually happening in some cases. (*something* messes with the browser tab holding Payroll Information that launches the earnings statement. I'm not sure what is doing the messing, but JavaScript in the opened tab would explain it.)