### PR TITLE
Foreshadow ABE 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ benefit enrollment opportunities are available to an employee.
 
 ### Next release: Putatively 7.2.0
 
++ Foreshadow 2019 annual benefits enrollment in Benefit Information widget
 + Prefer to source manager "Time/Absence Dashboard" URL from new HRS URLs
   service key `Time/Absence Dashboard`, falling back on now-deprecated portlet
   preference for this URL. [HRSPLT-454][]

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesService.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesService.java
@@ -1,0 +1,86 @@
+package edu.wisc.hr.service.benefits;
+
+import org.joda.time.Interval;
+import org.joda.time.LocalDate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service encapsulating Annual Benefits Enrollment dates and date math.
+ */
+@Service
+public class AnnualBenefitEnrollmentDatesService {
+
+  public static LocalDate firstDayOfAnnualBenefitsEnrollmentForeshadowing =
+      new LocalDate("2019-09-18");
+  public static LocalDate firstDayOfAnnualBenefitsEnrollment =
+      new LocalDate("2019-09-30");
+  public static LocalDate lastDayOfAnnualBenefitsEnrollment =
+      new LocalDate("2019-10-25");
+  public static LocalDate lastDayOfAnnualBenefitsEnrollmentFeedback =
+      new LocalDate("2019-11-30");
+
+  /**
+   * True iff on the given date should show the messages foreshadowing Annual Benefits Enrollment;
+   * @param when the given date
+   * @return true if during foreshadowing, false otherwise
+   */
+  public boolean foreshadowAnnualBenefitsEnrollment(final LocalDate when) {
+    return (
+        !when.isBefore(firstDayOfAnnualBenefitsEnrollmentForeshadowing)
+            && when.isBefore(firstDayOfAnnualBenefitsEnrollment));
+  }
+
+  /**
+   * True iff the given date is during annual benefits enrollment.
+   * @param when the given date
+   * @return true if during annual benefits enrollment, false otherwise
+   */
+  public boolean duringAnnualBenefitsEnrollment(final LocalDate when) {
+    return (
+        !when.isBefore(firstDayOfAnnualBenefitsEnrollment)
+            && !when.isAfter(lastDayOfAnnualBenefitsEnrollment));
+  }
+
+  /**
+   * Returns number of days remaining in ABE AFTER TODAY, counting the last day of ABE.
+   * So, today does not count, because today might be mostly elapsed, but the last day of ABE does
+   * count (if it's not today), because it's a day.
+   * Returns -1 if not currently during ABE. The last day is 0 days left.
+   * @param when
+   * @return
+   */
+  public int daysRemainingInAnnualBenefitsEnrollment(final LocalDate when) {
+
+    if (!duringAnnualBenefitsEnrollment(when)) {
+      return -1;
+    }
+
+    int currentDayOfYear = when.getDayOfYear();
+    int abeEndDayOfYear = lastDayOfAnnualBenefitsEnrollment.getDayOfYear();
+
+
+    return abeEndDayOfYear - currentDayOfYear;
+  }
+
+  /**
+   * True iff the given date is the last day of annual benefits enrollment.
+   * @param when the given date
+   * @return true if it's the last day
+   */
+  public boolean lastDayOfAnnualBenefitEnrollment(final LocalDate when) {
+    return (lastDayOfAnnualBenefitsEnrollment.equals(when));
+  }
+
+  /**
+   * True iff the given date is during the post-ABE feedback period.
+   * @param when the given date
+   * @return true if during feedback period
+   */
+  public boolean feedbackPeriod(final LocalDate when) {
+    return (
+        when.isAfter(lastDayOfAnnualBenefitsEnrollment)
+            && !when.isAfter(lastDayOfAnnualBenefitsEnrollmentFeedback));
+  }
+
+
+}

