### PR TITLE
BREAKING CHANGE: include Cypress earnings statements in the new earnings statements table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,19 @@
 # MyUW hrs-portlets change log
 
-## HRS Portlets 5 series
+## HRS Portlets 6 series
 
-The HRS Portlets 5 major version was occasioned by the breaking change of
-removing access to the direct deposit and W4 update forms, and with these the
-`ROLE_VIEW_DIRECT_DEPOSIT` role and the `directDepositSelfServiceUrl`
-portlet-preference. (There's no harm in continuing to set this preference; it
-just no longer has any effect.)
+The v6 major version was occasioned by introducing dependency on a new
+publication of Payroll Information as fname `earnings-statement-for-all`.
 
-However, in HRS Portlets 5.2 the links to the W4 update form and the direct
-deposit intructions form were restored to service, with support for
-`ROLE_VIEW_DIRECT_DEPOSIT` and the `Direct Deposit` URL from the HRS URLs
-DAO. (Each of these links (tax withholdings, direct deposit) only appears on a
-single tab within Payroll Information as of 5.2.) Support for
-`directDepositSelfServiceUrl` `portlet-preference` was *not* restored; the
-direct deposit button either uses its hard coded URL linking to the PDF form or
-it sources its URL from the HRS URLs web service.
+### (Unreleased) (6.0.0?)
 
-### (Unreleased) (5.9.0?)
+Breaking change in 6.0.0
+
++ Introduces dependency on `earnings-statement-for-all` as a
+  works-for-both-Madison-and-System-employees `fname` for a Payroll Information
+  that can render Cypress earnings statement PDFs. This makes feasible the
+  converter from the old Cypress statement model to the new universal statement
+  model (which includes the URL of the statement as part of the domain model).
 
 Features in 5.9.0:
 
