### PR TITLE
HRSPLT-399 initially limit earnings statement table to 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,22 @@ single tab within Payroll Information as of 5.2.) Support for
 direct deposit button either uses its hard coded URL linking to the PDF form or
 it sources its URL from the HRS URLs web service.
 
-### (Unreleased)
+### (Unreleased) (5.9.0?)
+
+Features in 5.9.0:
+
++ Limit initial earnings statement table render to at most 10 earnings
+  statements. Add a toggle control, modeled on the existing toggle for showing
+  earnings amounts, to show the truncated table rows. ( [HRSPLT-399][],
+  [#161][] )
+
+Fixes in 5.9.0:
 
 + Fix Payroll Information earnings statements table to stop trying to open
   earnings statements via `javascript:window.open({url})` and instead use a more
   typical `<a href="{url}" target="_blank" rel="noopener noreferrer">`
   ( [HRSPLT-398][], [#160][])
+
 
 ### 5.8.5 fix troubleshooter
 
@@ -761,6 +771,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#153]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/153
 [#155]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/155
 [#160]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/160
+[#161]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/160
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348
@@ -783,3 +794,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-391]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-391
 [HRSPLT-394]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-394
 [HRSPLT-398]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-398
+[HRSPLT-399]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-399

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -110,7 +110,9 @@
               </tr>
             </thead>
             <tbody>
-              <c:forEach var="earningsStatement" items="${earningsStatements}">
+              <%-- always show the first up-to-10 statements --%>
+              <c:forEach var="earningsStatement"
+                items="${earningsStatements}" end="9">
                 <tr>
                   <td headers="paid" class="dl-data-text">
                     <a href="${earningsStatement.url}"
@@ -133,10 +135,41 @@
                   </td>
                 </tr>
               </c:forEach>
+              <%-- initially hide any statements past 10 --%>
+              <c:forEach var="earningsStatement"
+              items="${earningsStatements}" begin="10">
+              <tr class="earnings-statement-beyond-ten" style="display:none">
+                <td headers="paid" class="dl-data-text">
+                  <a href="javascript:window.open('${earningsStatement.url}');">
+                    ${earningsStatement.paid}
+                  </a>
+                </td>
+                <td headers="earned" class="dl-data-text">
+                  <a href="javascript:window.open('${earningsStatement.url}');">
+                    ${earningsStatement.earned}
+                  </a>
+                </td>
+                <td headers="amount" class="dl-data-number">
+                  <a class="dl-earning-amount"
+                    href="javascript:window.open('${earningsStatement.url}');">
+                    ${earningsStatement.amount}
+                  </a>
+                </td>
+              </tr>
+
+            </c:forEach>
             </tbody>
           </table>
+          <div>
+            <form action="#">
+              <label for="${n}dl-show-all-earnings-statements-toggle">
+                Show all ${fn:length(earningsStatements)} Earnings Statements</label>
+              <input type="checkbox"
+                id="${n}dl-show-all-earnings-statements-toggle"
+                name="dl-show-all-earnings-statements-toggle" />
+            </form>
+            </div>
         </div>
-
       </div>
       <c:if test="${not empty understandingEarningUrl}">
           <div class="dl-link">
@@ -340,6 +373,40 @@
         $.log("Earnings Toggle: " + earningsToggle.length);
         earningsToggle.change(function() {
             updateAmmountVisibility(earningsToggle);
+        });
+
+        var updateShowAllEarningsStatements = function(checkbox) {
+            var checked = checkbox.is(':checked');
+            var surplusEarningsStatements = $("#${n}dl-payroll-information table.dl-table tr.earnings-statement-beyond-ten");
+            if (surplusEarningsStatements.length == 0) {
+                $.log("No additional earnings statements to show or hide");
+                return true;
+            }
+
+            var surplusEarningsStatementsData =
+              surplusEarningsStatements.data();
+
+            if (surplusEarningsStatementsData.visibilityUpdated == checked) {
+                $.log("Show all earnings statements toggled " + checked + " matches current state, returning false");
+                return false;
+            }
+
+            surplusEarningsStatementsData.visibilityUpdated = checked;
+            $.log("Show all earnings statements toggled: " + checked + " updating " + surplusEarningsStatements.length + " table rows");
+            if (checked) {
+              surplusEarningsStatements.show();
+            }
+            else {
+              surplusEarningsStatements.hide();
+            }
+
+            return true;
+        };
+
+        var showAllEarningsStatementsToggle =
+          $("#$dl-show-all-earnings-statements-toggle");
+        showAllEarningsStatementsToggle.change(function() {
+          updateShowAllEarningsStatements(showAllEarningsStatementsToggle);
         });
 
         var taxStatementUrl = dl.util.templateUrl("${irsStatementPdfUrl}");


### PR DESCRIPTION
Checkbox toggle to display all earnings statements.

Modeled after the checkbox toggle to display earnings statement amounts.

The idea here is to 

+ make the earnings statement table more usable for more frequent use cases (I want a very recent statement; I want a supporting link to understand my earnings statement or to adjust direct deposit),  
+ while continuing to enable the less frequent use case of access to an older statement, 
+ yet avoiding re-introducing the overwrought Fluid Infusion pager experience and dependency.