### PR TITLE
HRSPLT-426 characterize 2019-and-after as present rather than future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
   "University Staff end of year leave balance" ( [HRSPLT-418][], [#179][] )
 + fix: in Payroll Information, characterize 2019 as the present rather than as
   the future in the microcopy about 2019 and beyond earnings statements not
-  including leave balances. ( [HRSPLT-426][] )
+  including leave balances. ( [HRSPLT-426][], [#183][] )
 
 ### 6.2.0 Absence tab for all
 
@@ -897,6 +897,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#176]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/176
 [#178]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/178
 [#179]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/179
+[#183]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/183
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 
 + feat: change message `label.yearEndLeaveBalance` and its default value to
   "University Staff end of year leave balance" ( [HRSPLT-418][], [#179][] )
++ fix: in Payroll Information, characterize 2019 as the present rather than as
+  the future in the microcopy about 2019 and beyond earnings statements not
+  including leave balances. ( [HRSPLT-426][] )
 
 ### 6.2.0 Absence tab for all
 
@@ -928,3 +931,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-412]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-412
 [HRSPLT-415]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-415
 [HRSPLT-418]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-418
+[HRSPLT-426]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-426

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ This is intended as a solution for
 
 + When set, allows "Payroll Information" to include a hyperlink to the
   corresponding "Time and Absence" to ease employee navigating to check on leave
-  balances, since leave balances will no longer be available in earnings
-  statements starting in 2019. When not set, the supporting text that explains
-  that leave balances are only available in Time and Absence and no longer on
-  earnings statements themselves does not include a convenient hyperlink.
+  balances, since leave balances are no longer available in earnings statements
+  since 2019. When not set, the supporting text that explains that leave
+  balances are only available in Time and Absence and no longer on earnings
+  statements themselves does not include a convenient hyperlink.
 
 ### Specific to Personal Information
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -71,7 +71,7 @@
         <br/>
         <div class="data-table-description"
           style="color:black;">
-          2019 and after Earnings Statements will no longer have leave balances.
+          2019 and after Earnings Statements do not have leave balances.
           <c:choose>
             <c:when test="${not empty prefs['timeAndAbsenceFName']
               && not empty prefs['timeAndAbsenceFName'][0]}">


### PR DESCRIPTION
Update the microcopy setting the expectation that 2019 earnings statements do not include leave balances.

Status quo:

<img width="833" alt="status-quo-2019-represented-as-future" src="https://user-images.githubusercontent.com/952283/54373142-be8dd080-464a-11e9-93ac-8d05a8003556.png">

After this change:

<img width="783" alt="after-2019-represented-as-present" src="https://user-images.githubusercontent.com/952283/54373154-c483b180-464a-11e9-890e-6c2137256ce8.png">

