### PR TITLE
HRSPLT-418 genericize year-end leave balance label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 ### (Unreleased)
 
 + feat: change message `label.yearEndLeaveBalance` and its default value to
-  "University Staff end of year leave balance" ( [HRSPLT-418][] )
+  "University Staff end of year leave balance" ( [HRSPLT-418][], [#179][] )
 
 ### 6.2.0 Absence tab for all
 
@@ -893,6 +893,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#175]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/175
 [#176]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/176
 [#178]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/178
+[#179]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/179
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 
 ### (Unreleased)
 
-(No changes yet).
++ feat: change message `label.yearEndLeaveBalance` and its default value to
+  "University Staff end of year leave balance" ( [HRSPLT-418][] )
 
 ### 6.2.0 Absence tab for all
 
@@ -925,3 +926,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-411]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-411
 [HRSPLT-412]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-412
 [HRSPLT-415]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-415
+[HRSPLT-418]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-418

--- a/hrs-portlets-webapp/src/main/resources/messages.properties
+++ b/hrs-portlets-webapp/src/main/resources/messages.properties
@@ -64,4 +64,4 @@ label.disability.status=Disability Status
 label.veteran.status=Veteran Status
 label.ethnic.groups=Ethnic Groups
 label.status.link=view/update
-label.yearEndLeaveBalance=12/24/17 to 12/31/17 University Staff Leave Balance
+label.yearEndLeaveBalance=University Staff end of year leave balance

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -110,7 +110,8 @@
     <c:if test="${not empty hrsUrls['Year End Leave Balances']}">
         <div class="dl-link">
             <a href="${hrsUrls['Year End Leave Balances']}"
-               target="_blank"><spring:message code="label.yearEndLeaveBalance" text="Year End University Staff Leave Balance"/></a><br/>
+               target="_blank"><spring:message code="label.yearEndLeaveBalance"
+               text="University Staff end of year leave balance"/></a><br/>
         </div>
     </c:if>
     <sec:authorize ifAnyGranted="ROLE_ENTER_EDIT_CANCEL_OWN_ABSENCES">


### PR DESCRIPTION
Update the label on the year-end leave balances link (intended for use by university staff) to no longer include the specifics of what year's end it's talking about, so that the label works year-to-year without update.

Still has the problem that, besides showing to the intended audience, this link shows to employees for whom it is not relevant.

Before (screenshot):

<img width="539" alt="before screenshot, showing year-specific label" src="https://user-images.githubusercontent.com/952283/53762653-39f2c380-3e8e-11e9-9d56-d56900f07330.png">

After (mockup):

<img width="564" alt="after screenshot, showing generic label 'University Staff end of year leave balance'" src="https://user-images.githubusercontent.com/952283/53762642-352e0f80-3e8e-11e9-8411-0650d0134bb7.png">