--- a/hrs-portlets-api/src/test/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesServiceTest.java
+++ b/hrs-portlets-api/src/test/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesServiceTest.java
@@ -1,0 +1,96 @@
+package edu.wisc.hr.service.benefits;
+
+import static org.junit.Assert.*;
+
+import org.joda.time.LocalDate;
+import org.junit.Test;
+
+public class AnnualBenefitEnrollmentDatesServiceTest {
+
+  private AnnualBenefitEnrollmentDatesService service = new AnnualBenefitEnrollmentDatesService();
+
+  @Test
+  public void testForeshadowing() {
+    // foreshadowing does not begin prematurely
+    assertFalse(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2019-09-17")));
+
+    // foreshadowing begins Wednesday Sept 18
+    assertTrue(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2019-09-18")));
+
+    // and continues
+    assertTrue(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2019-09-22")));
+
+    // through the day before benefit enrollment begins
+    assertTrue(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2019-09-29")));
+
+    // and stops once benefit enrollment begins
+    assertFalse(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2019-09-30")));
+  }
+
+  @Test
+  public void testDuringAnnualBenefitsEnrollment() {
+    // annual benefits enrollment does not begin prematurely
+    assertFalse(service.duringAnnualBenefitsEnrollment(new LocalDate("2019-09-29")));
+
+    // but does begin punctually
+    assertTrue(service.duringAnnualBenefitsEnrollment(new LocalDate("2019-09-30")));
+
+    // and continues
+    assertTrue(service.duringAnnualBenefitsEnrollment(new LocalDate("2019-10-05")));
+
+    // through the last date of annual benefits enrollment
+    assertTrue(service.duringAnnualBenefitsEnrollment(new LocalDate("2019-10-25")));
+
+    // but not beyond annual benefits enrollment
+    assertFalse(service.duringAnnualBenefitsEnrollment(new LocalDate("2019-10-26")));
+  }
+
+  @Test
+  public void testLastDayAnnualBenefitsEnrollment() {
+    // the day before the last day is not the last day
+    assertFalse(service.lastDayOfAnnualBenefitEnrollment(new LocalDate("2019-10-24")));
+
+    // the last day is the last day
+    assertTrue(service.lastDayOfAnnualBenefitEnrollment(new LocalDate("2019-10-25")));
+
+    // the day after the last day is not the last day
+    assertFalse(service.lastDayOfAnnualBenefitEnrollment(new LocalDate("2019-10-26")));
+  }
+
+  @Test
+  public void testFeedbackPeriod() {
+    // the last day of benefit enrollment is not the feedback period
+    assertFalse(service.feedbackPeriod(new LocalDate("2019-10-25")));
+
+    // but the day after benefit enrollment is within the feedback period
+    assertTrue(service.feedbackPeriod(new LocalDate("2019-10-26")));
+
+    // and the feedback period continues
+    assertTrue(service.feedbackPeriod(new LocalDate("2019-11-12")));
+
+    // through its last day
+    assertTrue(service.feedbackPeriod(new LocalDate("2019-11-30")));
+
+    // but not after its last day
+    assertFalse(service.feedbackPeriod(new LocalDate("2019-12-01")));
+  }
+
+  @Test
+  public void testCountdown() {
+    // before ABE, returns -1
+    assertEquals(-1, service.daysRemainingInAnnualBenefitsEnrollment(new LocalDate("2019-09-29")));
+
+    // on the antepenultimate day of ABE, there are 2 more days remaining
+    assertEquals(2, service.daysRemainingInAnnualBenefitsEnrollment(new LocalDate("2019-10-23")));
+
+    // on the penultimate day of ABE, there is 1 more day remaining
+    assertEquals(1, service.daysRemainingInAnnualBenefitsEnrollment(new LocalDate("2019-10-24")));
+
+    // on the last day of ABE, there are 0 more days remaining
+    assertEquals(0, service.daysRemainingInAnnualBenefitsEnrollment(new LocalDate("2019-10-25")));
+
+    // after ABE, returns -1
+    assertEquals(-1, service.daysRemainingInAnnualBenefitsEnrollment(new LocalDate("2019-10-26")));
+  }
+
+}

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGenerator.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGenerator.java
@@ -1,25 +1,57 @@
 package edu.wisc.portlet.hrs.web.benefits;
 
+import edu.wisc.hr.service.benefits.AnnualBenefitEnrollmentDatesService;
 import java.util.Set;
+import org.joda.time.LocalDate;
 
 public class BenefitsLearnMoreLinkGenerator {
 
+  private AnnualBenefitEnrollmentDatesService datesService =
+      new AnnualBenefitEnrollmentDatesService();
+
   public String learnMoreLinkFor(Set<String> roles, boolean madisonness) {
 
-    if (!madisonness) {
-      // regardless of situation, non-madison employees get this learn more link
-      return "https://www.wisconsin.edu/ohrwd/benefits/";
-    } else if (roles.contains("ROLE_VIEW_NEW_HIRE_BENEFITS")) {
-      // madison users with a new hire event get this learn more link
-      return "https://hr.wisc.edu/benefits/new-employee-benefits-enrollment/";
-    } else if (roles.contains("ROLE_VIEW_OPEN_ENROLL_BENEFITS")) {
-      // madison users with an annual benefit enrollment opportunity get this
-      // learn more link
-      return "https://hr.wisc.edu/benefits/annual-benefits-enrollment/";
-    } else {
-      // madison users without an enrollment opportunity get this learn more
-      // link
+
+    // employees with a personal event-driven enrollment opportunity
+    // get a learn more link about that new hire opportunity
+
+    if (roles.contains("ROLE_VIEW_NEW_HIRE_BENEFITS")) {
+      if (madisonness) {
+        return "https://hr.wisc.edu/benefits/new-employee-benefits-enrollment/";
+      } else {
+        return "https://www.wisconsin.edu/ohrwd/benefits/";
+      }
+    }
+
+    // employees with an annual benefit enrollment opportunity
+    // get a learn more link about that annual opportunity
+
+    if (roles.contains("ROLE_VIEW_OPEN_ENROLL_BENEFITS")) {
+      if (madisonness) {
+        return "https://hr.wisc.edu/benefits/annual-benefits-enrollment/";
+      } else {
+        return "https://www.wisconsin.edu/abe";
+      }
+    }
+
+    // otherwise, during ABE foreshadowing,
+    // everyone gets the annual benefits enrollment preview learn more link
+    // because MyUW cannot tell whether the foreshadowing is relevant to the employee
+
+    if (datesService.foreshadowAnnualBenefitsEnrollment(new LocalDate())) {
+      if (madisonness) {
+        return "https://hr.wisc.edu/benefits/annual-benefits-enrollment/";
+      } else {
+        return "https://www.wisconsin.edu/abe";
+      }
+    }
+
+    // otherwise, everyone gets their routine benefits information URL
+
+    if (madisonness) {
       return "http://benefits.wisc.edu/";
+    } else {
+      return "https://www.wisconsin.edu/ohrwd/benefits/";
     }
 
   }

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentDuringCountdown.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentDuringCountdown.jsp
@@ -1,0 +1,48 @@
+<%--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+<%@ page trimDirectiveWhitespaces="true" %>
+<%@ include file="/WEB-INF/jsp/include.jsp"%>
+
+<portlet:defineObjects/>
+<spring:htmlEscape defaultHtmlEscape="true" />
+
+<div class="widget-body layout-align-center-center layout-column">
+  <span>PLACEHOLDER CONTENT</span>
+</div>
+
+<c:choose>
+  <c:when test="${isMadisonUser}">
+    <a
+      aria-label="Launch Benefit Information"
+      href="/web/exclusive/university-staff-benefits-statement"
+      class="launch-app-button">
+      Launch full app
+    </a>
+  </c:when>
+  <c:otherwise>
+    <a
+      aria-label="Launch Benefit Information"
+      href="/web/exclusive/uw-system-university-staff-benefits-statement"
+      class="launch-app-button">
+      Launch full app
+    </a>
+  </c:otherwise>
+</c:choose>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentFeedback.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentFeedback.jsp
@@ -1,0 +1,48 @@
+<%--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+<%@ page trimDirectiveWhitespaces="true" %>
+<%@ include file="/WEB-INF/jsp/include.jsp"%>
+
+<portlet:defineObjects/>
+<spring:htmlEscape defaultHtmlEscape="true" />
+
+<div class="widget-body layout-align-center-center layout-column">
+  <span>PLACEHOLDER CONTENT</span>
+</div>
+
+<c:choose>
+  <c:when test="${isMadisonUser}">
+    <a
+      aria-label="Launch Benefit Information"
+      href="/web/exclusive/university-staff-benefits-statement"
+      class="launch-app-button">
+      Launch full app
+    </a>
+  </c:when>
+  <c:otherwise>
+    <a
+      aria-label="Launch Benefit Information"
+      href="/web/exclusive/uw-system-university-staff-benefits-statement"
+      class="launch-app-button">
+      Launch full app
+    </a>
+  </c:otherwise>
+</c:choose>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentForeshadowing.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentForeshadowing.jsp
@@ -1,0 +1,64 @@
+<%--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+<%@ page trimDirectiveWhitespaces="true" %>
+<%@ include file="/WEB-INF/jsp/include.jsp"%>
+
+<portlet:defineObjects/>
+<spring:htmlEscape defaultHtmlEscape="true" />
+
+<div class="widget-body layout-align-center-center layout-column">
+  <span class="tsc__title">Annual Benefits Enrollment</span>
+  <div class="tsc__status">
+    <p>begins September 30.</p>
+  </div>
+
+  <div class="tsc__extra-buttons layout-align-center-center layout-row">
+    <c:if test="${not empty learnMoreLink}">
+      <a
+        aria-label="Learn more about benefits"
+        target="_blank" rel="noopener noreferrer"
+        href="${learnMoreLink}">
+        Learn more
+      </a>
+    </c:if>
+  </div>
+</div>
+
+<c:choose>
+  <c:when test="${isMadisonUser}">
+    <%-- Bug: will launch the wrong Benefit Information for Madison users
+         in context of my.wisconsin --%>
+    <a
+      aria-label="Launch Benefit Information"
+      href="/web/exclusive/university-staff-benefits-statement"
+      class="launch-app-button">
+      Launch full app
+    </a>
+  </c:when>
+  <c:otherwise>
+    <a
+      aria-label="Launch Benefit Information"
+      href="/web/exclusive/uw-system-university-staff-benefits-statement"
+      class="launch-app-button">
+      Launch full app
+    </a>
+  </c:otherwise>
+</c:choose>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentLastDay.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentLastDay.jsp
@@ -1,0 +1,73 @@
+<%--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+<%@ page trimDirectiveWhitespaces="true" %>
+<%@ include file="/WEB-INF/jsp/include.jsp"%>
+
+<portlet:defineObjects/>
+<spring:htmlEscape defaultHtmlEscape="true" />
+
+<div class="widget-body layout-align-center-center layout-column">
+  <span class="tsc__title">Annual Benefits Enrollment</span>
+  <div layout="column" layout-align="center center">
+    <p>
+      <span class="tsc__last-day">ends today!</span>
+    </p>
+    <p>
+      <a
+        class="md-button md-accent md-raised md-ink-ripple"
+        href="${hrsUrls['Open Enrollment/Hire Event']}">
+        Enroll now
+      </a>
+    </p>
+  </div>
+
+  <div class="tsc__extra-buttons layout-align-center-center layout-row">
+    <c:if test="${not empty learnMoreLink}">
+      <a
+        aria-label="Learn more about benefits"
+        target="_blank" rel="noopener noreferrer"
+        href="${learnMoreLink}">
+        Learn more
+      </a>
+    </c:if>
+  </div>
+</div>
+
+<c:choose>
+  <c:when test="${isMadisonUser}">
+    <%-- Bug: will launch the wrong Benefit Information for Madison users
+         in context of my.wisconsin --%>
+    <a
+      aria-label="Launch Benefit Information"
+      href="/web/exclusive/university-staff-benefits-statement"
+      class="launch-app-button">
+      Launch full app
+    </a>
+  </c:when>
+  <c:otherwise>
+    <a
+      aria-label="Launch Benefit Information"
+      href="/web/exclusive/uw-system-university-staff-benefits-statement"
+      class="launch-app-button">
+      Launch full app
+    </a>
+  </c:otherwise>
+</c:choose>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetPersonalEnrollmentEvent.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetPersonalEnrollmentEvent.jsp
@@ -1,0 +1,71 @@
+<%--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+<%@ page trimDirectiveWhitespaces="true" %>
+<%@ include file="/WEB-INF/jsp/include.jsp"%>
+
+<portlet:defineObjects/>
+<spring:htmlEscape defaultHtmlEscape="true" />
+
+<div class="widget-body layout-align-center-center layout-column">
+  <span class="tsc__title">You have
+    a benefit enrollment opportunity.</span>
+
+  <div class="tsc__status">
+    <p>
+      <a
+        class="md-button md-accent md-raised md-ink-ripple"
+        href="${hrsUrls['Open Enrollment/Hire Event']}">
+        Enroll now
+      </a>
+    </p>
+  </div>
+  <div class="tsc__extra-buttons layout-align-center-center layout-row">
+    <c:if test="${not empty learnMoreLink}">
+      <a
+        aria-label="Learn more about benefits"
+        target="_blank" rel="noopener noreferrer"
+        href="${learnMoreLink}">
+        Learn more
+      </a>
+    </c:if>
+  </div>
+</div>
+
+<c:choose>
+  <c:when test="${isMadisonUser}">
+    <%-- Bug: will launch the wrong Benefit Information for Madison users
+         in context of my.wisconsin --%>
+    <a
+      aria-label="Launch Benefit Information"
+      href="/web/exclusive/university-staff-benefits-statement"
+      class="launch-app-button">
+      Launch full app
+    </a>
+  </c:when>
+  <c:otherwise>
+    <a
+      aria-label="Launch Benefit Information"
+      href="/web/exclusive/uw-system-university-staff-benefits-statement"
+      class="launch-app-button">
+      Launch full app
+    </a>
+  </c:otherwise>
+</c:choose>


### PR DESCRIPTION
Continues to reflect personal event-driven ("new hire") enrollment opportunities in Benefit Information widget.

But adds, when there's no such personal opportunity, foreshadowing Annual Benefits Enrollment.

<img width="315" alt="Mockup showing foreshadowing ABE 2019" src="https://user-images.githubusercontent.com/952283/65007015-6cb05680-d8ca-11e9-9739-32a7e022f579.png">

Foreshadowing starts on Wednesday Sept 18.

Does not yet fully implement the during-ABE experience, which we don't need in place until ABE starts on Sept 30.

Oddities:

+ Madison and System have different Learn more URLs.
+ MyUW can't tell whether an employee will actually have the foreshadowed Annual Benefits Enrollment opportunity, or whether an employee had it, so shows foreshadowing and feedback collection based on dates, but can tell whether an employee for real has an active annual benefit enrollment opportunity right now, so shows the during-ABE treatment based on role.