@@ -42,6 +38,23 @@ Fixes in 5.9.0:
 + Fix URLs troubleshooter to sort the URLs alphabetically by URL key. This makes
   the tool more usable for confidently checking whether a particular key is
   present. ( [HRSPLT-401][], [#164][])
+
+## HRS Portlets 5 series
+
+The HRS Portlets 5 major version was occasioned by the breaking change of
+removing access to the direct deposit and W4 update forms, and with these the
+`ROLE_VIEW_DIRECT_DEPOSIT` role and the `directDepositSelfServiceUrl`
+portlet-preference. (There's no harm in continuing to set this preference; it
+just no longer has any effect.)
+
+However, in HRS Portlets 5.2 the links to the W4 update form and the direct
+deposit intructions form were restored to service, with support for
+`ROLE_VIEW_DIRECT_DEPOSIT` and the `Direct Deposit` URL from the HRS URLs
+DAO. (Each of these links (tax withholdings, direct deposit) only appears on a
+single tab within Payroll Information as of 5.2.) Support for
+`directDepositSelfServiceUrl` `portlet-preference` was *not* restored; the
+direct deposit button either uses its hard coded URL linking to the PDF form or
+it sources its URL from the HRS URLs web service.
 
 ### 5.8.5 fix troubleshooter
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,15 @@ it sources its URL from the HRS URLs web service.
 
 Features in 5.9.0:
 
++ Include legacy Cypress earnings statements in new Payroll Information
+  earnings statements table.
 + Limit initial earnings statement table render to at most 10 earnings
   statements. Add a toggle control, modeled on the existing toggle for showing
   earnings amounts, to show the truncated table rows. ( [HRSPLT-399][],
   [#161][], [#162][] )
++ Support the case where one or the other source of earnings statements (HRS,
+  Cypress) succeeds and the other source fails, both acknowledging the error and
+  listing those statements that MyUW did successfully retrieve.
 
 Fixes in 5.9.0:
 

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dm/ernstmt/RetrievedEarningsStatements.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dm/ernstmt/RetrievedEarningsStatements.java
@@ -1,0 +1,38 @@
+package edu.wisc.hr.dm.ernstmt;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public class RetrievedEarningsStatements {
+
+  private List<Exception> errors = new ArrayList<Exception>();
+
+  private List<SimpleEarningsStatement> statements = new ArrayList<SimpleEarningsStatement>();
+
+  public void registerError(final Exception error) {
+    this.errors.add(error);
+  }
+
+  public void addStatements(final Collection<SimpleEarningsStatement> statementsToAdd) {
+    if (null != statementsToAdd) {
+      this.statements.addAll(statementsToAdd);
+
+      Collections.sort(this.statements, new SimpleEarningsStatementDateComparator());
+    }
+  }
+
+  public boolean isErrored() {
+    return ! this.errors.isEmpty();
+  }
+
+  public List<Exception> getErrors() {
+    return errors;
+  }
+
+  public List<SimpleEarningsStatement> getStatements() {
+    return statements;
+  }
+
+}

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/service/ernstmt/EarningsStatementService.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/service/ernstmt/EarningsStatementService.java
@@ -1,0 +1,9 @@
+package edu.wisc.hr.service.ernstmt;
+
+import edu.wisc.hr.dm.ernstmt.RetrievedEarningsStatements;
+
+public interface EarningsStatementService {
+
+  RetrievedEarningsStatements statementsForEmplid(String emplid);
+
+}

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/service/ernstmt/MergingEarningsStatementService.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/service/ernstmt/MergingEarningsStatementService.java
@@ -1,0 +1,36 @@
+package edu.wisc.hr.service.ernstmt;
+
+import edu.wisc.hr.dao.ernstmt.SimpleEarningsStatementDao;
+import edu.wisc.hr.dm.ernstmt.RetrievedEarningsStatements;
+import java.util.List;
+
+public class MergingEarningsStatementService
+  implements EarningsStatementService {
+
+  private List<SimpleEarningsStatementDao> daos;
+
+  @Override
+  public RetrievedEarningsStatements statementsForEmplid(String emplid) {
+
+    final RetrievedEarningsStatements retrievedEarningsStatements =
+        new RetrievedEarningsStatements();
+
+    for (SimpleEarningsStatementDao dao : daos) {
+      try {
+        retrievedEarningsStatements.addStatements(dao.statementsForEmployee(emplid));
+      } catch (Exception e) {
+        retrievedEarningsStatements.registerError(e);
+      }
+    }
+
+    return retrievedEarningsStatements;
+  }
+
+  public List<SimpleEarningsStatementDao> getDaos() {
+    return daos;
+  }
+
+  public void setDaos(List<SimpleEarningsStatementDao> daos) {
+    this.daos = daos;
+  }
+}

--- a/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/ernstmt/CypressEarningStatementToSimpleEarningStatementConverter.java
+++ b/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/ernstmt/CypressEarningStatementToSimpleEarningStatementConverter.java
@@ -1,5 +1,6 @@
 package edu.wisc.cypress.dao.ernstmt;
 
+import edu.wisc.hr.dm.ernstmt.EarningStatement;
 import edu.wisc.hr.dm.ernstmt.SimpleEarningsStatement;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -26,11 +27,11 @@ public class CypressEarningStatementToSimpleEarningStatementConverter {
     try {
       String mmddyyyyPaid = cypressEarningStatement.getPaid();
 
-      SimpleDateFormat mmddyyyyFormat = new SimpleDateFormat("mm/dd/yyyy");
+      SimpleDateFormat mmddyyyyFormat = new SimpleDateFormat("MM/dd/yyyy");
 
       Date datePaid = mmddyyyyFormat.parse(mmddyyyyPaid);
 
-      convertedStatement.setDateOfCheck(LocalDate.fromDateFields(datePaid));
+      convertedStatement.setDateOfCheck(new LocalDate(datePaid));
 
     } catch (Exception e) {
       // leave the statement dateless

--- a/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/ernstmt/CypressEarningStatementToSimpleEarningStatementConverter.java
+++ b/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/ernstmt/CypressEarningStatementToSimpleEarningStatementConverter.java
@@ -1,0 +1,53 @@
+package edu.wisc.cypress.dao.ernstmt;
+
+import edu.wisc.hr.dm.ernstmt.SimpleEarningsStatement;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import org.joda.time.LocalDate;
+
+public class CypressEarningStatementToSimpleEarningStatementConverter {
+
+  private final String payrollInformationPortletFname;
+
+  public CypressEarningStatementToSimpleEarningStatementConverter(
+      String payrollInformationPortletFname) {
+    this.payrollInformationPortletFname = payrollInformationPortletFname;
+  }
+
+  public SimpleEarningsStatement
+    convertToSimpleEarningsStatement(EarningStatement cypressEarningStatement) {
+
+    if (null == cypressEarningStatement) {
+      throw new NullPointerException("Cannot convert a null statement.");
+    }
+
+    SimpleEarningsStatement convertedStatement = new SimpleEarningsStatement();
+
+    try {
+      String mmddyyyyPaid = cypressEarningStatement.getPaid();
+
+      SimpleDateFormat mmddyyyyFormat = new SimpleDateFormat("mm/dd/yyyy");
+
+      Date datePaid = mmddyyyyFormat.parse(mmddyyyyPaid);
+
+      convertedStatement.setDateOfCheck(LocalDate.fromDateFields(datePaid));
+
+    } catch (Exception e) {
+      // leave the statement dateless
+    }
+
+    convertedStatement.setAmount(cypressEarningStatement.getAmount());
+    convertedStatement.setEarned(cypressEarningStatement.getEarned());
+
+    // https://my.wisc.edu/portal/f/u360303l1s4/p/earnings-statement.u360303l1n9/exclusive/earning_statement.pdf.resource.uP?pP_docId=27404180
+
+    String statementUrl = "/portal/p/" + payrollInformationPortletFname +
+        "/exclusive/earning_statement.pdf.resource.uP?pP_docId=" +
+        cypressEarningStatement.getDocId();
+
+    convertedStatement.setUrl(statementUrl);
+
+    return convertedStatement;
+  }
+
+}

--- a/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/ernstmt/RestEarningStatementDao.java
+++ b/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/ernstmt/RestEarningStatementDao.java
@@ -19,8 +19,9 @@
 
 package edu.wisc.cypress.dao.ernstmt;
 
-
-
+import edu.wisc.hr.dao.ernstmt.SimpleEarningsStatementDao;
+import edu.wisc.hr.dm.ernstmt.SimpleEarningsStatement;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -44,7 +45,8 @@ import edu.wisc.hr.dm.ernstmt.EarningStatements;
  * @author Eric Dalquist
  */
 @Repository("restEarningStatementDao")
-public class RestEarningStatementDao implements EarningStatementDao {
+public class RestEarningStatementDao
+    implements EarningStatementDao, SimpleEarningsStatementDao {
 
   protected final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -111,5 +113,39 @@ public class RestEarningStatementDao implements EarningStatementDao {
     }
 
     return earningStatements;
+  }
+
+
+  @Override
+  public List<SimpleEarningsStatement> statementsForEmployee(String emplid) {
+
+    /*
+     * Converts from legacy list of Cypress-specific earning statements to
+     * modern list of SimpleEarningsStatement .
+     */
+
+    if (null == emplid) {
+      throw new NullPointerException(
+        "Cannot query statements for null emplid.");
+    }
+
+    EarningStatements cypressSpecificEarningStatements =
+      this.getEarningStatements(emplid);
+
+    List<EarningStatement> cypressSpecificEarningStatementsList =
+      cypressSpecificEarningStatements.getEarningStatements();
+
+    List<SimpleEarningsStatement> simpleEarningsStatements =
+      new ArrayList<SimpleEarningsStatement>();
+
+    for (EarningStatement cypressSpecificEarningStatement :
+        cypressSpecificEarningStatementsList) {
+
+      SimpleEarningsStatement statement = new SimpleEarningsStatement();
+      
+
+    }
+
+    return simpleEarningsStatements;
   }
 }

--- a/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/ernstmt/RestEarningStatementDao.java
+++ b/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/ernstmt/RestEarningStatementDao.java
@@ -54,6 +54,10 @@ public class RestEarningStatementDao
   private String statementsUrl;
   private String statementUrl;
 
+  // TODO: rather than hard coding Madison value, get correct fname
+  private CypressEarningStatementToSimpleEarningStatementConverter converter =
+      new CypressEarningStatementToSimpleEarningStatementConverter("earnings-statement");
+
   @Autowired
   public void setRestTemplate(ExtendedRestOperations restOperations) {
     this.restOperations = restOperations;
@@ -129,20 +133,21 @@ public class RestEarningStatementDao
         "Cannot query statements for null emplid.");
     }
 
-    EarningStatements cypressSpecificEarningStatements =
+    final EarningStatements cypressSpecificEarningStatements =
       this.getEarningStatements(emplid);
 
-    List<EarningStatement> cypressSpecificEarningStatementsList =
+    final List<EarningStatement> cypressSpecificEarningStatementsList =
       cypressSpecificEarningStatements.getEarningStatements();
 
-    List<SimpleEarningsStatement> simpleEarningsStatements =
+    final List<SimpleEarningsStatement> simpleEarningsStatements =
       new ArrayList<SimpleEarningsStatement>();
 
-    for (EarningStatement cypressSpecificEarningStatement :
+    for (final EarningStatement cypressSpecificEarningStatement :
         cypressSpecificEarningStatementsList) {
 
-      SimpleEarningsStatement statement = new SimpleEarningsStatement();
-      
+      final SimpleEarningsStatement statement =
+          this.converter.convertToSimpleEarningsStatement(cypressSpecificEarningStatement);
+      simpleEarningsStatements.add(statement);
 
     }
 

--- a/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/ernstmt/RestEarningStatementDao.java
+++ b/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/ernstmt/RestEarningStatementDao.java
@@ -54,9 +54,15 @@ public class RestEarningStatementDao
   private String statementsUrl;
   private String statementUrl;
 
-  // TODO: rather than hard coding Madison value, get correct fname
+  // TODO: rather than hard coding fname, somehow get the fname of the
+  // relevant Payroll Information fname
   private CypressEarningStatementToSimpleEarningStatementConverter converter =
-      new CypressEarningStatementToSimpleEarningStatementConverter("earnings-statement");
+      new CypressEarningStatementToSimpleEarningStatementConverter("earnings-statement-for-all");
+      // Depends upon a publication of Payroll Information as fname
+      // `earnings-statement-for-all` as the statically addressable server of
+      // Cypress earnings statement PDFs. i.e., a copy-and-paste of
+      // `earnings-statement` entity except with SUBSCRIBE granted to both
+      // Madison and System employees.
 
   @Autowired
   public void setRestTemplate(ExtendedRestOperations restOperations) {

--- a/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/ernstmt/CypressEarningStatementToSimpleEarningStatementConverterTest.java
+++ b/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/ernstmt/CypressEarningStatementToSimpleEarningStatementConverterTest.java
@@ -2,8 +2,10 @@ package edu.wisc.cypress.dao.ernstmt;
 
 import static org.junit.Assert.*;
 
+import edu.wisc.hr.dm.ernstmt.EarningStatement;
 import edu.wisc.hr.dm.ernstmt.SimpleEarningsStatement;
 import java.math.BigInteger;
+import org.joda.time.LocalDate;
 import org.junit.Test;
 
 
@@ -13,7 +15,7 @@ public class CypressEarningStatementToSimpleEarningStatementConverterTest {
   public void convertingNullStatementThrowsNullPointerException() {
 
     CypressEarningStatementToSimpleEarningStatementConverter converter =
-        new CypressEarningStatementToSimpleEarningStatementConverter();
+        new CypressEarningStatementToSimpleEarningStatementConverter("someFName");
 
     converter.convertToSimpleEarningsStatement(null);
   }
@@ -22,31 +24,42 @@ public class CypressEarningStatementToSimpleEarningStatementConverterTest {
   public void convertsSampleCypressEarningsStatement() {
 
     CypressEarningStatementToSimpleEarningStatementConverter converter =
-        new CypressEarningStatementToSimpleEarningStatementConverter();
+        new CypressEarningStatementToSimpleEarningStatementConverter("someFName");
 
     EarningStatement sampleCypressStatement = new EarningStatement();
-    // example data from
+    // example data evolved from
     // /hrs-portlets-cypress-impl/test/resources/sampleData/earning-statements.xml
-    sampleCypressStatement.setAmount(" $4,625.12");
+    sampleCypressStatement.setAmount("$4,625.12");
     sampleCypressStatement.setDocId(BigInteger.valueOf(8421763));
-    sampleCypressStatement.setEarned(" OCT 10");
+    sampleCypressStatement.setEarned("OCT 10");
     sampleCypressStatement.setFullTitle(
         "PAID:11/01/10_EARNED:EARNED OCT 10_Net: $4,625.12");
-    sampleCypressStatement.setPaid("11/01/10");
+    sampleCypressStatement.setPaid("11/01/2010");
 
     SimpleEarningsStatement convertedStatement =
         converter.convertToSimpleEarningsStatement(sampleCypressStatement);
 
-    assertNotNull(convertedStatement);
-    assertEquals("2010-11-01", convertedStatement.getIsoDateOfCheck());
-    assertEquals("11/01/2010", convertedStatement.getUsDateOfCheck());
+    sampleCypressStatement = null; // ensure test doesn't reference input directly
 
+    assertNull(sampleCypressStatement);
+
+    assertNotNull(convertedStatement);
+
+    assertEquals("$4,625.12", convertedStatement.getAmount());
+
+    assertEquals("OCT 10", convertedStatement.getEarned());
+
+    assertEquals(new LocalDate("2010-11-01"), convertedStatement.getDateOfCheck());
+    assertEquals("2010-11-01", convertedStatement.getIsoDateOfCheck());
+
+    assertEquals("/portal/p/someFName/exclusive/earning_statement.pdf.resource.uP?pP_docId=8421763",
+        convertedStatement.getUrl());
   }
 
   @Test
   public void failsGracefullyOnBogusPaidDate() {
     CypressEarningStatementToSimpleEarningStatementConverter converter =
-        new CypressEarningStatementToSimpleEarningStatementConverter();
+        new CypressEarningStatementToSimpleEarningStatementConverter("someFName");
 
     EarningStatement sampleCypressStatement = new EarningStatement();
     // example data from
@@ -63,7 +76,7 @@ public class CypressEarningStatementToSimpleEarningStatementConverterTest {
 
     assertNotNull(convertedStatement);
     assertEquals("unknown", convertedStatement.getIsoDateOfCheck());
-    assertEquals("unknown", convertedStatement.getUsDateOfCheck());
+    assertEquals("unknown", convertedStatement.getPaid());
   }
 
 }

--- a/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/ernstmt/CypressEarningStatementToSimpleEarningStatementConverterTest.java
+++ b/hrs-portlets-cypress-impl/src/test/java/edu/wisc/cypress/dao/ernstmt/CypressEarningStatementToSimpleEarningStatementConverterTest.java
@@ -1,0 +1,69 @@
+package edu.wisc.cypress.dao.ernstmt;
+
+import static org.junit.Assert.*;
+
+import edu.wisc.hr.dm.ernstmt.SimpleEarningsStatement;
+import java.math.BigInteger;
+import org.junit.Test;
+
+
+public class CypressEarningStatementToSimpleEarningStatementConverterTest {
+
+  @Test(expected = NullPointerException.class)
+  public void convertingNullStatementThrowsNullPointerException() {
+
+    CypressEarningStatementToSimpleEarningStatementConverter converter =
+        new CypressEarningStatementToSimpleEarningStatementConverter();
+
+    converter.convertToSimpleEarningsStatement(null);
+  }
+
+  @Test
+  public void convertsSampleCypressEarningsStatement() {
+
+    CypressEarningStatementToSimpleEarningStatementConverter converter =
+        new CypressEarningStatementToSimpleEarningStatementConverter();
+
+    EarningStatement sampleCypressStatement = new EarningStatement();
+    // example data from
+    // /hrs-portlets-cypress-impl/test/resources/sampleData/earning-statements.xml
+    sampleCypressStatement.setAmount(" $4,625.12");
+    sampleCypressStatement.setDocId(BigInteger.valueOf(8421763));
+    sampleCypressStatement.setEarned(" OCT 10");
+    sampleCypressStatement.setFullTitle(
+        "PAID:11/01/10_EARNED:EARNED OCT 10_Net: $4,625.12");
+    sampleCypressStatement.setPaid("11/01/10");
+
+    SimpleEarningsStatement convertedStatement =
+        converter.convertToSimpleEarningsStatement(sampleCypressStatement);
+
+    assertNotNull(convertedStatement);
+    assertEquals("2010-11-01", convertedStatement.getIsoDateOfCheck());
+    assertEquals("11/01/2010", convertedStatement.getUsDateOfCheck());
+
+  }
+
+  @Test
+  public void failsGracefullyOnBogusPaidDate() {
+    CypressEarningStatementToSimpleEarningStatementConverter converter =
+        new CypressEarningStatementToSimpleEarningStatementConverter();
+
+    EarningStatement sampleCypressStatement = new EarningStatement();
+    // example data from
+    // /hrs-portlets-cypress-impl/test/resources/sampleData/earning-statements.xml
+    sampleCypressStatement.setAmount(" $4,625.12");
+    sampleCypressStatement.setDocId(BigInteger.valueOf(8421763));
+    sampleCypressStatement.setEarned(" OCT 10");
+    sampleCypressStatement.setFullTitle(
+        "PAID:11/01/10_EARNED:EARNED OCT 10_Net: $4,625.12");
+    sampleCypressStatement.setPaid("garbage-in");
+
+    SimpleEarningsStatement convertedStatement =
+        converter.convertToSimpleEarningsStatement(sampleCypressStatement);
+
+    assertNotNull(convertedStatement);
+    assertEquals("unknown", convertedStatement.getIsoDateOfCheck());
+    assertEquals("unknown", convertedStatement.getUsDateOfCheck());
+  }
+
+}

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/EarningStatementDataController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/EarningStatementDataController.java
@@ -59,7 +59,7 @@ public class EarningStatementDataController {
    */
   private EarningStatementDao earningStatementDao;
 
-  private SimpleEarningsStatementDao earningsStatementDao;
+
 
     private Set<String> ignoredProxyHeaders;
     
@@ -71,11 +71,6 @@ public class EarningStatementDataController {
     @Autowired
     public void setEarningStatementDao(EarningStatementDao earningStatementDao) {
         this.earningStatementDao = earningStatementDao;
-    }
-
-    @Autowired
-    public void setEarningsStatementDao(SimpleEarningsStatementDao simpleEarningsStatementDao) {
-      this.earningsStatementDao = simpleEarningsStatementDao;
     }
 
     /**

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/EarningStatementDataController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/EarningStatementDataController.java
@@ -93,25 +93,6 @@ public class EarningStatementDataController {
         return "reportAttrJsonView";
     }
 
-    /**
-     * JSON representing the employee's earnings statements.
-     *
-     * @param modelMap
-     * @return "reportAttrJsonView" indicating the view to turn the modelMap into JSON
-     */
-    @ResourceMapping("earningsStatements")
-    public String earningsStatements(ModelMap modelMap) {
-
-      final String emplid = PrimaryAttributeUtils.getPrimaryId();
-
-      final List<SimpleEarningsStatement> earningsStatements =
-          this.earningsStatementDao.statementsForEmployee(emplid);
-
-      modelMap.addAttribute("report", earningsStatements);
-
-      return "reportAttrJsonView";
-    }
-
     //Server
     //
     @ResourceMapping("earning_statement.pdf")

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollInformationController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollInformationController.java
@@ -20,7 +20,9 @@
 package edu.wisc.portlet.hrs.web.payroll;
 
 import edu.wisc.hr.dao.ernstmt.SimpleEarningsStatementDao;
+import edu.wisc.hr.dm.ernstmt.RetrievedEarningsStatements;
 import edu.wisc.hr.dm.ernstmt.SimpleEarningsStatement;
+import edu.wisc.hr.service.ernstmt.EarningsStatementService;
 import java.util.List;
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
@@ -45,7 +47,7 @@ import edu.wisc.portlet.hrs.web.HrsControllerBase;
 @RequestMapping("VIEW")
 public class PayrollInformationController extends HrsControllerBase {
     private ContactInfoDao contactInfoDao;
-    private SimpleEarningsStatementDao earningsStatementDao;
+    private EarningsStatementService earningsStatementService;
 
     @Autowired
     public void setContactInfoDao(ContactInfoDao contactInfoDao) {
@@ -53,8 +55,8 @@ public class PayrollInformationController extends HrsControllerBase {
     }
 
     @Autowired
-    public void setEarningsStatementDao(SimpleEarningsStatementDao simpleEarningsStatementDao) {
-        this.earningsStatementDao = simpleEarningsStatementDao;
+    public void setEarningsStatementService(EarningsStatementService service) {
+        this.earningsStatementService = service;
     }
     
     /**
@@ -81,13 +83,11 @@ public class PayrollInformationController extends HrsControllerBase {
             model.addAttribute("personalDataError", true);
         }
 
-        try {
-            model.addAttribute("earningsStatements",
-                this.earningsStatementDao.statementsForEmployee(emplId));
-        } catch (Exception e) {
-            logger.warn("Exception getting earnings statements for " + emplId, e);
-            model.addAttribute("earningsStatementsError", true);
-        }
+        final RetrievedEarningsStatements statements =
+            this.earningsStatementService.statementsForEmplid(emplId);
+
+        model.addAttribute("earningsStatements", statements.getStatements());
+        model.addAttribute("earningsStatementsError", statements.isErrored());
         
         return "payrollInformation";
     }

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/TroubleshootingController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/troubleshoot/TroubleshootingController.java
@@ -3,7 +3,9 @@ package edu.wisc.portlet.hrs.web.troubleshoot;
 import edu.wisc.hr.dao.ernstmt.EarningStatementDao;
 import edu.wisc.hr.dao.ernstmt.SimpleEarningsStatementDao;
 import edu.wisc.hr.dao.roles.HrsRolesDao;
+import edu.wisc.hr.dm.ernstmt.RetrievedEarningsStatements;
 import edu.wisc.hr.dm.ernstmt.SimpleEarningsStatement;
+import edu.wisc.hr.service.ernstmt.EarningsStatementService;
 import edu.wisc.portlet.hrs.web.HrsControllerBase;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,17 +26,13 @@ public class TroubleshootingController
 
   private HrsRolesDao rolesDao;
 
-  public SimpleEarningsStatementDao getEarningsStatementsDao() {
-    return earningsStatementsDao;
-  }
+  private EarningsStatementService earningsStatementService;
 
   @Autowired
-  public void setEarningsStatementsDao(
-      SimpleEarningsStatementDao earningsStatementsDao) {
-    this.earningsStatementsDao = earningsStatementsDao;
+  public void setEarningsStatementService(
+      EarningsStatementService earningsStatementService) {
+    this.earningsStatementService = earningsStatementService;
   }
-
-  private SimpleEarningsStatementDao earningsStatementsDao;
 
   public HrsRolesDao getRolesDao() {
     return rolesDao;
@@ -72,13 +70,17 @@ public class TroubleshootingController
 
       List<SimpleEarningsStatement> earningsStatements = new ArrayList<SimpleEarningsStatement>();
 
-      try {
-        modelMap.put("earningsStatements",
-            earningsStatementsDao.statementsForEmployee(queriedEmplId));
-      } catch (Exception e) {
-        logger.warn("Failed to get earnings statements for emplid " + queriedEmplId, e);
-        modelMap.put("earningsStatementsError", e.getMessage());
+      RetrievedEarningsStatements retrievedEarningsStatements =
+          this.earningsStatementService.statementsForEmplid(queriedEmplId);
+
+      modelMap.put("earningsStatements",
+          retrievedEarningsStatements.getStatements());
+
+      if (retrievedEarningsStatements.isErrored()) {
+        Exception firstError = retrievedEarningsStatements.getErrors().get(0);
+        modelMap.put("earningsStatementsError", firstError.getMessage());
       }
+
 
     }
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/context/portlet/payroll-information.xml
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/context/portlet/payroll-information.xml
@@ -35,7 +35,16 @@
     <aop:config proxy-target-class="true" />
     <security:global-method-security secured-annotations="enabled" pre-post-annotations="enabled" proxy-target-class="true"/>
     <context:component-scan base-package="edu.wisc.portlet.hrs.web.payroll"/>
-    
+
+    <bean class="edu.wisc.hr.service.ernstmt.MergingEarningsStatementService">
+        <property name="daos">
+            <list>
+                <ref bean="restEarningStatementDao"/>
+                <ref bean="soapEarningsStatementDao"/>
+            </list>
+        </property>
+    </bean>
+
     <bean class="org.springframework.web.portlet.mvc.annotation.DefaultAnnotationHandlerMapping">
         <property name="interceptors" ref="defaultPortletInterceptors" />
     </bean>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/context/portlet/troubleshooting.xml
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/context/portlet/troubleshooting.xml
@@ -34,6 +34,16 @@
   <aop:config proxy-target-class="true" />
   <security:global-method-security secured-annotations="enabled" pre-post-annotations="enabled" proxy-target-class="true"/>
   <context:component-scan base-package="edu.wisc.portlet.hrs.web.troubleshoot"/>
+
+  <bean class="edu.wisc.hr.service.ernstmt.MergingEarningsStatementService">
+    <property name="daos">
+      <list>
+        <ref bean="restEarningStatementDao"/>
+        <ref bean="soapEarningsStatementDao"/>
+      </list>
+    </property>
+  </bean>
+
   <bean class="org.springframework.web.portlet.mvc.annotation.DefaultAnnotationHandlerMapping">
     <property name="interceptors" ref="defaultPortletInterceptors" />
   </bean>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -91,15 +91,17 @@
       </div>
       <div class="fl-pager">
 
+       <c:if test="${earningsStatementsError}">
+        <p>Error loading
+          <c:if test="${not empty earningsStatements}">some of </c:if>
+          your earnings statements. Try again later or contact the Help Desk.</p>
+        <c:if test="${not empty earningsStatements}">
+          <p>MyUW successfully loaded others of your earnings statements, shown below.</p>
+        </c:if>
+       </c:if>
 
-        <c:choose>
-        <c:when test="${earningsStatementsError}">
-        <p>Error loading your earnings statements. Try again later or contact the Help Desk.</p>
-        </c:when>
-        <c:when test="${empty earningsStatements}">
-        <p>You have no earnings statements.</p>
-        </c:when>
-        <c:otherwise>
+       <c:choose>
+        <c:when test="${not empty earningsStatements}">
         <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
           <table class="dl-table table" tabindex="0" aria-label="Earnings Statements detail table">
             <thead>
@@ -181,6 +183,11 @@
             <a href="${understandingEarningUrl}" target="_blank">Understanding Your Earnings Statement</a>
           </div>
       </c:if>
+      </c:when>
+
+      <c:when test="${empty earningsStatements && !earningsStatementsError}">
+        <p>You have no earnings statements.</p>
+      </c:when>
 
       </c:otherwise>
       </c:choose>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -189,7 +189,6 @@
         <p>You have no earnings statements.</p>
       </c:when>
 
-      </c:otherwise>
       </c:choose>
 
       <div class="dl-link">


### PR DESCRIPTION
BREAKING CHANGE: introduces dependency on new `earnings-statement-for-all` fname, for rendering the Cypress earnings statement PDFs (so can be addressed at same host-relative path regardless of system or madison-ness.)