### PR TITLE
HRSPLT-452 Fix Benefit Information widget learn more link for Madison users

### DIFF
--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitInformationController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitInformationController.java
@@ -20,6 +20,7 @@
 package edu.wisc.portlet.hrs.web.benefits;
 
 import java.util.Map;
+import java.util.Set;
 
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.portlet.bind.annotation.ResourceMapping;
 
 import edu.wisc.hr.dao.bnsumm.BenefitSummaryDao;
+import edu.wisc.hr.dao.roles.HrsRolesDao;
 import edu.wisc.hr.dm.bnsumm.BenefitSummary;
 
 import org.apache.commons.lang.StringUtils;
@@ -45,10 +47,19 @@ import edu.wisc.portlet.hrs.web.HrsControllerBase;
 @RequestMapping("VIEW")
 public class BenefitInformationController extends HrsControllerBase {
     private BenefitSummaryDao benefitSummaryDao;
+    private HrsRolesDao hrsRolesDao;
+
+    private BenefitsLearnMoreLinkGenerator learnMoreLinker =
+      new BenefitsLearnMoreLinkGenerator();
 
     @Autowired
     public void setBenefitSummaryDao(BenefitSummaryDao benefitSummaryDao) {
         this.benefitSummaryDao = benefitSummaryDao;
+    }
+
+    @Autowired
+    public void setHrsRolesDao(HrsRolesDao hrsRolesDao) {
+        this.hrsRolesDao = hrsRolesDao;
     }
 
     @RequestMapping
@@ -70,6 +81,10 @@ public class BenefitInformationController extends HrsControllerBase {
       model.addAttribute("isMadisonUser", isMadisonUser);
       final PortletPreferences preferences = request.getPreferences();
       model.addAttribute("learnMoreEBenefitGuide", preferences.getValue("ebenefitguidetext", null));
+
+      Set<String> roles = hrsRolesDao.getHrsRoles(emplId);
+      model.addAttribute("learnMoreLink",
+        learnMoreLinker.learnMoreLinkFor(roles, isMadisonUser));
 
       return "benefitInformation";
     }

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGenerator.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGenerator.java
@@ -1,0 +1,11 @@
+package edu.wisc.portlet.hrs.web.benefits;
+
+import java.util.Set;
+
+public class BenefitsLearnMoreLinkGenerator {
+
+  public String learnMoreLinkFor(Set<String> roles, boolean madisonness) {
+    return "https://www.wisconsin.edu/ohrwd/benefits/";
+  }
+
+}

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGenerator.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGenerator.java
@@ -5,7 +5,23 @@ import java.util.Set;
 public class BenefitsLearnMoreLinkGenerator {
 
   public String learnMoreLinkFor(Set<String> roles, boolean madisonness) {
-    return "https://www.wisconsin.edu/ohrwd/benefits/";
+
+    if (!madisonness) {
+      // regardless of situation, non-madison employees get this learn more link
+      return "https://www.wisconsin.edu/ohrwd/benefits/";
+    } else if (roles.contains("ROLE_VIEW_NEW_HIRE_BENEFITS")) {
+      // madison users with a new hire event get this learn more link
+      return "https://hr.wisc.edu/benefits/new-employee-benefits-enrollment/";
+    } else if (roles.contains("ROLE_VIEW_OPEN_ENROLL_BENEFITS")) {
+      // madison users with an annual benefit enrollment opportunity get this
+      // learn more link
+      return "https://hr.wisc.edu/benefits/annual-benefits-enrollment/";
+    } else {
+      // madison users without an enrollment opportunity get this learn more
+      // link
+      return "http://benefits.wisc.edu/";
+    }
+
   }
 
 }

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
@@ -28,14 +28,13 @@
       <div class="dl-banner-link">
         You have a benefit enrollment opportunity.
         <a target="_blank" href="${hrsUrls['Open Enrollment/Hire Event']}">Enroll now</a>
-        <c:choose>
-          <c:when test="${isMadisonUser}">
-            <a target="_blank" href="https://hr.wisc.edu/benefits/new-employee-benefits-enrollment/">Learn more</a>
-          </c:when>
-          <c:otherwise>
-            <a target="_blank" href="https://www.wisconsin.edu/ohrwd/benefits/">Learn more</a>
-          </c:otherwise>
-        </c:choose>
+        <c:if test="${not empty learnMoreLink}">
+          <a
+            href="${learnMoreLink}"
+            target="_blank" rel="noopener noreferrer">
+            Learn more
+          </a>
+        </c:if>
       </div>
     </sec:authorize>
 
@@ -43,14 +42,13 @@
       <div class="dl-banner-link">
         You have a benefit enrollment opportunity.
         <a target="_blank" href="${hrsUrls['Open Enrollment/Hire Event']}">Enroll now</a>
-        <c:choose>
-          <c:when test="${isMadisonUser}">
-            <a target="_blank" href="https://hr.wisc.edu/benefits/annual-benefits-enrollment/">Learn more</a>
-          </c:when>
-          <c:otherwise>
-            <a target="_blank" href="https://www.wisconsin.edu/ohrwd/benefits/">Learn more</a>
-          </c:otherwise>
-        </c:choose>
+        <c:if test="${not empty learnMoreLink}">
+          <a
+            href="${learnMoreLink}"
+            target="_blank" rel="noopener noreferrer">
+            Learn more
+          </a>
+        </c:if>
       </div>
     </sec:authorize>
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidget.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidget.jsp
@@ -42,22 +42,13 @@
     </div>
   </sec:authorize>
   <div class="tsc__extra-buttons layout-align-center-center layout-row">
-    <c:choose>
-      <c:when test="${isMadisonUser}">
-        <a
-          target="_blank" rel="noopener noreferrer"
-          href="https://hr.wisc.edu/benefits/annual-benefits-enrollment/">
-          Learn more
-        </a>
-      </c:when>
-      <c:otherwise>
-        <a
-          target="_blank" rel="noopener noreferrer"
-          href="https://www.wisconsin.edu/ohrwd/benefits/">
-          Learn more
-        </a>
-      </c:otherwise>
-    </c:choose>
+    <c:if test="${not empty learnMoreUrl}">
+      <a
+        target="_blank" rel="noopener noreferrer"
+        href="${learnMoreUrl}">
+        Learn more
+      </a>
+    </c:if>
   </div>
 </div>
 

--- a/hrs-portlets-webapp/src/test/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGeneratorTest.java
+++ b/hrs-portlets-webapp/src/test/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGeneratorTest.java
@@ -1,6 +1,7 @@
 package edu.wisc.portlet.hrs.web.benefits;
 
 import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -17,6 +18,45 @@ public class BenefitsLearnMoreLinkGeneratorTest {
     assertEquals("https://www.wisconsin.edu/ohrwd/benefits/",
       generator.learnMoreLinkFor(new HashSet<String>(), false));
 
+  }
+
+  @Test
+  public void testRolelessMadisonUser() {
+
+    assertEquals("http://benefits.wisc.edu/",
+      generator.learnMoreLinkFor(new HashSet<String>(), true));
+
+  }
+
+  @Test
+  public void testAnnualBenefitEnrollmentOpportunityMadisonUser() {
+    Set<String> roles = new HashSet<String>();
+    roles.add("ROLE_VIEW_OPEN_ENROLL_BENEFITS");
+
+    assertEquals("https://hr.wisc.edu/benefits/annual-benefits-enrollment/",
+      generator.learnMoreLinkFor(roles, true));
+
+  }
+
+  @Test
+  public void testNewHireBenefitEnrollmentOpportunityMadisonUser() {
+    Set<String> roles = new HashSet<String>();
+    roles.add("ROLE_VIEW_NEW_HIRE_BENEFITS");
+
+    assertEquals(
+      "https://hr.wisc.edu/benefits/new-employee-benefits-enrollment/",
+      generator.learnMoreLinkFor(roles, true));
+  }
+
+  @Test
+  public void testMadisonNewHireLearnMorePreferredOverAnnualLearnMore() {
+    Set<String> roles = new HashSet<String>();
+    roles.add("ROLE_VIEW_NEW_HIRE_BENEFITS");
+    roles.add("ROLE_VIEW_OPEN_ENROLL_BENEFITS");
+
+    assertEquals(
+      "https://hr.wisc.edu/benefits/new-employee-benefits-enrollment/",
+      generator.learnMoreLinkFor(roles, true));
   }
 
 }

