### PR TITLE
move during-foreshadowing date into service rather than test

### DIFF
--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesService.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesService.java
@@ -12,6 +12,11 @@ public class AnnualBenefitEnrollmentDatesService {
 
   public static LocalDate firstDayOfAnnualBenefitsEnrollmentForeshadowing =
       new LocalDate("2020-09-16");
+  /**
+   * Date during the ABE foreshadowing period, used in test cases.
+   */
+  public static final LocalDate DATE_DURING_ABE_FORESHADOWING =
+      new LocalDate("2020-09-22");
   public static LocalDate firstDayOfAnnualBenefitsEnrollment =
       new LocalDate("2020-09-28");
   public static LocalDate lastDayOfAnnualBenefitsEnrollment =

--- a/hrs-portlets-api/src/test/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesServiceTest.java
+++ b/hrs-portlets-api/src/test/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesServiceTest.java
@@ -9,9 +9,6 @@ public class AnnualBenefitEnrollmentDatesServiceTest {
 
   private AnnualBenefitEnrollmentDatesService service = new AnnualBenefitEnrollmentDatesService();
 
-  public static final LocalDate DATE_DURING_ABE_FORESHADOWING =
-    new LocalDate("2020-09-22");
-
   @Test
   public void testForeshadowing() {
     // foreshadowing does not begin prematurely
@@ -21,7 +18,7 @@ public class AnnualBenefitEnrollmentDatesServiceTest {
     assertTrue(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2020-09-16")));
 
     // and continues
-    assertTrue(service.foreshadowAnnualBenefitsEnrollment(DATE_DURING_ABE_FORESHADOWING));
+    assertTrue(service.foreshadowAnnualBenefitsEnrollment(AnnualBenefitEnrollmentDatesService.DATE_DURING_ABE_FORESHADOWING));
 
     // through the day before benefit enrollment begins
     assertTrue(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2020-09-27")));

--- a/hrs-portlets-webapp/pom.xml
+++ b/hrs-portlets-webapp/pom.xml
@@ -210,13 +210,6 @@
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>hrs-portlets-api</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/hrs-portlets-webapp/src/test/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGeneratorTest.java
+++ b/hrs-portlets-webapp/src/test/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGeneratorTest.java
@@ -1,6 +1,6 @@
 package edu.wisc.portlet.hrs.web.benefits;
 
-import edu.wisc.hr.service.benefits.AnnualBenefitEnrollmentDatesServiceTest;
+import edu.wisc.hr.service.benefits.AnnualBenefitEnrollmentDatesService;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -48,7 +48,7 @@ public class BenefitsLearnMoreLinkGeneratorTest {
   public void testRolelessNonMadisonUserAbeForeshadowing() {
 
     DateTimeUtils.setCurrentMillisFixed(
-      AnnualBenefitEnrollmentDatesServiceTest.DATE_DURING_ABE_FORESHADOWING.toDate().getTime());
+      AnnualBenefitEnrollmentDatesService.DATE_DURING_ABE_FORESHADOWING.toDate().getTime());
 
     assertEquals("https://www.wisconsin.edu/abe/",
         generator.learnMoreLinkFor(new HashSet<String>(), false));
@@ -59,7 +59,7 @@ public class BenefitsLearnMoreLinkGeneratorTest {
   public void testRolelessMadisonUserAbeForeshadowing() {
 
     DateTimeUtils.setCurrentMillisFixed(
-      AnnualBenefitEnrollmentDatesServiceTest.DATE_DURING_ABE_FORESHADOWING.toDate().getTime());
+      AnnualBenefitEnrollmentDatesService.DATE_DURING_ABE_FORESHADOWING.toDate().getTime());
 
     assertEquals("https://hr.wisc.edu/benefits/annual-benefits-enrollment/",
         generator.learnMoreLinkFor(new HashSet<String>(), true));


### PR DESCRIPTION
Rather than continue to fight with getting the webapp tests to depend upon the API tests and their publication of this date, move the date into the src rather than test, as part of the service.