### PR TITLE
HRSPLT-408 log at DEBUG on HRS integration SOAP faults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 
 ### (Unreleased)
 
++ fix: log at DEBUG level the SOAP message when encountering a SOAP fault in the HRS integration (
+  [HRSPLT-408][])
+
 ### 6.0.5 avoid popups in surplus earnings statement hyperlinks
 
 2018-12-10
@@ -883,3 +886,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-402]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-402
 [HRSPLT-403]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-403
 [HRSPLT-404]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-404
+[HRSPLT-404]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-408

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 ### (Unreleased)
 
 + fix: log at DEBUG level the SOAP message when encountering a SOAP fault in the HRS integration (
-  [HRSPLT-408][])
+  [HRSPLT-408][], [#172][])
 
 ### 6.0.5 avoid popups in surplus earnings statement hyperlinks
 
@@ -858,6 +858,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#167]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/167
 [#168]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/168
 [#169]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/169
+[#172]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/172
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/ResponseLoggingFaultResolver.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/ResponseLoggingFaultResolver.java
@@ -1,0 +1,35 @@
+package edu.wisc.hrs.dao;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ws.WebServiceMessage;
+import org.springframework.ws.client.core.FaultMessageResolver;
+import org.springframework.ws.soap.SoapMessage;
+import org.springframework.ws.soap.client.SoapFaultClientException;
+
+public class ResponseLoggingFaultResolver
+  implements FaultMessageResolver {
+
+  protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+  @Override
+  public void resolveFault(WebServiceMessage message) throws IOException {
+
+    if (logger.isDebugEnabled()) {
+
+      ByteArrayOutputStream messageAsOutputStream = new ByteArrayOutputStream();
+
+      message.writeTo(messageAsOutputStream);
+
+      String messageAsString = messageAsOutputStream.toString();
+
+      logger.debug("Error response: [" + messageAsString + "]");
+    }
+
+    // do what SoapFaultMessageResolver does
+    SoapMessage soapMessage = (SoapMessage) message;
+    throw new SoapFaultClientException(soapMessage);
+  }
+}

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -255,7 +255,11 @@
         <property name="interceptors" ref="hrsWss4jSecurityInterceptor" />
         <property name="messageSender" ref="hrsWebServiceMessageSender" />
         <property name="checkConnectionForFault" value="false" />
+        <property name="faultMessageResolver" ref="hrsFaultMessageResolver"/>
     </bean>
+
+    <bean id="hrsFaultMessageResolver" class="edu.wisc.hrs.dao.ResponseLoggingFaultResolver" />
+
     <bean id="hrsMarshaller" class="org.springframework.oxm.jaxb.Jaxb2Marshaller">
         <property name="contextPaths">
             <list>


### PR DESCRIPTION
Add a custom `FaultMessageResolver` that does what the default resolver does, except first logs the fault message at DEBUG level.

This is a stab at making it feasible to log the body of the HRS SOAP 500 response currently breaking the approvals count widget. The idea would be to merge, release, migrate this, bump the logging to DEBUG in stage, exercise the broken widget, and see if something useful appears in the log.