### PR TITLE
fix HRSPLT-400 condition leave balance init on leave balance inclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Features in 5.9.0:
 
 Fixes in 5.9.0:
 
++ Fix Time and Absence to correctly render in cases where it omits the Leave
+  Balances tab. Had been broken since 5.5.0. ( [HRSPLT-400][], [#163][] )
 + Fix Payroll Information earnings statements table to stop trying to open
   earnings statements via `javascript:window.open({url})` and instead use a more
   typical `<a href="{url}" target="_blank" rel="noopener noreferrer">`
@@ -773,6 +775,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#160]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/160
 [#161]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/160
 [#162]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/162
+[#163]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/163
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348
@@ -796,3 +799,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-394]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-394
 [HRSPLT-398]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-398
 [HRSPLT-399]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-399
+[HRSPLT-400]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-400

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -539,7 +539,8 @@
           });
         </sec:authorize>
 
-
+      <c:if test="${empty hrsUrls['Classic ESS Abs Bal']
+      || empty employeeRoles['ROLE_LINK_TO_CLASSIC_ESS_ABS_BAL']}">
         dl.pager.init("#${n}dl-leave-balance", {
             model: {
                 sortKey: "entitlement",
@@ -569,6 +570,7 @@
               }
             }
           });
+      </c:if>
 
         <sec:authorize ifAnyGranted="ROLE_VIEW_TIME_ENTRY_HISTORY">
           dl.pager.init("#${n}dl-time-entry", {


### PR DESCRIPTION
Don't try to init a datalist pager that was excluded from the page. Doing so causes the page's JavaScript to stack trace out which breaks data display in and navigation among remaining tabs.

As currently broken in `test`:

![time-abs-broken-in-test](https://user-images.githubusercontent.com/952283/49174391-d47dbc80-f30b-11e8-97cb-3d9d0cc742a1.png)
