### PR TITLE
HRSPLT-431 open HRS Fluid Time in new tab or window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 
 ### (Unreleased beyond 6.2.1)
 
-(No changes yet.)
++ fix: in Time and Absence, when in lieu of delivering MyUW Time and Absence
+  instead launching HRS self-service "Fluid Time", launch that in a new tab and
+  return the main MyUW tab back to viewing the MyUW home page. Fulfills local
+  MyUW style that launches of external-to-the-portal applications happen in new
+  tabs. ( [HRSPLT-431][], [#187][] )
 
 ### 6.2.1 Mitigate former employee loss of HRS self-service access
 
@@ -919,6 +923,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#182]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/182
 [#183]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/183
 [#185]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/185
+[#187]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/187
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348
@@ -958,3 +963,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-425]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-425
 [HRSPLT-426]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-426
 [HRSPLT-429]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-429
+[HRSPLT-431]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-431

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -28,7 +28,17 @@
   <c:choose>
     <c:when test="${not empty hrsUrls['Fluid Time']}">
       <script>
-        window.location.replace("${hrsUrls['Fluid Time']}");
+        // open HRS self-service in new tab. New tab for 'external apps' that
+        // do not feel like part of MyUW is the MyUW local style on this
+        // WARNING: Browser pop-up blockers will sometimes block this. However,
+        // we already incur pop-up blocker issues when launching into earnings
+        // statements and tax statements vended by HRS self-service, so this
+        // may not be in practice any worse than status quo.
+        window.open("${hrsUrls['Fluid Time']}", "_blank");
+        // having opened HRS self-service in a new tab, point this tab back to
+        // the MyUW home page (better would be to point it at wherever the user
+        // launched Time and Absence from).
+        window.location.replace("/web");
       </script>
     </c:when>
     <c:otherwise>


### PR DESCRIPTION
In case where launching MyUW Time and Absence instead launches HRS Self-service "Fluid Time", make that happen in a new "window" (often, tab, depending on browser), and return the MyUW window to the MyUW home page. This is to keep with MyUW's local style that launches of applications external MyUW that don't feel like MyUW apps, happens in a new tab.

[HRSPLT-431](https://jira.doit.wisc.edu/jira/browse/HRSPLT-431)