### PR TITLE
HRSPLT-460 style "Web Clock" link as button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The v7 major version was occasioned by the breaking change of no longer honoring
 `enrollmentFlag`, instead relying upon HRS roles to indicate whether and what
 benefit enrollment opportunities are available to an employee.
 
+### 7.2.4 (not yet released)
+
++ Style "Web Clock" link as a button for consistency with other
+  links-that-look-like-buttons in Time and Absence. ( [HRSPLT-460][] )
+
 ### 7.2.3
 
 2019-10-21
@@ -1101,5 +1106,6 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-453]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-453
 [HRSPLT-454]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-454
 [HRSPLT-459]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-459
+[HRSPLT-460]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-460
 
 [MUMMNG-4833]: https://jira.doit.wisc.edu/jira/browse/MUMMNG-4833

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/timeAbsence.jsp
@@ -167,7 +167,10 @@
     </sec:authorize>
     <sec:authorize ifAnyGranted="ROLE_VIEW_WEB_CLOCK">
       <div class="dl-link">
-        <a href="${hrsUrls['Web Clock']}" target="_blank">Web Clock</a><br/>
+        <a  class="btn btn-primary"
+          href="${hrsUrls['Web Clock']}"
+          target="_blank" rel="noopener noreferer">
+          Web Clock</a><br/>
       </div>
     </sec:authorize>
   </div>


### PR DESCRIPTION
["As a web clock user, I would like to more readily see the link."](https://jira.doit.wisc.edu/jira/browse/HRSPLT-460)

This applies the same `class="btn btn-primary"` styling to the "Web Clock" button as is already applied to e.g. the "Timesheet" button.

So, yay, consistency, and probably also scratches the itch of increasing the affordance on this link.