### PR TITLE
in tests, model and depend upon a date during ABE

### DIFF
--- a/hrs-portlets-api/src/test/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesServiceTest.java
+++ b/hrs-portlets-api/src/test/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesServiceTest.java
@@ -9,6 +9,9 @@ public class AnnualBenefitEnrollmentDatesServiceTest {
 
   private AnnualBenefitEnrollmentDatesService service = new AnnualBenefitEnrollmentDatesService();
 
+  public static final LocalDate DATE_DURING_ABE_FORESHADOWING =
+    new LocalDate("2020-09-22");
+
   @Test
   public void testForeshadowing() {
     // foreshadowing does not begin prematurely
@@ -18,7 +21,7 @@ public class AnnualBenefitEnrollmentDatesServiceTest {
     assertTrue(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2020-09-16")));
 
     // and continues
-    assertTrue(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2020-09-22")));
+    assertTrue(service.foreshadowAnnualBenefitsEnrollment(DATE_DURING_ABE_FORESHADOWING));
 
     // through the day before benefit enrollment begins
     assertTrue(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2020-09-27")));

--- a/hrs-portlets-webapp/pom.xml
+++ b/hrs-portlets-webapp/pom.xml
@@ -210,6 +210,13 @@
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hrs-portlets-api</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hrs-portlets-webapp/src/test/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGeneratorTest.java
+++ b/hrs-portlets-webapp/src/test/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGeneratorTest.java
@@ -1,5 +1,7 @@
 package edu.wisc.portlet.hrs.web.benefits;
 
+import edu.wisc.hr.service.benefits.AnnualBenefitEnrollmentDatesServiceTest;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -45,8 +47,8 @@ public class BenefitsLearnMoreLinkGeneratorTest {
   @Test
   public void testRolelessNonMadisonUserAbeForeshadowing() {
 
-    LocalDate foreshadowingAbe2019 = new LocalDate("2019-09-25");
-    DateTimeUtils.setCurrentMillisFixed(foreshadowingAbe2019.toDate().getTime());
+    DateTimeUtils.setCurrentMillisFixed(
+      AnnualBenefitEnrollmentDatesServiceTest.DATE_DURING_ABE_FORESHADOWING.toDate().getTime());
 
     assertEquals("https://www.wisconsin.edu/abe/",
         generator.learnMoreLinkFor(new HashSet<String>(), false));
@@ -56,9 +58,8 @@ public class BenefitsLearnMoreLinkGeneratorTest {
   @Test
   public void testRolelessMadisonUserAbeForeshadowing() {
 
-    LocalDate foreshadowingAbe2019 = new LocalDate("2019-09-25");
-
-    DateTimeUtils.setCurrentMillisFixed(foreshadowingAbe2019.toDate().getTime());
+    DateTimeUtils.setCurrentMillisFixed(
+      AnnualBenefitEnrollmentDatesServiceTest.DATE_DURING_ABE_FORESHADOWING.toDate().getTime());
 
     assertEquals("https://hr.wisc.edu/benefits/annual-benefits-enrollment/",
         generator.learnMoreLinkFor(new HashSet<String>(), true));


### PR DESCRIPTION
The test for the learn more link generator tests the during-abe-foreshadowing case. So it had knowledge of ABE dates. Which isn't awesome. So instead emphasized the date service test knowing and publishing a suitable date, and depend upon that.

Should get the tests to green. This is reminding me to write some documentation of how to maintain this each year for ABE.