### PR TITLE
HRSPLT-399 Fix show more earnings statements toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 The v6 major version was occasioned by introducing dependency on a new
 publication of Payroll Information as fname `earnings-statement-for-all`.
 
+### 6.0.2 fix show all earnings statements toggle
+
++ Fix reference to the show all earnings statements toggle ( [HRSPLT-399][],  )
+
 ### 6.0.1 fix earnings statements sort
 
 2018-11-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 
 ### 6.0.2 fix show all earnings statements toggle
 
-+ Fix reference to the show all earnings statements toggle ( [HRSPLT-399][],  )
++ Fix reference to the show all earnings statements toggle ( [HRSPLT-399][],
+  [#166][] )
 
 ### 6.0.1 fix earnings statements sort
 
@@ -811,6 +812,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#162]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/162
 [#163]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/163
 [#164]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/164
+[#166]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/166
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,8 +1,3 @@
 # Known issues
 
-+ In Payroll Information, JavaScript error:
-  `Syntax error, unrecognized expression: #$dl-show-all-earnings-statements-toggle`
-  with consequences
-  + Breaks show-all UI control
-  + Breaks tab switching
-
+(none)

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -416,7 +416,7 @@
         };
 
           var showAllEarningsStatementsToggle =
-            $("#$dl-show-all-earnings-statements-toggle");
+            $("#${n}dl-show-all-earnings-statements-toggle");
           showAllEarningsStatementsToggle.change(function() {
             updateShowAllEarningsStatements(showAllEarningsStatementsToggle);
           });


### PR DESCRIPTION
The reference to the toggle had failed to include the `{n}` namespacer. This should get the reference to match the element referenced. Thereby the JavaScript in this page will stop crashing and so the things that depend on running JavaScript in the page will again work. Also, showing and hiding suprlus earnings statements should work.