### PR TITLE
HRSPLT-415 grant ROLE_VIEW_ABSENCE_HISTORIES to UW_EMPLOYEE_ACTIVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 
 (No changes yet).
 
+### 6.2.0 Absence tab for all (not yet released)
+
++ feat: change `psAppContext.xml` role mapping config to grant MyUW HRS Portlets
+  role `ROLE_VIEW_ABSENCE_HISTORIES` to employees with HRS role
+  `UW_EMPLOYEE_ACTIVE`, to the effect that all employees will see the "Absence"
+  tab in "Time and Absence". ( [HRSPLT-415][] )
+
 ### 6.1.0 Payroll Information dynamic list-of-links
 
 + feat: add Payroll Information list-of-links resource URL (path: `listOfLinks`)
@@ -912,3 +919,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-408]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-408
 [HRSPLT-411]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-411
 [HRSPLT-412]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-412
+[HRSPLT-415]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-415

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 + feat: change `psAppContext.xml` role mapping config to grant MyUW HRS Portlets
   role `ROLE_VIEW_ABSENCE_HISTORIES` to employees with HRS role
   `UW_EMPLOYEE_ACTIVE`, to the effect that all employees will see the "Absence"
-  tab in "Time and Absence". ( [HRSPLT-415][] )
+  tab in "Time and Absence". ( [HRSPLT-415][], [#178][] )
 
 ### 6.1.0 Payroll Information dynamic list-of-links
 
@@ -887,6 +887,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#174]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/174
 [#175]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/175
 [#176]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/176
+[#178]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/178
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -45,6 +45,13 @@
         <entry key="UW_EMPLOYEE_ACTIVE">
           <set>
             <value>ROLE_UW_EMPLOYEE_ACTIVE</value>
+              <!-- No effect, just a canary in the mine. -->
+            <value>ROLE_VIEW_ABSENCE_HISTORIES</value>
+                <!-- effects
+                  In Time and Absence
+                    Allows rendering absenceHistories.json
+                    Show the Absence tab
+                -->
           </set>
         </entry>
 
@@ -52,11 +59,6 @@
         <entry key="UW_DYN_AM_EMPLOYEE">
             <set>
                 <value>ROLE_VIEW_ABSENCE_HISTORIES</value>
-                <!-- effects
-                  In Time and Absence
-                    Allows rendering absenceHistories.json
-                    Show the Absence tab
-                -->
                 <value>ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES</value>
                 <!--
                   In Time and Absence


### PR DESCRIPTION
Show the "Absence" tab in MyUW "Time and Absence", so that everyone (or, at least, everyone who still sees MyUW Time and Absence rather than being redirected away) can inspect their absence history via the table in the portlet.

Intended to mitigate downsides in leave balance snapshots (and usages! and earnings!) no longer printing on each earnings statement. Employees with access to time and absence self-service in HRS already have views of their leave usage and earnings there, but employees like those using STAR in DoIT who do not use employee self-service time management in HRS don't have access to those views.