### PR TITLE
HRSPLT-434 add benefitInformationWidget resource URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ DATE_TBD
 
 + feat: add `benefitInformationWidget` resource URL that provides markup
   suitable for use in new `remote-content` type widget
+  ( [HRSPLT-434][], [#198][] )
 
 ### 7.0.0 Enrollment opportunities via roles rather than enrollmentFlag
 
@@ -964,6 +965,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#185]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/185
 [#194]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/194
 [#197]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/197
+[#198]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/198
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348
@@ -1004,6 +1006,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-425]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-425
 [HRSPLT-426]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-426
 [HRSPLT-429]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-429
+[HRSPLT-434]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-434
 [HRSPLT-436]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-436
 [HRSPLT-437]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-437
 [HRSPLT-449]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-449

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The v7 major version was occasioned by the breaking change of no longer honoring
 `enrollmentFlag`, instead relying upon HRS roles to indicate whether and what
 benefit enrollment opportunities are available to an employee.
 
+### 7.1.0 Generate Benefit Information widget server-side
+
+DATE_TBD
+
++ feat: add `benefitInformationWidget` resource URL that provides markup
+  suitable for use in new `remote-content` type widget
+
 ### 7.0.0 Enrollment opportunities via roles rather than enrollmentFlag
 
 2019-05-31

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitInformationController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitInformationController.java
@@ -72,4 +72,14 @@ public class BenefitInformationController extends HrsControllerBase {
 
       return "benefitInformation";
     }
+
+    @ResourceMapping("benefitInformationWidget")
+    public String benefitInformationWidget(
+      ModelMap model, PortletRequest request) {
+
+      // same model as the portlet view JSP
+      viewBenefitInfo(model, request);
+
+      return "benefitInformationWidget";
+    }
 }

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidget.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidget.jsp
@@ -1,0 +1,80 @@
+<%--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+<%@ page trimDirectiveWhitespaces="true" %>
+<%@ include file="/WEB-INF/jsp/include.jsp"%>
+
+<portlet:defineObjects/>
+<spring:htmlEscape defaultHtmlEscape="true" />
+
+<div class="widget-body" layout="column" layout-align="center center">
+  <sec:authorize
+    ifAnyGranted="ROLE_VIEW_NEW_HIRE_BENEFITS, ROLE_VIEW_OPEN_ENROLL_BENEFITS">
+    <span class="tsc__title">You have
+      a<sec:authorize ifAnyGranted="ROLE_VIEW_OPEN_ENROLL_BENEFITS">n annual</sec:authorize>
+      benefit enrollment opportunity.</span>
+
+    <div class="tsc__status">
+      <p>
+        <md-button class="md-raised md-accent"
+          href="${hrsUrls['Open Enrollment/Hire Event']}">Enroll now</md-button>
+      </p>
+    </div>
+  </sec:authorize>
+  <div class="tsc__extra-buttons" layout="row" layout-align="center center">
+    <c:choose>
+      <c:when test="${isMadisonUser}">
+        <a
+          target="_blank" rel="noopener noreferrer"
+          href="https://hr.wisc.edu/benefits/annual-benefits-enrollment/">
+          Learn more
+        </a>
+      </c:when>
+      <c:otherwise>
+        <a
+          target="_blank" rel="noopener noreferrer"
+          href="https://www.wisconsin.edu/ohrwd/benefits/">
+          Learn more
+        </a>
+      </c:otherwise>
+    </c:choose>
+  </div>
+</div>
+
+<c:choose>
+  <c:when test="${isMadisonUser}">
+    <%-- Bug: will launch the wrong Benefit Information for Madison users
+         in context of my.wisconsin --%>
+    <launch-button
+      data-href="/web/exclusive/university-staff-benefits-statement"
+      data-target="_self"
+      data-button-text="Launch full app"
+      data-aria-label="Launch Benefit Information">
+    </launch-button>
+  </c:when>
+  <c:otherwise>
+    <launch-button
+      data-href="/web/exclusive/uw-system-university-staff-benefits-statement"
+      data-target="_self"
+      data-button-text="Launch full app"
+      data-aria-label="Launch Benefit Information">
+    </launch-button>
+  </c:otherwise>
+</c:choose>


### PR DESCRIPTION
Adds a new `benefitInformationWidget` Resource URL to Benefit Information that returns *the markup* suitable for use as a uPortal-app-framework `remote-content` type widget.

View implemented as a new JSP. Parallel to and uses same Model as existing `benefitInformation.jsp`.

Known bug: The few stray Madison users accessing `my.wisconsin.edu` will attempt to launch the *Madison* instance of the Benefit Information portlet from the *System* instance of the widget. This is because I didn't see how to know which widget instance is rendering, only whether the *user* is a Madison user.

Maybe this is an acceptable bug for immediate purposes, and again we should be looking at more assertively keeping Madison users out of my.wisconsin and instead in my.wisc.

Does not yet implement the countdown etc. experience for annual benefits enrollment, but of course that would be the idea, to implement that complexity server-side.