### PR TITLE
HRSPLT-402 predicate HRS earnings statements on HRS URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
   showing errors to employees (that is, differentiating the
   HRS-earnings-statements-should-be-working-but-are-broken case from the
   HRS-earnings-statements-are-not-yet-expected-to-be-working case). (
-  [HRSPLT-402][],  )
+  [HRSPLT-402][], [#167][] )
 
 ### 6.0.1 fix earnings statements sort
 
@@ -819,6 +819,8 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#162]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/162
 [#163]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/163
 [#164]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/164
+[#167]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/167
+
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 The v6 major version was occasioned by introducing dependency on a new
 publication of Payroll Information as fname `earnings-statement-for-all`.
 
+### 6.0.2 predicate HRS earnings statements on URL
+
+2018-12-03
+
++ Only query for HRS earnings statements when the HRS URL "Earning Statement"
+  (sic) is set. This allows promoting a hrs-portlets version that supports HRS
+  earnings statements in advance of HRS supporting earnings statements, without
+  showing errors to employees (that is, differentiating the
+  HRS-earnings-statements-should-be-working-but-are-broken case from the
+  HRS-earnings-statements-are-not-yet-expected-to-be-working case). (
+  [HRSPLT-402][],  )
+
 ### 6.0.1 fix earnings statements sort
 
 2018-11-30
@@ -832,3 +844,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-399]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-399
 [HRSPLT-400]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-400
 [HRSPLT-401]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-401
+[HRSPLT-402]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-402

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/service/ernstmt/MergingEarningsStatementService.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/service/ernstmt/MergingEarningsStatementService.java
@@ -1,13 +1,28 @@
 package edu.wisc.hr.service.ernstmt;
 
 import edu.wisc.hr.dao.ernstmt.SimpleEarningsStatementDao;
+import edu.wisc.hr.dao.url.HrsUrlDao;
 import edu.wisc.hr.dm.ernstmt.RetrievedEarningsStatements;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.StringUtils;
 
+/**
+ * Merging earnings statement service that collects earnings statements from both HRS and Cypress,
+ * merging these together into a single bundle of earnings statements.
+ *
+ * Both DAOs are optional. Turn off HRS or Cypress as earnings statement source by not setting that
+ * DAO. Additionally, will not query HRS earnings statements if HrsUrlDao.EARNINGS_STATEMENT_KEY is
+ * not set, so HRS earnings statement support can be held back by holding back setting that URL.
+ */
 public class MergingEarningsStatementService
   implements EarningsStatementService {
 
-  private List<SimpleEarningsStatementDao> daos;
+  private SimpleEarningsStatementDao hrsEarningsStatementDao;
+
+  private SimpleEarningsStatementDao cypressEarningsStatementDao;
+
+  private HrsUrlDao urlDao;
 
   @Override
   public RetrievedEarningsStatements statementsForEmplid(String emplid) {
@@ -15,9 +30,23 @@ public class MergingEarningsStatementService
     final RetrievedEarningsStatements retrievedEarningsStatements =
         new RetrievedEarningsStatements();
 
-    for (SimpleEarningsStatementDao dao : daos) {
+    // only try to get HRS earnings statements if the HRS "Earning Statement" URL is configured.
+
+    String hrsEarningsStatementUrl = urlDao.getHrsUrls().get(HrsUrlDao.EARNINGS_STATEMENT_KEY);
+
+    if (null != hrsEarningsStatementDao && StringUtils.hasText(hrsEarningsStatementUrl)) {
       try {
-        retrievedEarningsStatements.addStatements(dao.statementsForEmployee(emplid));
+        retrievedEarningsStatements.addStatements(
+            hrsEarningsStatementDao.statementsForEmployee(emplid));
+      } catch (Exception e) {
+        retrievedEarningsStatements.registerError(e);
+      }
+    }
+
+    if (null != cypressEarningsStatementDao) {
+      try {
+        retrievedEarningsStatements.addStatements(
+            cypressEarningsStatementDao.statementsForEmployee(emplid));
       } catch (Exception e) {
         retrievedEarningsStatements.registerError(e);
       }
@@ -26,11 +55,19 @@ public class MergingEarningsStatementService
     return retrievedEarningsStatements;
   }
 
-  public List<SimpleEarningsStatementDao> getDaos() {
-    return daos;
+  public void setHrsEarningsStatementDao(
+      SimpleEarningsStatementDao hrsEarningsStatementDao) {
+    this.hrsEarningsStatementDao = hrsEarningsStatementDao;
   }
 
-  public void setDaos(List<SimpleEarningsStatementDao> daos) {
-    this.daos = daos;
+  public void setCypressEarningsStatementDao(
+      SimpleEarningsStatementDao cypressEarningsStatementDao) {
+    this.cypressEarningsStatementDao = cypressEarningsStatementDao;
   }
+
+  @Autowired
+  public void setUrlDao(HrsUrlDao urlDao) {
+    this.urlDao = urlDao;
+  }
+
 }

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/context/portlet/payroll-information.xml
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/context/portlet/payroll-information.xml
@@ -37,11 +37,11 @@
     <context:component-scan base-package="edu.wisc.portlet.hrs.web.payroll"/>
 
     <bean class="edu.wisc.hr.service.ernstmt.MergingEarningsStatementService">
-        <property name="daos">
-            <list>
-                <ref bean="restEarningStatementDao"/>
-                <ref bean="soapEarningsStatementDao"/>
-            </list>
+        <property name="hrsEarningsStatementDao">
+            <ref bean="soapEarningsStatementDao"/>
+        </property>
+        <property name="cypressEarningsStatementDao">
+            <ref bean="restEarningStatementDao"/>
         </property>
     </bean>
 


### PR DESCRIPTION
Don't attempt to query HRS earnings statements in the case where HRS earnings statements are not yet expected to work.

Avoids a premature error to employees.