### PR TITLE
HRSPLT-444 label manage-others'-performance link "Manager" not "Manage"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ publication of Payroll Information as fname `earnings-statement-for-all`.
 
 ### 6.4.0 Add Performance list-of-links
 
-2019-05-07
+(Not yet released)
 
 + feat: add Performance Portlet vending `performanceListOfLinks` resource URL.
   ( [HRSPLT-437][] )

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/performance/PerformanceLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/performance/PerformanceLinksController.java
@@ -90,7 +90,7 @@ public class PerformanceLinksController
     if (roles.contains(ROLE_LINK_MANAGE_PERFORMANCE)) {
       if (StringUtils.isNotBlank(othersPerformanceUrl)) {
         linkList.add(
-            new Link("Manage", othersPerformanceUrl, "_blank", "assignment_group"));
+            new Link("Manager", othersPerformanceUrl, "_blank", "assignment_group"));
       } else {
         logger.warn(
           "HRS URL [" + HrsUrlDao.OTHERS_PERFORMANCE_KEY + "] expected" +


### PR DESCRIPTION
Labels the link "Manager" which is more parallel with the other link, "Employee".