### PR TITLE
HRSPLT-408 try to DEBUG / TRACE log raw response in error case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 
 ### (Unreleased)
 
-+ fix: log at DEBUG level the SOAP message when encountering a SOAP fault in the HRS integration (
-  [HRSPLT-408][], [#172][])
++ experimental: fix: log at DEBUG level when encountering error sending-and-receiving a SOAP 
+  message. At TRACE level log the raw response. Special handling when the error is a SOAP fault and 
+  hrs-portlets understands that it's a SOAP fault. ( [HRSPLT-408][], [#172][], [#173][] )
 
 ### 6.0.5 avoid popups in surplus earnings statement hyperlinks
 
@@ -859,6 +860,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#168]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/168
 [#169]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/169
 [#172]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/172
+[#173]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/173
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -249,7 +249,7 @@
     </bean>
 
 
-    <bean id="baseHrsWebServiceTemplate" class="org.jasig.springframework.ws.client.core.DestinationOverridingWebServiceTemplate" abstract="true">
+    <bean id="baseHrsWebServiceTemplate" class="edu.wisc.portlet.hrs.util.ErrorLoggingDestinationOverridingWebServiceTemplate" abstract="true">
         <property name="marshaller" ref="hrsMarshaller" />
         <property name="unmarshaller" ref="hrsMarshaller" />
         <property name="interceptors" ref="hrsWss4jSecurityInterceptor" />

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/util/ErrorLoggingDestinationOverrridingWebServiceTemplate.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/util/ErrorLoggingDestinationOverrridingWebServiceTemplate.java
@@ -1,0 +1,163 @@
+package edu.wisc.portlet.hrs.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.xml.transform.TransformerException;
+import org.jasig.springframework.ws.client.core.DestinationOverridingWebServiceTemplate;
+import org.springframework.ws.WebServiceMessage;
+import org.springframework.ws.client.WebServiceClientException;
+import org.springframework.ws.client.WebServiceTransformerException;
+import org.springframework.ws.client.core.WebServiceMessageCallback;
+import org.springframework.ws.client.core.WebServiceMessageExtractor;
+import org.springframework.ws.client.support.interceptor.ClientInterceptor;
+import org.springframework.ws.context.MessageContext;
+import org.springframework.ws.transport.WebServiceConnection;
+
+/**
+ * Extends superclass attempting to log the raw response at TRACE level when erring while sending
+ * and receiving a web service message.
+ */
+public class ErrorLoggingDestinationOverrridingWebServiceTemplate
+  extends DestinationOverridingWebServiceTemplate  {
+
+  /*
+   * Implementation copied from super-class.
+   */
+  @SuppressWarnings("unchecked")
+  @Override
+  protected <T> T doSendAndReceive(MessageContext messageContext,
+      WebServiceConnection connection,
+      WebServiceMessageCallback requestCallback,
+      WebServiceMessageExtractor<T> responseExtractor) throws IOException {
+    try {
+      if (requestCallback != null) {
+        requestCallback.doWithMessage(messageContext.getRequest());
+      }
+      // Apply handleRequest of registered interceptors
+      int interceptorIndex = -1;
+
+      ClientInterceptor[] interceptors = getInterceptors();
+
+      if (interceptors != null) {
+        for (int i = 0; i < interceptors.length; i++) {
+          interceptorIndex = i;
+          if (!interceptors[i].handleRequest(messageContext)) {
+            break;
+          }
+        }
+      }
+      // if an interceptor has set a response, we don't send/receive
+      if (!messageContext.hasResponse()) {
+        sendRequest(connection, messageContext.getRequest());
+        if (hasError(connection, messageContext.getRequest())) {
+
+          // MODIFIED: attempt to get and log the response
+          if (logger.isDebugEnabled()) { // logResponse is a no-op above DEBUG logging
+            try {
+              WebServiceMessage response = connection.receive(getMessageFactory());
+              messageContext.setResponse(response);
+              logResponse(messageContext);
+            } catch (Exception e) {
+              logger.warn("In error case. Failed to log response.", e);
+            }
+          }
+
+          return (T)handleError(connection, messageContext.getRequest());
+        }
+        WebServiceMessage response = connection.receive(getMessageFactory());
+        messageContext.setResponse(response);
+      }
+      logResponse(messageContext);
+      if (messageContext.hasResponse()) {
+        if (!hasFault(connection, messageContext.getResponse())) {
+          triggerHandleResponse(interceptorIndex, messageContext);
+          return responseExtractor.extractData(messageContext.getResponse());
+        }
+        else {
+          triggerHandleFault(interceptorIndex, messageContext);
+          return (T)handleFault(connection, messageContext);
+        }
+      }
+      else {
+        return null;
+      }
+    }
+    catch (TransformerException ex) {
+      throw new WebServiceTransformerException("Transformation error: " + ex.getMessage(), ex);
+    }
+  }
+
+  /*
+   * Copied from superclass to make private method available to this sub-class.
+   */
+  private void sendRequest(WebServiceConnection connection, WebServiceMessage request) throws IOException {
+    if (sentMessageTracingLogger.isTraceEnabled()) {
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      request.writeTo(os);
+      sentMessageTracingLogger.trace("Sent request [" + os.toString("UTF-8") + "]");
+    }
+    else if (sentMessageTracingLogger.isDebugEnabled()) {
+      sentMessageTracingLogger.debug("Sent request [" + request + "]");
+    }
+    connection.send(request);
+  }
+
+  /*
+   * Copied from superclass to make private method available to this sub-class.
+   */
+  private void logResponse(MessageContext messageContext) throws IOException {
+    if (messageContext.hasResponse()) {
+      if (receivedMessageTracingLogger.isTraceEnabled()) {
+        ByteArrayOutputStream requestStream = new ByteArrayOutputStream();
+        messageContext.getRequest().writeTo(requestStream);
+        ByteArrayOutputStream responseStream = new ByteArrayOutputStream();
+        messageContext.getResponse().writeTo(responseStream);
+        receivedMessageTracingLogger
+            .trace("Received response [" + responseStream.toString("UTF-8") + "] for request [" +
+                requestStream.toString("UTF-8") + "]");
+      }
+      else if (receivedMessageTracingLogger.isDebugEnabled()) {
+        receivedMessageTracingLogger
+            .debug("Received response [" + messageContext.getResponse() + "] for request [" +
+                messageContext.getRequest() + "]");
+      }
+    }
+    else {
+      if (logger.isDebugEnabled()) {
+        receivedMessageTracingLogger
+            .debug("Received no response for request [" + messageContext.getRequest() + "]");
+      }
+    }
+  }
+
+  /*
+   * Copied from superclass to make private method available to this sub-class.
+   * Modified to access interceptors via accessor method.
+   */
+  private void triggerHandleResponse(int interceptorIndex, MessageContext messageContext) {
+    ClientInterceptor[] interceptors = getInterceptors();
+    if (messageContext.hasResponse() && interceptors != null) {
+      for (int i = interceptorIndex; i >= 0; i--) {
+        if (!interceptors[i].handleResponse(messageContext)) {
+          break;
+        }
+      }
+    }
+  }
+
+  /*
+   * Copied from superclass to make private method available to this sub-class.
+   * Modified to access interceptors via accessor method.
+   */
+  private void triggerHandleFault(int interceptorIndex, MessageContext messageContext) {
+    ClientInterceptor[] interceptors = getInterceptors();
+    if (messageContext.hasResponse() && interceptors != null) {
+      for (int i = interceptorIndex; i >= 0; i--) {
+        if (!interceptors[i].handleFault(messageContext)) {
+          break;
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
If you're like me, you'd think that #172's logging of soap faults would help. You'd be wrong.

It turns out that the Spring WS 2.1.2 client thinks that the call to the Approvals SOAP service is *erroring* rather than *faulting* (or that it's faulting and it's not sufficiently configured to cope with faults), and so the fault handler isn't called in practice in the way the Approvals integration is actually failing. The key bit in `WebServiceTemplate` is this:

```java
if ( CONDITION_THAT_IS_TRUE ) {
  sendRequest(connection, messageContext.getRequest());
  if (hasError(connection, messageContext.getRequest())) {
    return (T)handleError(connection, messageContext.getRequest());
  }
  WebServiceMessage response = connection.receive(getMessageFactory());
  messageContext.setResponse(response);
}
logResponse(messageContext);
```

See that? It sends the request. If there's an error, it tries to handle the error. Only if there's no error does it even receive the response. And then it logs the response.

This changeset heroically further sub-classes `WebServiceTemplate`, extending it to attempt to log the response even in the error case. It's hacky in that it overrides a protected method that called some private methods, so it also brings along copy-and-pastes of those private methods. Messy.

The new key bit becomes this:

```java
if ( CONDITION_THAT_IS_TRUE ) {
  sendRequest(connection, messageContext.getRequest());
  if (hasError(connection, messageContext.getRequest())) {

    // MODIFIED: attempt to get and log the response
    if (logger.isDebugEnabled()) { // logResponse is a no-op above DEBUG logging
      try {
        WebServiceMessage response = connection.receive(getMessageFactory());
        messageContext.setResponse(response);
        logResponse(messageContext);
      } catch (Exception e) {
        logger.warn("In error case. Failed to log response.", e);
      }
    }

    return (T)handleError(connection, messageContext.getRequest());
  }
  WebServiceMessage response = connection.receive(getMessageFactory());
  messageContext.setResponse(response);
}
logResponse(messageContext);
```

One nice detail: behavior only changes at DEBUG or more logging level, and we don't routinely run at such detailed logging levels in production. This mitigates the risk in adding this logging.

I'm not sure this is going to work. For this to work, it's going to have to successfully receive the response even in the face of whatever this error is. I don't know what the error is -- that's the point of adding more logging, after all, to figure out what the error is. Not knowing what the error is, I don't have a feel for whether it's an error that's going to break receiving the response enough to write out the raw response.

This is only really really useful at TRACE level, at which level it should drop down to logging the bytes from the raw stream rather than caring at all about the semantics of those bytes.