### PR TITLE
fix: grant help link more width

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/css/HRSPortlet.css
+++ b/hrs-portlets-webapp/src/main/webapp/css/HRSPortlet.css
@@ -126,6 +126,7 @@
 
 .hrs .dl-help-link {
   margin: .5em 1em;
+  width: 50%;
 }
 
 .hrs .hrs-notification-wrapper {


### PR DESCRIPTION
Now that help links have a longer label and a icon, allow them much more horizontal space.

In practice it's just empty whitespace to the left of the link, so granting lots of width seems fine.

Before:

<img width="803" alt="Screen Shot 2019-05-03 at 9 20 20 AM" src="https://user-images.githubusercontent.com/952283/57144526-dc440000-6d86-11e9-835f-6cf17ffed508.png">

(live from predev)


After:

<img width="799" alt="Screen Shot 2019-05-03 at 9 19 32 AM" src="https://user-images.githubusercontent.com/952283/57144500-cdf5e400-6d86-11e9-9ab8-e030f77698a9.png">



(mocked up in browser)
