### PR TITLE
HRSPLT-458 differentiate Manager Time and Approval widget and app labels on dashboard link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ YYYY-MM-DD (Not yet released.)
 
 + Use `Time and Absence Edit/Cancel` HRS URL when set; continue to honor
   `editCancelAbsenceUrl` portlet-preference when HRS URL not set.
++ Differentiated default labels for approvals dashboard link in Manager Time and
+  Approval widget vs app, with the label in the app changing to append
+  " (Approve Time)".
++ deprecated `approvalsDashboardLabel` portlet preference
 
 ### 7.2.1
 

--- a/README.md
+++ b/README.md
@@ -58,11 +58,14 @@ This is intended as a solution for
 + When not set, the label defaults to "Approve Time" (as defined in
   `ManagerLinksController.DEFAULT_APPROVE_TIME_LABEL`).
 
-#### `approvalsDashboardLabel` portlet preference (optional)
+#### `approvalsDashboardLabel` portlet preference (optional) (DEPRECATED)
 
 + Sets the label for the approvals dashboard hyperlink.
-+ When not set, the label defaults to "Time/Absence Dashboard" (as defined in
-  `ManagerLinksController.DEFAULT_DASHBOARD_LABEL`).
++ When not set, the label defaults to "Time/Absence Dashboard"
+  in the Manager Time and Approval list-of-links widget
+  (as defined in `ManagerLinksController.DEFAULT_DASHBOARD_LABEL_WIDGET`)
+  and "Time/Absence Dashboard (Approve Time)" in the Manager Time and Approval
+  app (as defined in `ManagerLinksController.DEFAULT_DASHBOARD_LABEL_APP`).
 
 #### `approvalsDashboardUrl` portlet preference (optional) (DEPRECATED)
 

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/managerlinks/ManagerLinksController.java
@@ -34,8 +34,21 @@ public class ManagerLinksController
 
   /**
    * Default user-facing label for the approvals dashboard link.
+   * @deprecated instead use the app-specific or widget-specific label.
    */
   public static String DEFAULT_DASHBOARD_LABEL = "Time/Absence Dashboard";
+
+  /**
+   * Default user-facing label for the approvals dashboard link,
+   * as surfaced in the Manager Time and Approval app.
+   */
+  public static String DEFAULT_DASHBOARD_LABEL_APP = "Time/Absence Dashboard (Approve Time)";
+
+    /**
+   * Default user-facing label for the approvals dashboard link,
+   * as surfaced in the Manager Time and Approval widget.
+   */
+  public static String DEFAULT_DASHBOARD_LABEL_WIDGET = "Time/Absence Dashboard";
 
   /**
    * A strict reading of the MyUW style guidance wrt list-of-links apps would have this sentence
@@ -87,7 +100,7 @@ public class ManagerLinksController
     final PortletPreferences preferences = request.getPreferences();
     final String approvalsDashboardUrl = approvalsDashboardUrl(preferences);
     final String approvalsDashboardLabel =
-        preferences.getValue("approvalsDashboardLabel", DEFAULT_DASHBOARD_LABEL);
+        preferences.getValue("approvalsDashboardLabel", DEFAULT_DASHBOARD_LABEL_WIDGET);
     final String approveAbsenceLabel =
         preferences.getValue("approveAbsenceLabel", DEFAULT_APPROVE_ABSENCE_LABEL);
     final String approveTimeLabel =
@@ -184,7 +197,7 @@ public class ManagerLinksController
     final String approvalsDashboardUrl = approvalsDashboardUrl(preferences);
 
     final String approvalsDashboardLabel =
-        preferences.getValue("approvalsDashboardLabel", DEFAULT_DASHBOARD_LABEL);
+        preferences.getValue("approvalsDashboardLabel", DEFAULT_DASHBOARD_LABEL_APP);
     final String approveAbsenceLabel =
         preferences.getValue("approveAbsenceLabel", DEFAULT_APPROVE_ABSENCE_LABEL);
     final String approveTimeLabel =


### PR DESCRIPTION
Status quo:

1. The link in both the Manager Time and Approval widget and app both share the default label "Time/Absence Dashboard".
2. While there's support for overriding this label via portlet-preference, that preference isn't actually being set in production.

With this change:

1. The link in the Manager Time and Approval widget keeps the default label "Time/Absence Dashboard"
2. The link in the Manager Time and Approval app differentiates its default label to "Time/Absence Dashboard (Approve Time)"
3. While the portlet-preference can still override these, that feature is marked deprecated for future removal, since setting it would override both labels at once and clobber their differentiation.

