### PR TITLE
HRSPLT-399 predicate show all control on there being more to show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Features in 5.9.0:
 + Limit initial earnings statement table render to at most 10 earnings
   statements. Add a toggle control, modeled on the existing toggle for showing
   earnings amounts, to show the truncated table rows. ( [HRSPLT-399][],
-  [#161][] )
+  [#161][], [#162][] )
 
 Fixes in 5.9.0:
 
@@ -772,6 +772,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#155]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/155
 [#160]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/160
 [#161]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/160
+[#162]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/162
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -110,6 +110,7 @@
               </tr>
             </thead>
             <tbody>
+              <c:set var="surplusEarningsStatements" value="false" />
               <%-- always show the first up-to-10 statements --%>
               <c:forEach var="earningsStatement"
                 items="${earningsStatements}" end="9">
@@ -138,6 +139,7 @@
               <%-- initially hide any statements past 10 --%>
               <c:forEach var="earningsStatement"
               items="${earningsStatements}" begin="10">
+              <c:set var="surplusEarningsStatements" value="true" />
               <tr class="earnings-statement-beyond-ten" style="display:none">
                 <td headers="paid" class="dl-data-text">
                   <a href="javascript:window.open('${earningsStatement.url}');">
@@ -160,16 +162,19 @@
             </c:forEach>
             </tbody>
           </table>
-          <div>
-            <form action="#">
-              <label for="${n}dl-show-all-earnings-statements-toggle">
-                Show all ${fn:length(earningsStatements)} Earnings Statements</label>
-              <input type="checkbox"
-                id="${n}dl-show-all-earnings-statements-toggle"
-                name="dl-show-all-earnings-statements-toggle" />
-            </form>
+          <c:if test="${surplusEarningsStatements}">
+            <div>
+              <form action="#">
+                <label for="${n}dl-show-all-earnings-statements-toggle">
+                  Show all ${fn:length(earningsStatements)}
+                  Earnings Statements</label>
+                <input type="checkbox"
+                  id="${n}dl-show-all-earnings-statements-toggle"
+                  name="dl-show-all-earnings-statements-toggle" />
+              </form>
             </div>
         </div>
+        </c:if>
       </div>
       <c:if test="${not empty understandingEarningUrl}">
           <div class="dl-link">


### PR DESCRIPTION
Suppress the show all earnings statements control when already showing all earnings statements.

Before:

![show-all-1-statements](https://user-images.githubusercontent.com/952283/49096110-78456a80-f22f-11e8-94ae-41ddeb4c56bd.png)
