### PR TITLE
HRSPLT-459 always label the button "View/Update Dependent Information"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ YYYY-MM-DD (Not yet released.)
 + Differentiated default labels for approvals dashboard link in Manager Time and
   Approval widget vs app, with the label in the app changing to append
   " (Approve Time)".
++ Always label the button "View/Update Dependent Information",
+  regardless of whether it is linking to
+  `Dependent/Beneficiary Info` or to
+  `Dependent Information`. ( [HRSPLT-459][])
 + deprecated `approvalsDashboardLabel` portlet preference
 
 ### 7.2.1
@@ -1089,5 +1093,6 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-449]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-449
 [HRSPLT-453]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-453
 [HRSPLT-454]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-454
+[HRSPLT-459]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-459
 
 [MUMMNG-4833]: https://jira.doit.wisc.edu/jira/browse/MUMMNG-4833

--- a/docs/urls.md
+++ b/docs/urls.md
@@ -82,10 +82,12 @@ This is the URL of the "View Dependent Coverage" link in Benefit Information.
 This is an old HRS URL that was superseded by `Dependent/Beneficiary Info`.
 
 When present, and HRS URL `Dependent/Beneficiary Info` is *not* present,
-is the URL of the "View Dependent Details" link in Benefit Information.
+is the URL of the "View/Update Dependent Information" link
+in Benefit Information.
 
-When absent, the "View Dependent Details" link in Benefit Information is not
-shown.
+When absent, and HRS URL `Dependent/Beneficiary Info` is also absent,
+the "View/Update Dependent Information" link in Benefit Information
+is not shown.
 
 ## `Dependent/Beneficiary Info` (optional)
 
@@ -93,8 +95,10 @@ When present,
 is the URL of the "View/Update Dependent Information" link in
 Benefit Information.
 
-When absent, the "View/Update Dependent Information" link is not shown, but the
-"View Dependent Details" link might be shown instead.
+When absent,
+the "View/Update Dependent Information" link may still show,
+linking to `Dependent Information`,
+if that `Dependent Information` HRS URL is present.
 
 ## `Direct Deposit`
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
@@ -211,10 +211,10 @@
                 target="_blank" rel="noopener noreferer"
                 class="btn btn-default">View/Update Dependent Information</a>
             </c:when>
-            <%-- otherwise if the old read-only information URL is available,
+            <%-- otherwise if the old information URL is available,
               use it --%>
             <c:when test="${not empty hrsUrls['Dependent Information']}">
-                <a href="${hrsUrls['Dependent Information']}" target="_blank" class="btn btn-default">View Dependent Details</a>
+                <a href="${hrsUrls['Dependent Information']}" target="_blank" class="btn btn-default">View/Update Dependent Information</a>
             </c:when>
           </c:choose>
         </div>


### PR DESCRIPTION
Always label the button "View/Update Dependent Information", 
regardless of which HRS URL is driving what URL it links to.