### PR TITLE
HRSPLT-461 update W-2 and 1095-C labels to reflect  not just 2018

### DIFF
--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -279,7 +279,7 @@
         <c:if test="${not empty hrsUrls['View W-2']}">
           <a class="btn btn-primary"
             href="${hrsUrls['View W-2']}"
-            target="_blank" rel="noopener noreferrer">View 2018 W-2</a>
+            target="_blank" rel="noopener noreferrer">View W-2 forms</a>
         </c:if>
         <c:if test="${not empty hrsUrls['W-2 Consent']}">
           <a class="btn btn-default"
@@ -290,7 +290,7 @@
         <c:if test="${not empty hrsUrls['View 1095-C']}">
           <a class="btn btn-primary"
             href="${hrsUrls['View 1095-C']}"
-            target="_blank" rel="noopener noreferrer">View 2018 1095-C</a>
+            target="_blank" rel="noopener noreferrer">View 1095-C forms</a>
         </c:if>
         <c:if test="${not empty hrsUrls['1095-C Consent']}">
           <a class="btn btn-default"


### PR DESCRIPTION
2019 W-2s and 1095-Cs will be shipping, such that the hyperlinks currently labeled "View 2018 W-2" and "View 2018 1095-C" will be linking to pages that primarily provide *2019* documents with access to 2018 documents.

This change therefore updates those link labels to reflect their new nature.