### PR TITLE
changelog: the old leave balance label was just wrong, so fix not feat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
   `ROLE_UW_EMPLOYEE_ACTIVE` mitigating their lack of access to HRS self-service
   content (W-2s and earnings statements issued in 2019).
   ( [HRSPLT-425][], [#182][] )
-+ feat: change message `label.yearEndLeaveBalance` and its default value to
++ fix: change message `label.yearEndLeaveBalance` and its default value to
   "University Staff end of year leave balance" ( [HRSPLT-418][], [#179][] )
 + fix: in Payroll Information, characterize 2019 as the present rather than as
   the future in the microcopy about 2019 and beyond earnings statements not


### PR DESCRIPTION
The change in #179 was incorrectly characterized in the changelog as a `feat`. It's not a new feature, it's a fix -- the status quo label is objectively just not a true way to characterize what that link links to, so that change fixed a bug.