--- a/hrs-portlets-webapp/src/test/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGeneratorTest.java
+++ b/hrs-portlets-webapp/src/test/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGeneratorTest.java
@@ -1,0 +1,22 @@
+package edu.wisc.portlet.hrs.web.benefits;
+
+import java.util.HashSet;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+
+public class BenefitsLearnMoreLinkGeneratorTest {
+
+  BenefitsLearnMoreLinkGenerator generator =
+    new BenefitsLearnMoreLinkGenerator();
+
+  @Test
+  public void testRolelessNonMadisonUser() {
+
+    assertEquals("https://www.wisconsin.edu/ohrwd/benefits/",
+      generator.learnMoreLinkFor(new HashSet<String>(), false));
+
+  }
+
+}


### PR DESCRIPTION
There are 3 different Benefit Information "Learn more" links the widget ought to display to Madison employee, depending upon whether the employee has an event-driven benefit enrollment opportunity, an annual benefit enrollment opportunity, or no enrollment opportunity. And then there's a fourth case, for non-Madison employees.

The classic Benefit Information Portlet JSP got this right, but the new JSP driving the new Benefit Information widget did not get this right.

This changeset refactors the learn more calculation into a learn more link generator (covered by a passing unit test) and then relies upon it in both the Benefit Information Portlet and in the Benefit Information widget.