### PR TITLE
Prune no-op benefit enrollment opportunity message in Time and Absence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ RELEASE-DATE-GOES-HERE-NOT-YET-RELEASED
 + feat: reflect new HRS roles indicating enrollment opportunities, with
   tightened up UI messaging supported by contextual "Learn more" links.
   ( [HRSPLT-436][], [#194][] )
++ fix: removes bugged no-op code in Time and Absence. It was bugged in a few
+  ways. The controlling bug is that it was predicated on an HRS URL key that
+  MyUW is not receiving from HRS, and so was a no-op. This release removes the
+  bugged code so no one has to worry going forward about whether it is (wrongly)
+  displaying to employees. ( [#197][] )
 
 ## HRS Portlets 6 series
 
@@ -951,6 +956,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#183]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/183
 [#185]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/185
 [#194]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/194
+[#197]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/197
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -50,15 +50,6 @@
 <div id="${n}dl-time-absence" class="fl-widget portlet dl-time-absence hrs">
   <div>
     <div class="dl-banner-links">
-      <c:if test="${not empty hrsUrls['Benefits Enrollment']}">
-        <div class="dl-banner-link">
-          You have a benefit enrollment opportunity. Please enroll online by clicking the
-          following link.
-          <a target="_blank" href="${hrsUrls['Benefits Enrollment']}">
-            Benefits Enrollment</a>
-        </div>
-      </c:if>
-
       <hrs:helpLink appContext="Time and Absence" />
     </div>
 


### PR DESCRIPTION
The code removed in this PR is bugged in that it's not predicated on the viewing employee actually having an enrollment opportunity, such that if it were not otherwise bugged as described below it would be incorrectly telling employees who do not in fact have an enrollment opportunity that they have an enrollment opportunity.

Fortunately, the code removed in this PR is also bugged in that it uses and is predicated on the presence of an HRS URL `Benefits Enrollment` but that's not the key that HRS uses to convey the URL for self-service benefits enrollment, so the c:if test case here never evaluates true and so this div is never displayed.

Hurray for saving graces. This PR therefore amounts to removing distracting no-op code.

If the feature of drawing attention to benefit enrollment opportunities in places other than Benefit Information is needed, great, let's implement it anew, correctly. In the meantime this PR cleans up a trip hazard.