### PR TITLE
fix: do not open surplus earnings statements using JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 
 ### (Unreleased)
 
++ fix: open surplus earnings statements like opening the first ten earnings
+  statements, not with JavaScript that'll trigger pop-up blockers.
 + style: obsessively 2-space-indent `payrollInformation.jsp` in the hope of
   sooner detecting future bugs like HRSPLT-404.
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -162,18 +162,21 @@
                     <c:set var="surplusEarningsStatements" value="true" />
                     <tr class="earnings-statement-beyond-ten" style="display:none">
                       <td headers="paid" class="dl-data-text">
-                        <a href="javascript:window.open('${earningsStatement.url}');">
+                        <a href="${earningsStatement.url}"
+                          target="_blank" rel="noopener noreferrrer">
                           ${earningsStatement.paid}
                         </a>
                       </td>
                       <td headers="earned" class="dl-data-text">
-                        <a href="javascript:window.open('${earningsStatement.url}');">
+                        <a href="${earningsStatement.url}"
+                          target="_blank" rel="noopener noreferrrer">
                           ${earningsStatement.earned}
                         </a>
                       </td>
                       <td headers="amount" class="dl-data-number">
                         <a class="dl-earning-amount"
-                          href="javascript:window.open('${earningsStatement.url}');">
+                          href="${earningsStatement.url}"
+                          target="_blank" rel="noopener noreferrrer">
                           ${earningsStatement.amount}
                         </a>
                       </td>


### PR DESCRIPTION
the JavaScript will trigger popup blockers, let's avoid that.