### PR TITLE
HRSPLT-458 Condition "Approve Time" link on "Approve Payable time" HRS URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ YYYY-MM-DD (Not yet released.)
   `editCancelAbsenceUrl` portlet-preference when HRS URL not set.
 + Predicate "Approve Time" link in "Manager Time and Approval" app on presence
   of `Approve Payable time` (sic) HRS URL.
++ Remove logging as error case where `Approve Payable time` (sic) HRS URL is not
+  present, as removal of this HRS URL is expected in a forthcoming PeopleSoft
+  Update Manager update ("PUM").
 
 ### 7.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ YYYY-MM-DD (Not yet released.)
 
 + Use `Time and Absence Edit/Cancel` HRS URL when set; continue to honor
   `editCancelAbsenceUrl` portlet-preference when HRS URL not set.
++ Predicate "Approve Time" link in "Manager Time and Approval" app on presence
+  of `Approve Payable time` (sic) HRS URL.
 
 ### 7.2.1
 

--- a/hrs-portlets-webapp/docs/urls.md
+++ b/hrs-portlets-webapp/docs/urls.md
@@ -1,0 +1,26 @@
+# URLS sourced from the HRS URLs web service
+
+The keys, meaning, and usages of the URLs sourced from the HRS URLs web service.
+
+**Not a complete list of URL keys supported from HRS.**
+
+See also the [HRS URLs troubleshooting app][], which lists the URL key-value pairs
+currently received from HRS.
+
+## `Approve Payable time` (sic)
+
+Note that A in Approve and P in Payable are capitals,
+but t in time is lowercase.
+
+Deep link into HRS self-service to the page where supervisors approve time
+reported by their supervisees.
+
+Example: `https://www.hrs.wisconsin.edu/psp/hrs-fd/EMPLOYEE/HRMS/c/ROLE_MANAGER.TL_SRCH_APPRV_GRP.GBL`
+
+When present, is the URL for the "Approve time" link in the
+"Manager Time and Approval" widget and app.
+
+When absent, the "Approve time" link disappears from the
+"Manager Time and Approval" widget and app.
+
+[HRS URLs troubleshooting app]: https://my.wisc.edu/web/exclusive/hrs-portlet-urls

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -150,19 +150,17 @@ public class ManagerLinksController
       }
     }
 
-    if (roles.contains("ROLE_VIEW_MANAGED_TIMES")) {
-      final String approveTimeUrl = getHrsUrls().get(HrsUrlDao.APPROVE_PAYABLE_TIME_KEY);
-      if (StringUtils.isNotBlank(approveTimeUrl)) {
-        final Link approveTime = new Link();
-        approveTime.setTitle(approveTimeLabel);
-        approveTime.setIcon("access_time");
-        approveTime.setHref(approveTimeUrl);
-        approveTime.setTarget("_blank");
-        linkList.add(approveTime);
-      } else {
-        logger.error("HRS URL [" + HrsUrlDao.APPROVE_PAYABLE_TIME_KEY + "] expected but not found "
-            + "and so could not be offered to emplid " + emplId);
-      }
+    final String approveTimeUrl = getHrsUrls().get(HrsUrlDao.APPROVE_PAYABLE_TIME_KEY);
+    if (StringUtils.isNotBlank(approveTimeUrl)
+      && roles.contains("ROLE_VIEW_MANAGED_TIMES")) {
+
+      final Link approveTime = new Link();
+      approveTime.setTitle(approveTimeLabel);
+      approveTime.setIcon("access_time");
+      approveTime.setHref(approveTimeUrl);
+      approveTime.setTarget("_blank");
+
+      linkList.add(approveTime);
     }
 
     final Map<String, Object[]> content = new HashMap<String, Object[]>();

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/managerLinks.jsp
@@ -53,6 +53,7 @@
       </li>
     </sec:authorize>
 
+    <c:if test="${not empty hrsUrls['Approve Payable time']}">
     <sec:authorize ifAnyGranted="ROLE_VIEW_MANAGED_TIMES">
       <li>
         <a href="${hrsUrls['Approve Payable time']}"
@@ -61,6 +62,7 @@
         </a>
       </li>
     </sec:authorize>
+    </c:if>
 
     <li>
       <a href="${helpUrl}"


### PR DESCRIPTION
Big picture: the "Approve Time" link is eventually disappearing, with the approvals dashboard conceptually replacing it.

These changes are to make MyUW hrs-portlets gracefully weather this change.

With this change:

+ If the `Approve Payable time` (sic) HRS URL is present, honor it, including it as the "Approve Time" link in Manager Time and Approval app and widget.
+ If that URL is not present, don't sweat it, dropping the "Approve Time" links and *not* logging an error