### PR TITLE
fix: HRSPLT-401 sort HRS URL keys alphabetically in URLs troubleshooter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,9 @@ Fixes in 5.9.0:
   earnings statements via `javascript:window.open({url})` and instead use a more
   typical `<a href="{url}" target="_blank" rel="noopener noreferrer">`
   ( [HRSPLT-398][], [#160][])
-
++ Fix URLs troubleshooter to sort the URLs alphabetically by URL key. This makes
+  the tool more usable for confidently checking whether a particular key is
+  present. ( [HRSPLT-401][], [#164][])
 
 ### 5.8.5 fix troubleshooter
 
@@ -776,6 +778,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#161]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/160
 [#162]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/162
 [#163]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/163
+[#164]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/164
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348
@@ -800,3 +803,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-398]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-398
 [HRSPLT-399]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-399
 [HRSPLT-400]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-400
+[HRSPLT-401]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-401

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/urls/UrlsController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/urls/UrlsController.java
@@ -3,6 +3,7 @@ package edu.wisc.portlet.hrs.web.urls;
 import edu.wisc.portlet.hrs.web.HrsControllerBase;
 import edu.wisc.portlet.hrs.web.listoflinks.Link;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,9 +44,13 @@ public class UrlsController
   protected List<Link> hrsUrlsAsLinks() {
     Map<String, String> hrsUrls = this.getHrsUrls();
 
+    List<String> urlKeys = new ArrayList(hrsUrls.keySet());
+
+    Collections.sort(urlKeys);
+
     List<Link> linkList = new ArrayList<Link>();
 
-    for (String urlName : hrsUrls.keySet()) {
+    for (String urlName : urlKeys) {
       final Link link = new Link();
       link.setTitle(urlName);
       link.setHref(hrsUrls.get(urlName));


### PR DESCRIPTION
![sorted-hrs-urls-in-predev](https://user-images.githubusercontent.com/952283/49238084-4d8d1a80-f3c5-11e8-9e65-518dcc507e38.png)
