### PR TITLE
HRSPLT-449 style help-link so that icon aligns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 The v6 major version was occasioned by introducing dependency on a new
 publication of Payroll Information as fname `earnings-statement-for-all`.
 
+### 6.4.1 Tweak help-link style
+
++ fix: line up the launch icon at the end of the help link with the help link
+  label text ( [HRSPLT-449][] )
+
 ### 6.4.0 Add Performance list-of-links
 
 2019-05-28
@@ -970,3 +975,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-426]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-426
 [HRSPLT-429]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-429
 [HRSPLT-437]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-437
+[HRSPLT-449]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-449

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/tags/hrs/helpLink.tag
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/tags/hrs/helpLink.tag
@@ -15,7 +15,8 @@
   <a
     id="help-link"
     href="${helpUrl}"
-    target="_blank" rel="noopener noreferrer">
+    target="_blank" rel="noopener noreferrer"
+    style="display: flex; align-items: center;justify-content: flex-end;">
     ${appContext} help and resources
     <!-- material.io launch icon-->
     <svg id="launch-icon" xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Before:

<img width="314" alt="screenshot-icon-not-aligned" src="https://user-images.githubusercontent.com/952283/58509861-28ebe280-815d-11e9-86e0-e3eb69fa2d19.png">

After:

<img width="315" alt="screenshot-icon-aligned" src="https://user-images.githubusercontent.com/952283/58509854-26898880-815d-11e9-9de7-69adb84129bd.png">

Credit to @thevoiceofzeke for [providing the CSS styles](https://jira.doit.wisc.edu/jira/browse/HRSPLT-449?focusedCommentId=1049694&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1049694).