### PR TITLE
HRSPLT-425 msg former employees in Payroll Info to mitigate no self-serv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 ### (Unreleased)
 
 + fix: in Payroll Information, show message to users without
-  ROLE_UW_EMPLOYEE_ACTIVE mitigating their lack of access to HRS self-service
-  content (W-2s and earnings statements issued in 2019). ( [HRSPLT-425][], )
+  `ROLE_UW_EMPLOYEE_ACTIVE` mitigating their lack of access to HRS self-service
+  content (W-2s and earnings statements issued in 2019).
+  ( [HRSPLT-425][], [#182][] )
 + feat: change message `label.yearEndLeaveBalance` and its default value to
   "University Staff end of year leave balance" ( [HRSPLT-418][], [#179][] )
 + fix: in Payroll Information, characterize 2019 as the present rather than as
@@ -900,6 +901,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#176]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/176
 [#178]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/178
 [#179]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/179
+[#182]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/182
 [#183]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/183
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 
 ### (Unreleased)
 
++ fix: in Payroll Information, show message to users without
+  ROLE_UW_EMPLOYEE_ACTIVE mitigating their lack of access to HRS self-service
+  content (W-2s and earnings statements issued in 2019). ( [HRSPLT-425][], )
 + feat: change message `label.yearEndLeaveBalance` and its default value to
   "University Staff end of year leave balance" ( [HRSPLT-418][], [#179][] )
 + fix: in Payroll Information, characterize 2019 as the present rather than as
@@ -932,4 +935,5 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-412]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-412
 [HRSPLT-415]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-415
 [HRSPLT-418]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-418
+[HRSPLT-425]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-425
 [HRSPLT-426]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-426

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -31,7 +31,22 @@
       </div>
     </div>
 
+    <sec:authorize ifNotGranted="ROLE_UW_EMPLOYEE_ACTIVE">
+      <div class="fl-widget hrs-notification-wrapper alert alert-info">
+        <div class="hrs-notification-content">
+          <p>
+            IF YOU ARE NO LONGER A UW EMPLOYEE, MyUW cannot provide your 2018
+            W-2, 2019 earnings statements, or self-service access to change your
+            mailing address. You may contact your prior employer for help
+            accessing these documents, to update your mailing address, or to
+            submit a duplicate tax statement request.
+          </p>
+        </div>
+      </div>
+    </sec:authorize>
+
     <hrs:notification/>
+
   </div>
 
   <div id="${n}dl-tabs"

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -35,11 +35,11 @@
       <div class="fl-widget hrs-notification-wrapper alert alert-info">
         <div class="hrs-notification-content">
           <p>
-            IF YOU ARE NO LONGER A UW EMPLOYEE, MyUW cannot provide your 2018
-            W-2, 2019 earnings statements, or self-service access to change your
-            mailing address. You may contact your prior employer for help
-            accessing these documents, to update your mailing address, or to
-            submit a duplicate tax statement request.
+            <strong>If you are no longer a UW employee,</strong> MyUW cannot
+            provide your 2018 W-2, 2019 earnings statements, or self-service
+            access to change your mailing address. You may contact your prior
+            employer for help accessing these documents, to update your mailing
+            address, or to submit a duplicate tax statement request.
           </p>
         </div>
       </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -35,11 +35,11 @@
       <div class="fl-widget hrs-notification-wrapper alert alert-info">
         <div class="hrs-notification-content">
           <p>
-            <strong>If you are no longer a UW employee,</strong> MyUW cannot
-            provide your 2018 W-2, 2019 earnings statements, or self-service
-            access to change your mailing address. You may contact your prior
-            employer for help accessing these documents, to update your mailing
-            address, or to submit a duplicate tax statement request.
+            Former employees do not have online access to their 2019 and forward
+            earning statements and 2018 and forward W-2s.
+            <a href="https://kb.wisc.edu/helpdesk/page.php?id=90392"
+              target="_blank" rel="noopener noreferrer">
+              Learn more about accessing statements</a>.
           </p>
         </div>
       </div>


### PR DESCRIPTION
In Payroll Information, mitigate former employee lack of self-service access to earnings statements and W-2s issued in 2019 (so, the W-2 for tax year 2018 that you might want to use over the next month or so to prepare your personal taxes).

Adds a message at the top of the portlet, showing on all tabs, to employees who lack the `UW_EMPLOYEE_ACTIVE` HRS role, which in practice seems to be mostly or entirely former employees.

Revised mockup, as implemented:

<img width="634" alt="mockup - Payroll Information - top message to former employees" src="https://user-images.githubusercontent.com/952283/54434761-f9504100-46fc-11e9-9c43-82146165b8f0.png">

