### PR TITLE
Drop myuw-help-link in favor of helpLink JSP tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 
 ### (Unreleased beyond 6.2.1)
 
-(No changes yet.)
++ feat: improve affordance of upper-right help hyperlinks. Implementation
+  introduces a `helpLink` JSP tag.
 
 ### 6.2.1 Mitigate former employee loss of HRS self-service access
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
@@ -46,12 +46,7 @@
     </c:when>
     </c:choose>
 
-    <div class="dl-help-link">
-      <myuw-help-link
-        app-context="Benefits"
-        url="${helpUrl}">
-      </myuw-help-link>
-    </div>
+    <hrs:helpLink appContext="Benefits" />
   </div>
 
   <hrs:notification/>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -34,12 +34,7 @@
 
 <div id="${n}dl-contact-info" class="dl-contact-info hrs">
   <div class="dl-banner-links">
-    <div class="dl-help-link">
-      <myuw-help-link
-        app-context="Personal Information"
-        url="${helpUrl}">
-      </myuw-help-link>
-    </div>
+    <hrs:helpLink appContext="Personal Information" />
   </div>
 
   <sec:authorize ifNotGranted="ROLE_UW_EMPLOYEE_ACTIVE">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerTimeApproval.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerTimeApproval.jsp
@@ -31,12 +31,7 @@
             <a href="${hrsUrls['Time Management']}" target="_blank">Manager Self Service - Time Management</a>
         </div>
 
-        <div class="dl-help-link">
-          <myuw-help-link
-            app-context="Approvals"
-            url="${helpUrl}">
-          </myuw-help-link>
-        </div>
+        <hrs:helpLink appContext="Approvals" />
       </div>
 
       <hrs:notification/>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -26,12 +26,7 @@
   class="fl-widget portlet dl-payroll-information hrs">
   <div style='margin: 0 10px;'>
     <div class="dl-banner-links">
-      <div class="dl-help-link">
-        <myuw-help-link
-          app-context="Payroll"
-          url="${helpUrl}">
-        </myuw-help-link>
-      </div>
+      <hrs:helpLink appContext="Payroll" />
     </div>
 
     <sec:authorize ifNotGranted="ROLE_UW_EMPLOYEE_ACTIVE">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -59,12 +59,7 @@
         </div>
       </c:if>
 
-      <div class="dl-help-link">
-        <myuw-help-link
-          app-context="Time and Absence"
-          url="${helpUrl}">
-        </myuw-help-link>
-      </div>
+      <hrs:helpLink appContext="Time and Absence" />
     </div>
 
     <div id="${n}leaveReportingNotice" style="display: none;">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/tags/hrs/helpLink.tag
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/tags/hrs/helpLink.tag
@@ -1,0 +1,28 @@
+<%@ include file="/WEB-INF/jsp/include.jsp"%>
+
+<%@ tag bodyContent="empty" isELIgnored="false" %>
+
+<%@ attribute name="appContext" required="false" %>
+
+<c:if test="${empty appContext}">
+  <c:set var="appContext" value="App"/>
+</c:if>
+
+<!-- Depends upon helpUrl **Request** attribute. -->
+
+<c:if test="${not empty helpUrl}">
+<div class="dl-help-link">
+  <a
+    id="help-link"
+    href="${helpUrl}"
+    target="_blank" rel="noopener noreferrer">
+    ${appContext} help and resources
+    <!-- material.io launch icon-->
+    <svg id="launch-icon" xmlns="http://www.w3.org/2000/svg"
+      width="24" height="24" viewBox="0 0 24 24">
+      <path d="M0 0h24v24H0z" fill="none"/>
+      <path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/>
+    </svg>
+  </a>
+</div>
+</c:if>


### PR DESCRIPTION
I give up. I don't know why `myuw-help-link` Web Component isn't rendering, but I do think I can implement the desired UI control via a custom JSP tag and have it generate the correct HTML snippet server side instead. Let's do that and fight with Web Components in another context another day.