### PR TITLE
HRSPLT-463 hide old tax statements by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ benefit enrollment opportunities are available to an employee.
 + Update W-2 and 1095-C hyperlinks in Payroll Information to reflect that these
   no longer will link specifically to 2018 documents.
   ( [HRSPLT-461][], [#216][] )
++ Hide old tax statements by default, with a checkbox for showing the old
+  statements. This is intended to help users focus on the more recent statements
+  that more likely address their current needs while continuing to make access
+  to old statements possible. ( [HRSPLT-463][], [#217][] )
 
 ### 7.2.4
 
@@ -1068,6 +1072,7 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [#202]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/202
 [#205]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/205
 [#216]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/216
+[#217]: https://github.com/UW-Madison-DoIT/hrs-portlets/pull/217
 
 [HRSPLT-346]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-346
 [HRSPLT-348]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-348
@@ -1117,5 +1122,6 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-459]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-459
 [HRSPLT-460]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-460
 [HRSPLT-461]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-461
+[HRSPLT-463]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-463
 
 [MUMMNG-4833]: https://jira.doit.wisc.edu/jira/browse/MUMMNG-4833

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -300,7 +300,17 @@
         </c:if>
       </div>
 
-      <div class="fl-pager">
+      <div>
+        <form action="#">
+          <label for="${n}dl-show-old-tax-statements-toggle">
+            Show 2017 and earlier tax statements</label>
+          <input type="checkbox"
+            id="${n}dl-show-old-tax-statements-toggle"
+            name="dl-show-old-tax-statements-toggle" />
+        </form>
+      </div>
+
+      <div class="fl-pager old-tax-statements" style="display:none">
         <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
           <table class="dl-table table" tabindex="0" aria-label="Tax Statement table">
             <thead>
@@ -457,6 +467,23 @@
         });
       </c:if>
 
+      var updateShowOldTaxStatements = function(checkbox) {
+        var checked = checkbox.is(':checked');
+
+        var oldTaxStatements = $("#old-tax-statements");
+
+        if (checked) {
+          oldTaxStatements.show();
+        } else {
+          oldTaxStatements.hide();
+        }
+      }
+
+      var showOldTaxStatementsToggle = $("#${n}dl-show-old-tax-statements-toggle");
+
+      showOldTaxStatementsToggle.change(function() {
+        updateShowOldTaxStatements(showOldTaxStatementsToggle);
+      });
 
       var taxStatementUrl = dl.util.templateUrl("${irsStatementPdfUrl}");
       dl.pager.init("#${n}dl-tax-statements", {


### PR DESCRIPTION
In most cases where employees are looking for tax statements, they will be best served by recent tax statements. So continue to lead with those, that are available via the hyperlinks into HRS. Hide the older statements by default to reduce distractions from those.

Continue to make it possible to access the old statements by providing a checkbox that, when checked, will show the old statements table.