### PR TITLE
HRSPLT-454 source manager time and absence dashboard URL from HRS URLs service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ benefit enrollment opportunities are available to an employee.
 
 + Prefer to source manager "Time/Absence Dashboard" URL from new HRS URLs
   service key `Time/Absence Dashboard`, falling back on now-deprecated portlet
-  preference for this URL.
+  preference for this URL. [HRSPLT-454][]
 + Remove "View Time Entry Exceptions" link. [HRSPLT-453][]
 
 #### Deprecated in 7.1.4
@@ -1059,3 +1059,4 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-437]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-437
 [HRSPLT-449]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-449
 [HRSPLT-453]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-453
+[HRSPLT-454]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-454

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,16 @@ benefit enrollment opportunities are available to an employee.
 
 ### Next release: Putatively 7.1.4
 
++ Prefer to source manager "Time/Absence Dashboard" URL from new HRS URLs
+  service key `Time/Absence Dashboard`, falling back on now-deprecated portlet
+  preference for this URL.
 + Remove "View Time Entry Exceptions" link. [HRSPLT-453][]
+
+#### Deprecated in 7.1.4
+
++ Time and Absence portlet preference `approvalsDashboardUrl` is deprecated.
+  Provision the time and absence approvals dashboard URL via new HRS URLs DAO
+  key `Time/Absence Dashboard`.
 
 ### 7.1.3 Really fix Benefit Information widget "Learn more" link
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,14 @@ This is intended as a solution for
 + When not set, the label defaults to "Time/Absence Dashboard" (as defined in
   `ManagerLinksController.DEFAULT_DASHBOARD_LABEL`).
 
-#### `approvalsDashboardUrl` portlet preference (optional)
+#### `approvalsDashboardUrl` portlet preference (optional) (DEPRECATED)
 
-+ When set, Manager Time and Approval uses this URL as the href for a list-of-links link shown to
-  to employees with a particular role.
-+ When not set, this link is not shown.
++ Superseded by `Time/Absence Dashboard` URL from HRS URLs DAO. Configure that
+  instead; when both that and this portlet-preference are set the URL from the
+  HRS URLs DAO is controlling.
++ Manager Time and Approval uses this URL as the href for a list-of-links link
+  shown to employees with a particular role.
++ When not set (and not superseded via HRS URLs DAO), this link is not shown.
 
 ### Specific to Payroll Information
 

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/url/HrsUrlDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/url/HrsUrlDao.java
@@ -71,4 +71,6 @@ public interface HrsUrlDao {
      * employees to manage their own performance.
      */
     public static String SELF_PERFORMANCE_KEY = "Employee ePerf";
+
+    public static String TIME_ABSENCE_DASHBOARD_KEY = "Time/Absence Dashboard";
 }

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -61,7 +61,6 @@ public class ManagerLinksController
   }
 
   private HrsRolesDao rolesDao;
-  private HrsUrlDao urlDao;
 
   public HrsRolesDao getRolesDao() {
     return rolesDao;

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -85,8 +85,7 @@ public class ManagerLinksController
     final Set<String> roles = Collections.unmodifiableSet(this.rolesDao.getHrsRoles(emplId));
 
     final PortletPreferences preferences = request.getPreferences();
-    final String approvalsDashboardUrl =
-        preferences.getValue("approvalsDashboardUrl", null);
+    final String approvalsDashboardUrl = approvalsDashboardUrl(preferences);
     final String approvalsDashboardLabel =
         preferences.getValue("approvalsDashboardLabel", DEFAULT_DASHBOARD_LABEL);
     final String approveAbsenceLabel =
@@ -129,8 +128,10 @@ public class ManagerLinksController
         approvalsDashboard.setTarget("_blank");
         linkList.add(approvalsDashboard);
       } else {
-        logger.error("Portlet preference [approvalsDashboardUrl] expected but not found "
-            + "and so could not be offered to " + emplId);
+        logger.error("Portlet preference [approvalsDashboardUrl] "
+          + "or HRS URLS DAO url " + HrsUrlDao.TIME_ABSENCE_DASHBOARD_KEY + " "
+          + "expected but not found "
+          + "and so could not be offered to " + emplId);
       }
     }
 
@@ -179,8 +180,9 @@ public class ManagerLinksController
     final String emplId = PrimaryAttributeUtils.getPrimaryId();
 
     final PortletPreferences preferences = request.getPreferences();
-    final String approvalsDashboardUrl =
-        preferences.getValue("approvalsDashboardUrl", null);
+
+    final String approvalsDashboardUrl = approvalsDashboardUrl(preferences);
+
     final String approvalsDashboardLabel =
         preferences.getValue("approvalsDashboardLabel", DEFAULT_DASHBOARD_LABEL);
     final String approveAbsenceLabel =
@@ -194,6 +196,28 @@ public class ManagerLinksController
     modelMap.put("approveTimeLabel", approveTimeLabel);
 
     return "managerLinks";
+  }
+
+  /**
+   * Returns the approvals dashboard URL, preferring that from the HRS URLs
+   * DAO, falling back on a Portlet Preference, and returning null if neither is
+   * available.
+   *
+   * @param preferences the PortletPreferences
+   * @return the preferred approvals dashboard URL, or null if not set
+   */
+  public String approvalsDashboardUrl(PortletPreferences preferences) {
+    String approvalsDashboardUrl =
+      this.getHrsUrls().get(HrsUrlDao.TIME_ABSENCE_DASHBOARD_KEY);
+
+    if (null == approvalsDashboardUrl) {
+      approvalsDashboardUrl =
+        preferences.getValue("approvalsDashboardUrl", null);
+      // this sourcing approvals dashboard URL from portlet-preference is
+      // DEPRECATED and will be removed in a future release.
+    }
+
+    return approvalsDashboardUrl;
   }
 
 }


### PR DESCRIPTION
[HRSPLT-454](https://jira.doit.wisc.edu/jira/browse/HRSPLT-454)

Adds support for and prefers sourcing manager time/absence dashboard URL from new HRS URLS DAO key-value pair.

Continues to support, deprecated, portlet-preference for setting this.