### PR TITLE
HRSPLT-369 dynamic payroll info list-of-links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 
 ### (Unreleased)
 
++ feat: add Payroll Information list-of-links resource URL (path: `listOfLinks`)
+  that honors `ROLE_VIEW_DIRECT_DEPOSIT` in the same way as the Payroll
+  Information portlet content honors that role (linking employee self-service
+  Direct Deposit iff the employee has that role and the `Direct Deposit` HRS URL
+  is set, otherwise linking the PDF form for adjusting direct deposit.) (
+  [HRSPLT-369][], [#176][] )
+
 + fix: clarify label of link to HRS-vended W-2s, that these are *2018* W-2s. ( [HRSPLT-411][], [#174][] )
 + fix: clarify label of link to HRS-vended 1095-Cs, that these are *2018*
   1095-Cs. ( [HRSPLT-412][], [#175][] )
@@ -866,6 +873,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#173]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/173
 [#174]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/173
 [#175]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/175
+[#176]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/176
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348
@@ -873,6 +881,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-363]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-363
 [HRSPLT-365]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-365
 [HRSPLT-368]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-368
+[HRSPLT-369]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-369
 [HRSPLT-370]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-370
 [HRSPLT-371]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-371
 [HRSPLT-375]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-375

--- a/README.md
+++ b/README.md
@@ -193,6 +193,15 @@ this hour limiting policy applies to them.)
 + `managerListOfLinks` : JSON suitable for driving a `list-of-links` widget representing links
   appropriate to the employee's roles for approving others' time and absences.
 
+### Payroll Information
+
++ `listOfLinks` : JSON suitable for driving a `list-of-links` widget for the
+  Payroll Information app. 4 links: the Payroll Information app relevant to the
+  viewing employee ("Earnings Statements"), the direct deposit updating
+  affordance appropriate to the employee ("Direct Deposit"), the tax statements
+  tab of the relevant Payroll Information app ("Tax Statements"), and the PDF
+  form for updating payroll tax withholdings ("Update W4").
+
 ### Roles
 
 + `hasRole` : JSON suitable for driving a `switch` widget switching on whether the employee has a

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/url/HrsUrlDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/url/HrsUrlDao.java
@@ -46,6 +46,8 @@ public interface HrsUrlDao {
      */
     public static String APPROVE_PAYABLE_TIME_KEY = "Approve Payable time";
 
+    public static String SELF_SERVICE_DIRECT_DEPOSIT_KEY = "Direct Deposit";
+
     /**
      * The name of the key the value of which is the deep link to HRS for an
      * employee to view the garnishments on their own earnings.

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollListOfLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollListOfLinksController.java
@@ -62,7 +62,6 @@ public class PayrollListOfLinksController
     taxStatementsLink.setHref("/portal/p/" + fname + "?pP_requestedContent=Tax%20Statements");
     taxStatementsLink.setIcon("toll");
 
-
     Link withholdingsLink = new Link();
     withholdingsLink.setTitle("Update W4");
     withholdingsLink.setHref(WITHHOLDINGS_PDF_URL);
@@ -121,7 +120,7 @@ public class PayrollListOfLinksController
     Map<String, String> urls = this.getHrsUrls();
 
     if (roles.contains(ROLE_SELF_SERVICE_DIRECT_DEPOSIT) &&
-        ( null != urls.get(HrsUrlDao.SELF_SERVICE_DIRECT_DEPOSIT_KEY))) {
+        (null != urls.get(HrsUrlDao.SELF_SERVICE_DIRECT_DEPOSIT_KEY))) {
       directDepositLink.setHref(urls.get(HrsUrlDao.SELF_SERVICE_DIRECT_DEPOSIT_KEY));
       directDepositLink.setIcon("account_balance_wallet");
     } else {
@@ -130,7 +129,6 @@ public class PayrollListOfLinksController
     }
     return directDepositLink;
   }
-
 
   @Autowired
   public void setRolesDao(HrsRolesDao hrsRolesDao) {

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollListOfLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollListOfLinksController.java
@@ -1,0 +1,140 @@
+package edu.wisc.portlet.hrs.web.payroll;
+
+import edu.wisc.hr.dao.roles.HrsRolesDao;
+import edu.wisc.hr.dao.url.HrsUrlDao;
+import edu.wisc.portlet.hrs.web.HrsControllerBase;
+import edu.wisc.portlet.hrs.web.listoflinks.Link;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.portlet.PortletRequest;
+import org.jasig.springframework.security.portlet.authentication.PrimaryAttributeUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.portlet.bind.annotation.ResourceMapping;
+
+@Controller
+@RequestMapping("VIEW")
+public class PayrollListOfLinksController
+  extends HrsControllerBase {
+
+  public static final String MADISON_FNAME = "earnings-statement";
+  public static final String SYSTEM_FNAME = "uw-system-earnings-statement";
+
+  public static final String DIRECT_DEPOSIT_PDF_URL =
+      "https://uwservice.wisconsin.edu/docs/forms/pay-direct-deposit.pdf";
+
+  public static final String WITHHOLDINGS_PDF_URL =
+      "https://uwservice.wisconsin.edu/docs/forms/pay-employee-withholding.pdf";
+
+  public static final String ROLE_SELF_SERVICE_DIRECT_DEPOSIT = "ROLE_VIEW_DIRECT_DEPOSIT";
+
+  private HrsRolesDao hrsRolesDao;
+
+
+
+  /**
+   * Model is "content" --> "links" --> Link[],
+   * suitable for (in JSON representation) use as the remote source for dynamic list-of-links
+   * widget in uPortal-app-framework.
+   * @param modelMap Spring PortletMVC model map
+   * @param request PortletRequest
+   * @return String representing view
+   */
+  @ResourceMapping("listOfLinks")
+  public String listOfLinks(ModelMap modelMap, PortletRequest request) {
+
+    String fname = fname(request);
+
+    Link earningsStatementsLink = new Link();
+    earningsStatementsLink.setTitle("Earnings Statements");
+    earningsStatementsLink.setHref("/web/exclusive/" + fname);
+    earningsStatementsLink.setIcon("attach_money");
+
+    Link directDepositLink = directDepositLink();
+
+    Link taxStatementsLink = new Link();
+    taxStatementsLink.setTitle("Tax Statements");
+    taxStatementsLink.setHref("/portal/p/" + fname + "?pP_requestedContent=Tax%20Statements");
+    taxStatementsLink.setIcon("toll");
+
+
+    Link withholdingsLink = new Link();
+    withholdingsLink.setTitle("Update W4");
+    withholdingsLink.setHref(WITHHOLDINGS_PDF_URL);
+    withholdingsLink.setTarget("_blank");
+    withholdingsLink.setIcon("picture_as_pdf");
+
+    final List<Link> linkList = new ArrayList<Link>();
+    linkList.add(earningsStatementsLink);
+    linkList.add(directDepositLink);
+    linkList.add(taxStatementsLink);
+    linkList.add(withholdingsLink);
+
+    final Map<String, Object[]> content = new HashMap<String, Object[]>();
+    content.put("links", linkList.toArray());
+
+    modelMap.put("content", content);
+
+    return "contentAttrJsonView";
+
+  }
+
+  /**
+   * Returns the Payroll Information portlet-definition fname to use for links for the viewing user.
+   * @param request PortletRequest
+   * @return MADISON_FNAME or SYSTEM_FNAME
+   */
+  private String fname(PortletRequest request) {
+    String fname = MADISON_FNAME;
+
+    String remoteUser = request.getRemoteUser();
+
+    if (remoteUser != null && remoteUser.contains("@")) {
+      fname = SYSTEM_FNAME;
+    }
+    return fname;
+  }
+
+  /**
+   * Returns the correct Direct Deposit link for this user,
+   * honoring the self-service direct deposit role iff HRS has provided that HRS self-service URL,
+   * otherwise using the static PDF URL.
+   *
+   * @return Direct Deposit link appropriate for the viewing user
+   */
+  private Link directDepositLink() {
+    Link directDepositLink = new Link();
+    directDepositLink.setTitle("Update Direct Deposit");
+    directDepositLink.setTarget("_blank");
+
+    // if the employee has the self-service direct deposit role
+    // and the self-service direct deposit URL is set
+    // then use this HRS self-service URL, otherwise use the URL to the PDF
+
+    final String emplId = PrimaryAttributeUtils.getPrimaryId();
+    Set<String> roles = this.hrsRolesDao.getHrsRoles(emplId);
+    Map<String, String> urls = this.getHrsUrls();
+
+    if (roles.contains(ROLE_SELF_SERVICE_DIRECT_DEPOSIT) &&
+        ( null != urls.get(HrsUrlDao.SELF_SERVICE_DIRECT_DEPOSIT_KEY))) {
+      directDepositLink.setHref(urls.get(HrsUrlDao.SELF_SERVICE_DIRECT_DEPOSIT_KEY));
+      directDepositLink.setIcon("account_balance_wallet");
+    } else {
+      directDepositLink.setHref(DIRECT_DEPOSIT_PDF_URL);
+      directDepositLink.setIcon("picture_as_pdf");
+    }
+    return directDepositLink;
+  }
+
+
+  @Autowired
+  public void setRolesDao(HrsRolesDao hrsRolesDao) {
+    this.hrsRolesDao = hrsRolesDao;
+  }
+
+}


### PR DESCRIPTION
Adds Payroll Information `listOfLinks` resourceUrl implementing a dynamic Payroll Information widget that

+ changes the Direct Deposit link between linking the PDF form and linking the employee self-service function, depending on employee role and URL availability, and
+ automatically links the relevant Payroll Information fname for the requesting employee.

To make use of this, we'll need corresponding entity changes to make Payroll Information dynamic rather than static list-of-links widgets.