### PR TITLE
Fix bugged "Tax Statements" tab (div matching)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 
 (No changes so far.)
 
+### 6.0.4 fix tax statements tab
+
++ Fix div matching bug that under some circumstances would break the tax
+  tax statements tab in Payroll Information ( [HRSPLT-404][], [#169][] )
+
 ### 6.0.3 fix troubleshooter
 
 2018-12-06
@@ -836,6 +841,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#166]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/166
 [#167]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/167
 [#168]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/168
+[#169]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/169
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348
@@ -863,3 +869,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-401]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-401
 [HRSPLT-402]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-402
 [HRSPLT-403]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-403
+[HRSPLT-404]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-404

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -180,9 +180,8 @@
                   name="dl-show-all-earnings-statements-toggle" />
               </form>
             </div>
+          </c:if>
         </div>
-        </c:if>
-      </div>
       <c:if test="${not empty understandingEarningUrl}">
           <div class="dl-link">
             <a href="${understandingEarningUrl}" target="_blank">Understanding Your Earnings Statement</a>
@@ -242,6 +241,7 @@
         </sec:authorize>
       </div>
 
+      </div>
     </div>
     <div id="${n}dl-tax-statements" class="dl-tax-statements ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
 


### PR DESCRIPTION
Fix div matching bug that would under some circumstances make the Tax Statements tab content a child of rather than a sibling of the Earnings Statements tab content, breaking the datalist tab switching panel UI control such that selecting the Tax Statements tab would render an empty tab.