### PR TITLE
Include "Preferred Name" in the description of what employees can do in HRS self-service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ before-PUM22-mode presentation of the Personal Information portlet.
 
 ### 8.0.0
 
++ Adds "Preferred Name" to the employee-facing text description of what an
+  employee can adjust in HRS self-service. ( [HRSPLT-468][] )
 + Personal Information no longer supports unused pre-PUM-22 mode.
 + `updateMyPersonalInfoUrl` portlet-preference no longer has any effect.
   Instead, Personal Information now links to the HRS URL named
@@ -1162,5 +1164,6 @@ This and many more earlier releases exist as [releases in the GitHub repo][].
 [HRSPLT-463]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-463
 [HRSPLT-466]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-466
 [HRSPLT-467]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-467
+[HRSPLT-468]: https://jira.doit.wisc.edu/jira/browse/HRSPLT-468
 
 [MUMMNG-4833]: https://jira.doit.wisc.edu/jira/browse/MUMMNG-4833

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # MyUW hrs-portlets change log
 
+## HRS Portlets 8 series
+
+The v8 major version was occasioned by the breaking change of the `updateMyPersonalInfoUrl`
+portlet-preference no longer having any effect, and thereby no longer supporting unused-since-2017
+before-PUM22-mode presentation of the Personal Information portlet.
+
+### 8.0.0
+
++ Personal Information no longer supports unused pre-PUM-22 mode.
++ `updateMyPersonalInfoUrl` portlet-preference no longer has any effect.
+  Instead, Personal Information now links to the HRS URL named
+  `Personal Information` rather than indulging in a layer of indirection via
+  that portlet-preference.
+
 ## HRS Portlets 7 series
 
 The v7 major version was occasioned by the breaking change of no longer honoring

--- a/README.md
+++ b/README.md
@@ -104,11 +104,6 @@ technically the underlying portlet name is `ContactInfo`.
 + When set, Personal Information shows the value of this preference as a user-facing message in the context of editing preferred name. This is intended as a spot for documentation nuancing what edits are and are not permitted.
 + When not set, this message does not appear.
 
-#### `updateMyPersonalInfoUrl` portlet preference (optional)
-
-+ When set, uses its value as the href for the link to HRS self-service management of personal information.
-+ When set, turns on "PUM22 mode", which tweaks the display a bit. The deep links specific to self-service updating of ethnicity, disability, and veteran status reporting disappear (in favor of the linked UI being the omnibus UI for updating all personal information).
-
 ### Specific to Time and Absence
 
 #### `editCancelAbsenceUrl` portlet preference (optional)

--- a/docs/urls.md
+++ b/docs/urls.md
@@ -199,17 +199,9 @@ is the URL of the "View Details" link on the "Time Entry" tab in the
 
 ## `Personal Information`
 
-The `updateMyPersonalInfoUrl` portlet-preference overrides this URL.
+Is the URL of the "Update my personal information" link in Personal Information.
 
-When present, and the `updateMyPersonalInfoUrl` portlet-preference is *not* set,
-is the URL of the "Update my personal information" link in Personal Information.
-
-When absent, and the `updateMyPersonalInfoUrl` portlet-preference is *not* set,
-shows an employee-facing error message.
-
-"Personal Information" (both Madison and System version) references this URL,
-as its `updateMyPersonalInfoUrl` portlet-preference,
-via the `HRSPortlets/go?` service.
+When absent, Personal Information shows an employee-facing error message.
 
 ## `Request Absence` (required)
 

--- a/hrs-portlets-webapp/src/main/resources/messages.properties
+++ b/hrs-portlets-webapp/src/main/resources/messages.properties
@@ -36,8 +36,6 @@ updateInfoLink=Update my personal information
 no=No
 yes=Yes
 
-bottomNotePart1=Please note that you can update Home Address, Phone, Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in HRS.
-
 updateBusinessOfficeAddressInstructionsPart1=To update your Business/Office Address, please contact 
 updateBusinessOfficeAddressInstructionsPart2=your human resources office
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -227,21 +227,13 @@
 
   <sec:authorize ifAnyGranted="ROLE_UW_EMPLOYEE_ACTIVE">
   <c:choose>
-    <c:when test="${not empty prefs['updateMyPersonalInfoUrl']
-      && not empty prefs['updateMyPersonalInfoUrl'][0]}">
-
-      <!-- configured with HRS self-service personal information update
-       URL via portlet-preference. Use HRS PUM 22 content. -->
-
-       <!-- federal reporting statuses deliberately removed in PUM22 mode,
-            in favor of that data just being down inside
-            linked HRS self-service UI. -->
+    <c:when test="${not empty hrsUrls['Personal Information']">
 
       <div class="dl-contact-info-update">
         <div>
           <p>
             <strong>
-            <a href="${prefs['updateMyPersonalInfoUrl'][0]}"
+            <a href="${hrsUrls['Personal Information']}"
               target="_blank" rel="noopener noreferer">
               Update My Personal Information
             </a>
@@ -280,118 +272,8 @@
         </div>
       </div>
     </c:when>
