### PR TITLE
MUMMNG-4833 add enrollmentRole JSON controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,15 @@ The v7 major version was occasioned by the breaking change of no longer honoring
 `enrollmentFlag`, instead relying upon HRS roles to indicate whether and what
 benefit enrollment opportunities are available to an employee.
 
-### Next release: Putatively 7.1.4
+### Next release: Putatively 7.2.0
 
 + Prefer to source manager "Time/Absence Dashboard" URL from new HRS URLs
   service key `Time/Absence Dashboard`, falling back on now-deprecated portlet
   preference for this URL. [HRSPLT-454][]
 + Remove "View Time Entry Exceptions" link. [HRSPLT-453][]
++ Add `enrollmentRole` JSON controller ( [MUMMNG-4833][] [#205] )
 
-#### Deprecated in 7.1.4
+#### Deprecated in 7.2.0
 
 + Time and Absence portlet preference `approvalsDashboardUrl` is deprecated.
   Provision the time and absence approvals dashboard URL via new HRS URLs DAO
@@ -1014,6 +1015,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#200]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/200
 [#201]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/201
 [#202]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/202
+[#205]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/205
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348
@@ -1060,3 +1062,5 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-449]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-449
 [HRSPLT-453]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-453
 [HRSPLT-454]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-454
+
+[MUMMNG-4833]: https://jira.doit.wisc.edu/jira/browse/MUMMNG-4833

--- a/README.md
+++ b/README.md
@@ -191,6 +191,16 @@ this hour limiting policy applies to them.)
 
 (Not a comprehensive listing.)
 
+### Benefit Information
+
++ `enrollmentRole` : JSON suitable for predicating a uPortal-home notification.
+  Looks like `enrollmentFlag`, but driven by HRS portlet role, not enrollment
+  flag.
+  + `ROLE_VIEW_NEW_HIRE_BENEFITS` yields `H`
+  + `ROLE_VIEW_OPEN_ENROLL_BENEFITS` yields `O`
+  + having neither role yields `Z`
+  + in that precedence order.
+
 ### Manager Links
 
 + `managerListOfLinks` : JSON suitable for driving a `list-of-links` widget representing links

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitSummaryDataController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitSummaryDataController.java
@@ -35,8 +35,8 @@ import edu.wisc.hr.dm.bnsumm.BenefitSummary;
 import org.jasig.springframework.security.portlet.authentication.PrimaryAttributeUtils;
 
 /**
- * 
- * 
+ *
+ *
  * @author Eric Dalquist
  */
 @Controller
@@ -52,7 +52,7 @@ public class BenefitSummaryDataController {
     @ResourceMapping("benefitSummary")
     public String getBenefitSummary(ModelMap modelMap) {
         final String emplid = PrimaryAttributeUtils.getPrimaryId();
-        
+
         final BenefitSummary benefitSummary = this.benefitSummaryDao.getBenefitSummary(emplid);
         modelMap.addAttribute("benefits", benefitSummary.getBenefits());
         modelMap.addAttribute("dependents", benefitSummary.getDependents());
@@ -65,20 +65,20 @@ public class BenefitSummaryDataController {
     @ResourceMapping("enrollmentFlag")
     public String getEnrollmentFlag(ModelMap modelMap) {
       final String emplid = PrimaryAttributeUtils.getPrimaryId();
-      
-      final BenefitSummary benefitSummary = 
+
+      final BenefitSummary benefitSummary =
         this.benefitSummaryDao.getBenefitSummary(emplid);
-      
+
       Map<String, String> enrollmentFlagMap = new HashMap<String, String>();
-      
+
       enrollmentFlagMap.put(
         "enrollmentFlag", benefitSummary.getEnrollmentFlag());
-      
+
       List<Map<String, String>> report = new ArrayList<Map<String, String>>();
       report.add(enrollmentFlagMap);
-      
+
       modelMap.addAttribute("report", report);
-      
+
       return "jsonView";
     }
     


### PR DESCRIPTION
Historically, we'd predicated annual benefit enrollment notification on enrollmentFlag.

We're switching to rely on HRS roles for this.

This adds a new `enrollmentRole` JSON controller that implements the same JSON API as the historical `enrollmentFlag` controller, so that we can port forward the notification to base on role rather than flag.

[MUMMNG-4833](https://jira.doit.wisc.edu/jira/browse/MUMMNG-4833), part of implementing annual benefits enrollment for October 2019.