### PR TITLE
Link to Preferred Name portlet rather than implementing edit UI inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # MyUW hrs-portlets change log
 
+### Next (presumably, 10.0.0)
+
+(Date)
+
++ Copy edit for active voice and brevity:
+  uses "Update your preferred name in HRS using the 'Update My Personal Information' link below."
+  instead of "Your preferred name in HRS will haver to be updated separately using the 'Update My Personal Information' link below."
+
 ## HRS Portlets 9 series
 
 The v9 major version was occasioned by the breaking change of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # MyUW hrs-portlets change log
 
+## HRS Portlets 10 series
+
+The v10 major version was occasioned by the breaking change of no longer offering direct editing of preferred name in the Personal Information portlet, instead hyperlinking to the  Preferred Name portlet for this UI. This reduces the number of copies of that edit UI to maintain.
+
 ### Next (presumably, 10.0.0)
 
 (Date)
 
++ Links to the Preferred Name portlet for preferred name editing, rather than duplicating that UI inline in Personal Information.
 + Copy edit for active voice and brevity:
   uses "Update your preferred name in HRS using the 'Update My Personal Information' link below."
   instead of "Your preferred name in HRS will haver to be updated separately using the 'Update My Personal Information' link below."

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/contactinfo/ContactInfoController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/contactinfo/ContactInfoController.java
@@ -58,12 +58,12 @@ public class ContactInfoController extends HrsControllerBase {
 	private final String PVI_ATTR = "wiscedupvi";
     private final EmailValidator emailValidator = EmailValidator.getInstance();
     private static final String HR_CONTACT_URL_PREFERENCE_NAME="humanResourceContactUrl";
-    
+
     private String businessEmailRolesPreferences = "businessEmailRoles";
     private ContactInfoDao contactInfoDao;
     private BusinessEmailUpdateDao businessEmailUpdateDao;
     private PreferredNameService preferredNameService;
-    
+
     public void setBusinessEmailRolesPreferences(String businessEmailRolesPreferences) {
         this.businessEmailRolesPreferences = businessEmailRolesPreferences;
     }
@@ -72,7 +72,7 @@ public class ContactInfoController extends HrsControllerBase {
     public void setBusinessEmailUpdateDao(BusinessEmailUpdateDao businessEmailUpdateDao) {
         this.businessEmailUpdateDao = businessEmailUpdateDao;
     }
-    
+
     @Autowired
     public void setPreferredNameService(PreferredNameService service) {
     	this.preferredNameService = service;
@@ -82,7 +82,7 @@ public class ContactInfoController extends HrsControllerBase {
     public void setContactInfoDao(ContactInfoDao contactInfoDao) {
         this.contactInfoDao = contactInfoDao;
     }
-    
+
     /**
      * Populate the ModelMap with the link of humanResourceOffice
      * @param request
@@ -97,59 +97,59 @@ public class ContactInfoController extends HrsControllerBase {
     @RenderMapping
     public String viewContactInfo(ModelMap model, PortletRequest request) {
         final String emplId = PrimaryAttributeUtils.getPrimaryId();
-        
+
         final PersonInformation contactInformation = this.contactInfoDao.getPersonalData(emplId);
         model.addAttribute("contactInformation", contactInformation);
-        
+
         final boolean showBusinessEmail = showBusinessEmail(request);
         model.addAttribute("showBusinessEmail", showBusinessEmail);
         if (showBusinessEmail) {
             final PreferredEmail preferredEmail = this.businessEmailUpdateDao.getPreferedEmail(emplId);
             model.addAttribute("preferredEmail", preferredEmail);
         }
-        
+
         setupPreferredName(model, request);
-        
-        
-        
+
+
+
         return "contactInfo";
     }
-    
+
     private void setupPreferredName(ModelMap modelMap, PortletRequest request) {
     	@SuppressWarnings("unchecked")
 		Map<String, String> userInfo = (Map <String, String>) request.getAttribute(PortletRequest.USER_INFO);
-    	
+
     	modelMap.addAttribute("displayName",userInfo.get("displayName"));//for system
         modelMap.addAttribute("legalName",userInfo.get("wiscEduSORName")); // for uw-madison
         boolean isPreferredNameEnabled = !StringUtils.isBlank(userInfo.get("wiscEduSORName"));
         modelMap.addAttribute("isPreferredNameEnabled", isPreferredNameEnabled);
-        
+
         if(isPreferredNameEnabled) {
     		PreferredName preferredName = preferredNameService.getPreferredName(getPvi(request));
-    		
+
     		String currentFirstName = userInfo.get("wiscedupreferredfirstname");
     		String currentMiddleName = userInfo.get("wiscedupreferredmiddlename");
     		String currentLastName = userInfo.get("wiscedupreferredlastname");
-    		
+
     		if(preferredName != null) {
     			modelMap.addAttribute("firstName", preferredName.getFirstName());
     			modelMap.addAttribute("middleName", preferredName.getMiddleName());
     			modelMap.addAttribute("lastName", preferredName.getLastName());
     		}
-    		
+
     		modelMap.addAttribute("pendingStatus",preferredNameService.getStatus(new PreferredName(currentFirstName, currentMiddleName,currentLastName,getPvi(request)),preferredNameService.getPreferredName(getPvi(request))));
     		modelMap.addAttribute("sirName",userInfo.get("sn"));
-    		
+
     		//edit setup
     		if(!modelMap.containsKey("preferredName")) {
-    		
+
     			if(preferredName != null) {
     				modelMap.addAttribute("preferredName", preferredName);
     			} else {
     				modelMap.addAttribute("preferredName", new PreferredName());
     			}
     		}
-    		
+
     		if(request.getParameter("therewasanerror") != null) {
     			modelMap.addAttribute("therewasanerror","true");
     		}
@@ -160,35 +160,35 @@ public class ContactInfoController extends HrsControllerBase {
     protected boolean showBusinessEmail(PortletRequest request) {
         final PortletPreferences preferences = request.getPreferences();
         final String[] roles = preferences.getValues(this.businessEmailRolesPreferences, new String[0]);
-        
+
         for (final String businessEmailRole : roles) {
             if (request.isUserInRole(businessEmailRole)) {
                 this.logger.debug("Showing business email info, user is in role: {}", businessEmailRole);
                 return true;
             }
         }
-        
+
         this.logger.debug("Hiding business email info, user is not in any of the roles: {}", Arrays.asList(roles));
-        
+
         return false;
     }
-    
+
     @ResourceMapping("businessEmailAddress")
     public String updateBusinessEmailAddress(
             @RequestParam("email") String email,
             ResourceRequest request,
             ModelMap modelMap) throws PortletRequestMethodNotSupportedException {
-        
+
         //TODO can I move this into the annotations?
         //TODO add method support to portlet annotations in portlet contrib
         if (!"POST".equals(request.getMethod())) {
             throw new PortletRequestMethodNotSupportedException(request.getMethod(), new String[] { "POST" });
         }
-        
+
         final String emplid = PrimaryAttributeUtils.getPrimaryId();
-        
+
         email = email.trim();
-        
+
         if (!StringUtils.isEmpty(email)) {
             if (emailValidator.isValid(email)) {
                 this.businessEmailUpdateDao.updatePreferedEmail(emplid, email);
@@ -197,25 +197,25 @@ public class ContactInfoController extends HrsControllerBase {
                 logger.warn("User {} submitted invalid email address {} the change request will be ignored.", emplid, email);
             }
         }
-        
+
         return this.getBusinessEmailAddress(modelMap);
     }
-    
+
     protected String getBusinessEmailAddress( ModelMap modelMap) {
-        
+
         final String emplid = PrimaryAttributeUtils.getPrimaryId();
-        
+
         final PreferredEmail preferredEmail = this.businessEmailUpdateDao.getPreferedEmail(emplid);
         final String updatedEmail = preferredEmail.getEmail();
         modelMap.addAttribute("email", updatedEmail);
-        
+
         return "jsonView";
     }
-    
+
     private String getPvi(PortletRequest request) {
     	@SuppressWarnings("unchecked")
 		Map<String, String> userInfo = (Map <String, String>) request.getAttribute(PortletRequest.USER_INFO);
-    	
+
     	final String pvi = userInfo.get(PVI_ATTR);
     	return pvi;
     }

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/contactinfo/ContactInfoController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/contactinfo/ContactInfoController.java
@@ -22,10 +22,6 @@ package edu.wisc.portlet.hrs.web.contactinfo;
 import java.util.Arrays;
 import java.util.Map;
 
-import javax.portlet.ActionRequest;
-import javax.portlet.ActionResponse;
-import javax.portlet.PortletMode;
-import javax.portlet.PortletModeException;
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
 import javax.portlet.ResourceRequest;
@@ -35,12 +31,9 @@ import org.apache.commons.validator.routines.EmailValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
-import org.springframework.validation.BindingResult;
-import org.springframework.validation.ValidationUtils;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.portlet.bind.annotation.ActionMapping;
 import org.springframework.web.portlet.bind.annotation.RenderMapping;
 import org.springframework.web.portlet.bind.annotation.ResourceMapping;
 import org.springframework.web.portlet.handler.PortletRequestMethodNotSupportedException;
@@ -50,8 +43,6 @@ import edu.wisc.hr.dao.person.ContactInfoDao;
 import edu.wisc.hr.dm.bnsemail.PreferredEmail;
 import edu.wisc.hr.dm.person.PersonInformation;
 import edu.wisc.hr.dm.prefname.PreferredName;
-import edu.wisc.hr.dm.prefname.PreferredNameExtended;
-import edu.wisc.hr.dm.prefname.PreferredNameValidator;
 import edu.wisc.hr.service.PreferredNameService;
 
 import org.jasig.springframework.security.portlet.authentication.PrimaryAttributeUtils;
@@ -209,36 +200,6 @@ public class ContactInfoController extends HrsControllerBase {
         
         return this.getBusinessEmailAddress(modelMap);
     }
-    
-    @ActionMapping(params="action=savePreferredName")
-	public void submitEdit(ActionRequest request, ActionResponse response, PreferredName preferredName, BindingResult bindingResult) throws PortletModeException {
-      
-        @SuppressWarnings("unchecked")
-        Map<String, String> userInfo = (Map <String, String>) request.getAttribute(PortletRequest.USER_INFO);
-      
-        PreferredNameExtended pne = new PreferredNameExtended(preferredName, userInfo.get("sn"));
-		//validation
-		ValidationUtils.invokeValidator(new PreferredNameValidator(), pne, bindingResult);
-		if(!bindingResult.hasErrors()) {
-			//submit changes to DAO
-			preferredName.setPvi(getPvi(request));
-			
-			preferredNameService.setPreferredName(preferredName.getPvi(), preferredName);
-			//redirect to view page on success
-			response.setPortletMode(PortletMode.VIEW);
-		} else {
-			//fail back to edit mode with flag set
-			response.setRenderParameter("therewasanerror", "true");
-			response.setPortletMode(PortletMode.VIEW);
-		}
-	}
-    
-    @ActionMapping(params="action=deletePreferredName") 
-	public void submitDelete(ActionRequest request, ActionResponse response) throws PortletModeException {
-		final String pvi = getPvi(request);
-		preferredNameService.deletePreferredName(pvi);
-		response.setPortletMode(PortletMode.VIEW);
-	}
     
     protected String getBusinessEmailAddress( ModelMap modelMap) {
         

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -22,16 +22,6 @@
 <%@ include file="/WEB-INF/jsp/include.jsp"%>
 <%@ include file="/WEB-INF/jsp/header.jsp"%>
 
-<portlet:actionURL portletMode="VIEW" var="savePreferredNameURL">
-  <portlet:param name="action" value="savePreferredName" />
-</portlet:actionURL>
-
-<portlet:actionURL portletMode="VIEW" var="deletePreferredNameURL">
-  <portlet:param name="action" value="deletePreferredName" />
-</portlet:actionURL>
-
-<spring:message code="savePreferredName" var="savePreferredName" text="Save"/>
-
 <div id="${n}dl-contact-info" class="dl-contact-info hrs">
   <div class="dl-banner-links">
     <hrs:helpLink appContext="Personal Information" />
@@ -77,71 +67,12 @@
                       <span>${preferredName}</span>
                     </c:if>
                           &nbsp;<span class="uportal-channel-table-caption">${pendingStatus }</span>
-                          &nbsp;<a aria-label="change preferred name" href="#" onclick="dl_v1.displayEdit(true);"><spring:message code="edit"/></a>
-                          &nbsp;<a aria-label="delete preferred name" href="${deletePreferredNameURL}" onclick="return confirm('Are you sure you want to delete your preferred name?');"><spring:message code="delete"/></a>
+                          &nbsp;<a aria-label="Add, edit, or delete your preferred name" href="/portal/p/preferred-name">Edit</a>
                   </span>
               </div>
-              <div class='edit-area'>
-              <form action="${savePreferredNameURL}" method="post">
-                <spring:nestedPath path="preferredName">
-                      <div class="contact-info-pref-name-edit ${n}edit" style="display: none;">
-                          <span aria-label="preferred name update form" tabindex="0" class="uportal-channel-strong">
-                              <spring:message code="label.preferred.name"/>:
-                          </span>
-                          <div class='${n}edit-error pref-name-edit-error' style="display: none; padding: .5em;">
-                              <span><form:errors path="firstName" cssClass="error"/>
-                                  &nbsp;<form:errors path="middleName" cssClass="error"/>
-                                  &nbsp;<form:errors path="lastName" cssClass="error"/>
-                            </span>
-                          </div>
-                          <div class='pref-name-edit'>
-                              <div class='names'>
-                                  <div class="edit-name">
-                                  <span class='label'>First</span>
-                                  <br/>
-                                  <span>
-                                      <form:input aria-label="edit first name box" path="firstName" class="uportal-input-text ${n}first-name" maxlength="30" />
-                                  </span>
-                                  </div>
-                                  <div class="edit-name">
-                                  <span class='label'>Middle</span>
-                                  <br/>
-                                  <span>
-                                      <form:input aria-label="edit middle name box" path="middleName" class="uportal-input-text ${n}middle-name" maxlength="30" />
-                                  </span>
-                                  </div>
-                                <div class="edit-name">
-                                <span class='label'>Last*</span>
-                                <br/>
-                                <span>
-                                  <form:input aria-label="edit last name box" path="lastName" class="uportal-input-text ${n}last-name" maxlength="30" />
-                                </span>
-                                </div>
-                              </div>
-                              <div class='info-text'>
-                                *<spring:message code='error.lastNameWeirdLogicError'/>
-                              </div>
-                              <div class="edit-buttons">
-                                  <span>
-                                      <input class="uportal-button fancy-button btn btn-primary" value="${savePreferredName}" type="submit">
-                                  </span>
-                                  <span>
-                                      <a href="#" onclick='dl_v1.displayEdit(false);' class="uportal-button fancy-cancel btn btn-default"><spring:message code="button.cancel" text="Cancel"/></a>
-                                  </span>
 
-                              </div>
 
-                          </div>
-                      </div>
-                  </spring:nestedPath>
-            </form>
-            </div>
             <div class='edit-notice'>
-                <c:if test="${!empty prefs['notice'][0]}">
-                  <p class="prefNotice">
-                     ${prefs['notice'][0]}
-                  </p>
-                </c:if>
                 <p class='edit-notice'>
                   Update your preferred name in HRS
                   using the 'Update My Personal Information' link below.
@@ -454,35 +385,4 @@
 })(dl_v1.jQuery);
 </rs:compressJs>
 </script>
-<script type="text/javascript">
-(function($) {
-   $(document).ready(function() {
-      $(".${n}edit").hide();
-      $(".${n}edit-error").hide();
-
-      dl_v1.displayEdit = function (enable) {
-    	  if(enable) {
-    		  $(".${n}view").hide();
-    		  $(".${n}edit").show();
-    	  } else {
-    		  $(".${n}edit").hide();
-    		  $(".${n}edit-error").hide();
-    		  $(".${n}view").show();
-
-    	  }
-      }
-   });
-})(dl_v1.jQuery);
-</script>
-
-<c:if test="${!empty therewasanerror }">
-<script type="text/javascript">
-(function($) {
-   $(document).ready(function() {
-	   dl_v1.displayEdit(true);
-	   $(".${n}edit-error").show();
-   });
-})(dl_v1.jQuery);
-</script>
-</c:if>
 </c:if>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -143,7 +143,7 @@
                   </p>
                 </c:if>
                 <p class='edit-notice'>
-                  Your preferred name in HRS will have to be updated separately
+                  Update your preferred name in HRS
                   using the 'Update My Personal Information' link below.
                   This will appear in employee self-service
                   (e.g. your timesheet) only.


### PR DESCRIPTION
Status quo, the Portal Information portlet in HRS Portlets re-implements inline a copy of the self-service preferred name editing UI that's also in the Preferred Name portlet. This makes for two copies of that UI to maintain.

This Pull Request would change this to instead hyperlink to the Preferred Name portlet from the Personal Information app, to provide the self-service editing. Employees would still be able to *view* the current state of their preferred name in Personal Information. It's just that instead of editing it inline, they'd go to the one true UI for self-service editing Preferred Name, and thereby we wouldn't have to remember to keep two copies of that UI in sync.

## Before:

Shows preferred name and UI controls to change or delete.

![Screenshot of status quo showing UI controls to Change or Delete preferred name inline in Personal Information](https://user-images.githubusercontent.com/952283/101952697-ac91e680-3bbe-11eb-84e0-d63e7841c8a0.png)

Clicking Change opens an inline edit experience.

![before-inline-edit](https://user-images.githubusercontent.com/952283/101952819-e19e3900-3bbe-11eb-937d-79a9268a1be0.png)

## After:

Shows preferred name and link to edit.

![Screenshot showing an Edit link alongside the preferred name](https://user-images.githubusercontent.com/952283/101952787-d21ef000-3bbe-11eb-9395-4d1dfa6cf630.png)

Clicking "Edit" navigates to the self-service tool specific to editing Preferred Name. This is the same tool available to other populations who participate in Madison preferred name.

![Screenshot of the preferred name Portlet](https://user-images.githubusercontent.com/952283/101952851-ef53be80-3bbe-11eb-8075-968cabeb2eab.png)


[MYUWADMIN-1382](https://jira.doit.wisc.edu/jira/browse/MYUWADMIN-1382)