-    <c:when test="${not empty hrsUrls['Personal Information']}">
-
-      <!-- Not configured with a self-service personal information update URL
-      via portlet preference, but have a URL fom HRS URLs web service.
-      Legacy mode. -->
-
-      <div class="federal-reporting-statuses">
-        <!-- federal reporting statuses only show in legacy mode. -->
-        <c:if test="${not empty hrsUrls['Disability Status']}">
-          <div>
-            <span>
-              <strong>
-                <spring:message
-                  code="label.disability.status"
-                  text="Disability Status"/>
-              </strong>
-            </span>
-            <span>(
-              <a
-                aria-label="view or update Disability Status"
-                href="${hrsUrls['Disability Status']}"
-                target="_blank"
-                rel="noopener noreferer">
-                  <spring:message code="label.status.link" text="view/update"/>
-              </a>
-            )</span>
-          </div>
-        </c:if>
-
-        <c:if test="${not empty hrsUrls['Veteran Status']}">
-          <div>
-            <span>
-              <strong>
-                <spring:message
-                  code="label.veteran.status"
-                  text="Veteran Status"/>
-              </strong>
-            </span>
-            <span>(
-              <a
-                aria-label="view or update Veteran Status"
-                href="${hrsUrls['Veteran Status']}"
-                target="_blank">
-                  <spring:message
-                    code="label.status.link"
-                    text="view/update"/>
-              </a>
-            )</span>
-          </div>
-        </c:if>
-
-        <c:if test="${not empty hrsUrls['Ethnic Groups']}">
-          <div>
-            <span>
-              <strong>
-                <spring:message
-                  code="label.ethnic.groups"
-                  text="Ethnic Groups"/>
-              </strong>
-            </span>
-            <span>(
-              <a
-                aria-label="view or update Ethnic Groups"
-                href="${hrsUrls['Ethnic Groups']}"
-                target="_blank"
-                rel="noopener noreferer">
-                  <spring:message code="label.status.link" text="view/update"/>
-              </a>
-            )</span>
-          </div>
-        </c:if>
-      </div>
-
-      <div class="dl-contact-info-update">
-        <a
-          href="${hrsUrls['Personal Information']}"
-          target="_blank"
-          rel="noopener noreferer">
-            <spring:message code="updateInfoLink"/>
-        </a>
-        <br/>
-        <div>
-          <p class="padded-paragraph">
-            Please note that you can update Home Address, Phone, Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in HRS.
-          </p>
-          <p>
-            <strong>
-              <spring:message code="updateBusinessOfficeAddressInstructionsPart1"
-                text="To update your Business/Office Address, please contact "/>
-              <c:choose>
-                <c:when test="${not empty humanResourceOfficeContactUrl}">
-                  <a href="${humanResourceOfficeContactUrl}"
-                   target="_blank"
-                   rel="noopener noreferer">
-                    <spring:message code="updateBusinessOfficeAddressInstructionsPart2"
-                     text="your human resources office"/>
-                  </a>.
-                </c:when>
-                <c:otherwise>
-                  <spring:message code="updateBusinessOfficeAddressInstructionsPart2"
-                   text="your human resources office"/>.
-                </c:otherwise>
-              </c:choose>
-            </strong>
-          </p>
-        </div>
-      </div>
-    </c:when>
-
     <c:otherwise>
-      <!-- in case where cannot source HRS self-service UI URL from
-        portlet preference nor from HRS URLs web service,
+      <!-- in case where cannot source HRS self-service UI URL from HRS URLs,
         show error. -->
       <p>Error: this application is not configured with a link to
         HRS self service personal information UI.</p>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -245,7 +245,10 @@
             </strong>
             <p style="padding-left: 2cm;">
               <strong>
-                Addresses (Home &amp; Mail); Contact Details (Phone &amp; Email); Emergency Contacts; Release Home Information; Marital Status; Coordination of Benefits; Medicare Information; Ethnic Groups; Veteran Status; Disability.
+                Addresses (Home &amp; Mail); Contact Details (Phone &amp; Email);
+                Emergency Contacts; Release Home Information; Marital Status;
+                Coordination of Benefits; Medicare Information; Ethnic Groups;
+                Veteran Status; Disability.
               </strong>
             </p>
           </p>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -246,9 +246,9 @@
             <p style="padding-left: 2cm;">
               <strong>
                 Addresses (Home &amp; Mail); Contact Details (Phone &amp; Email);
-                Emergency Contacts; Release Home Information; Marital Status;
-                Coordination of Benefits; Medicare Information; Ethnic Groups;
-                Veteran Status; Disability.
+                Preferred Name; Emergency Contacts; Release Home Information;
+                Marital Status; Coordination of Benefits; Medicare Information;
+                Ethnic Groups; Veteran Status; Disability.
               </strong>
             </p>
           </p>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -363,7 +363,7 @@
         <br/>
         <div>
           <p class="padded-paragraph">
-            <spring:message code="bottomNotePart1" text="Please note that you can update Home Address, Phone, Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in HRS."/>
+            Please note that you can update Home Address, Phone, Release Information, Emergency Contacts, Marital Status, Coordination of Benefits, Disability Status, Veteran Status, and Ethnic Group in HRS.
           </p>
           <p>
             <strong>


### PR DESCRIPTION
Also removes legacy before-PUM22 mode.

[HRSPLT-468](https://jira.doit.wisc.edu/jira/browse/HRSPLT-468)

Mockup:

![mockup-listing-preferred-name](https://user-images.githubusercontent.com/952283/79234031-45554400-7e2f-11ea-8b82-eb1440cd666a.png)
