### PR TITLE
HRSPLT-423: Benefit Information: Mitigate former employee loss of HRS self-service functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 + fix: in Payroll Information, characterize 2019 as the present rather than as
   the future in the microcopy about 2019 and beyond earnings statements not
   including leave balances. ( [HRSPLT-426][], [#183][] )
++ fix: in Benefit Information, mitigate the case where an employee has an HRS
+  emplid and so has access to Benefit Information, but no longer has roles in
+  HRS, and so the links to HRS self-service will not work for the employee.
+  ( [HRSPLT-423][], [#180][] )
 
 ### 6.2.0 Absence tab for all
 
@@ -903,6 +907,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#176]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/176
 [#178]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/178
 [#179]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/179
+[#180]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/180
 [#181]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/181
 [#182]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/182
 [#183]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/183
@@ -940,6 +945,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-412]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-412
 [HRSPLT-415]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-415
 [HRSPLT-418]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-418
+[HRSPLT-423]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-423
 [HRSPLT-424]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-424
 [HRSPLT-425]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-425
 [HRSPLT-426]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-426

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
@@ -82,6 +82,21 @@
         </div>
         <hrs:pagerNavBar position="bottom" />
       </div>
+
+      <sec:authorize ifNotGranted="ROLE_UW_EMPLOYEE_ACTIVE">
+        <div class="fl-widget hrs-notification-wrapper alert alert-info">
+          <div class="hrs-notification-content">Some links in this MyUW Benefit
+            Information app will not work for you because the Human Resources
+            System (HRS) does not assign you the active employee role. This
+            affects the 'View Benefits Summary Detail' and
+            'Update TSA Deductions' buttons on this tab. You may
+            <a href="https://kb.wisc.edu/helpdesk/"
+              target="_blank" rel="noopener noreferrer">
+              contact the Help Desk</a>
+            for assistance.</div>
+        </div>
+      </sec:authorize>
+
       <div class="container-fluid row">
         <%-- when URL available from portlet pref, use that --%>
         <%-- else use URL from URLs web service if available --%>
@@ -163,6 +178,21 @@
         </div>
         <hrs:pagerNavBar position="bottom" />
       </div>
+
+      <sec:authorize ifNotGranted="ROLE_UW_EMPLOYEE_ACTIVE">
+        <div class="fl-widget hrs-notification-wrapper alert alert-info">
+          <div class="hrs-notification-content">Some links in this MyUW Benefit
+            Information app will not work for you because the Human Resources
+            System (HRS) does not assign you the active employee role. This
+            affects the 'View/Update Dependent Information' and
+            'View Dependent Coverage' buttons on this tab. You may
+            <a href="https://kb.wisc.edu/helpdesk/"
+              target="_blank" rel="noopener noreferrer">
+              contact the Help Desk</a>
+            for assistance.</div>
+        </div>
+      </sec:authorize>
+
       <div class="container-fluid row">
         <div class='col-xs-3 col-xs-offset-2'>
           <c:choose>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
@@ -90,7 +90,7 @@
           <c:when test="${not empty prefs['benefitsSummaryUrl']
             && not empty prefs['benefitsSummaryUrl'][0]}">
             <div class='col-xs-4 col-xs-offset-2'>
-              <a href="${prefs['benefitsSummaryUrl'][0]}" 
+              <a href="${prefs['benefitsSummaryUrl'][0]}"
                 target="_blank" rel="noopener noreferer"
                 class="btn btn-default">
                   View Benefits Summary Detail
@@ -99,7 +99,7 @@
           </c:when>
           <c:when test="${not empty hrsUrls['Benefits Summary']}">
             <div class='col-xs-4 col-xs-offset-2'>
-              <a href="${hrsUrls['Benefits Summary']}" 
+              <a href="${hrsUrls['Benefits Summary']}"
                 target="_blank" rel="noopener noreferer"
                 class="btn btn-default">
                   View Benefits Summary Detail


### PR DESCRIPTION
Status quo: the MyUW Benefit Information app will taunt former employees with links to HRS self-service functions that they will not be able to use because they lack the requisite roles in HRS.

This change: adds messages to the 2 (of 3) tabs in Benefit Information that include hyperlinks affected by this issue, advising the user of the issue and inviting them to contact the Help Desk for assistance.

Mockups:

<img width="1588" alt="Mockup of Summary tab of Benefit Information app showing added message just above the buttons at the bottom of the tab" src="https://user-images.githubusercontent.com/952283/54366279-63ee7780-463e-11e9-8482-f77bffe61f3f.png">

<img width="1594" alt="Mockup of Dependents tab of Benefit Information app showing added message just above the buttons at the bottom of the tab"  src="https://user-images.githubusercontent.com/952283/54366297-68b32b80-463e-11e9-89b8-0e92362265f5.png">
