### PR TITLE
HRSPLT-424 predicate personal info edit link on ROLE_UW_EMPLOYEE_ACTIVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 
 ### (Unreleased)
 
++ fix: in Personal Information, predicate the edit hyperlink (into HRS
+  self-service) on ROLE_UW_EMPLOYEE_ACTIVE ( [HRSPLT-424][], [#181][]  )
 + fix: in Payroll Information, show message to users without
   `ROLE_UW_EMPLOYEE_ACTIVE` mitigating their lack of access to HRS self-service
   content (W-2s and earnings statements issued in 2019).
@@ -901,6 +903,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#176]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/176
 [#178]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/178
 [#179]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/179
+[#181]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/181
 [#182]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/182
 [#183]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/183
 
@@ -937,5 +940,6 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-412]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-412
 [HRSPLT-415]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-415
 [HRSPLT-418]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-418
+[HRSPLT-424]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-424
 [HRSPLT-425]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-425
 [HRSPLT-426]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-426

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -206,6 +206,7 @@
     </c:choose>
   </div>
 
+  <sec:authorize ifAnyGranted="ROLE_UW_EMPLOYEE_ACTIVE">
   <c:choose>
     <c:when test="${not empty prefs['updateMyPersonalInfoUrl']
       && not empty prefs['updateMyPersonalInfoUrl'][0]}">
@@ -378,6 +379,7 @@
     </c:otherwise>
 
   </c:choose>
+  </sec:authorize>
   
   <div class="change-business-email-dialog hrs" title="Change Campus Business Email">
     <div>


### PR DESCRIPTION
Don't show the content in the MyUW (employee) Personal Information app about updating one's personal information in HRS with its hyperlink to HRS self-service to employees who do not have the UW_EMPLOYEE_ACTIVE role and so who will not be able to successfully follow that hyperlink to do that updating.

<img width="712" alt="what-to-suppress" src="https://user-images.githubusercontent.com/952283/54368291-dca30300-4641-11e9-8855-13f82b5102cf.png">
