### PR TITLE
replace the W-2 button when it won't work for the viewing user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The v10 major version was occasioned by the breaking change of no longer offerin
 
 (Date)
 
++ In Payroll Information,
+  for users without the HRS role `UW_EMPLOYEE_ACTIVE`,
+  replaces the "View W-2 forms" button
+  with a button that links to [KB article](https://kb.wisc.edu/helpdesk/page.php?id=90392)
+  explaining how to request documents.
+  Users without the `UW_EMPLOYEE_ACTIVE` role
+  cannot use the regular version of that button
+  because such users lack access to HRS employee self-service.
 + Links to the Preferred Name portlet for preferred name editing, rather than duplicating that UI inline in Personal Information.
 + Copy edit for active voice and brevity:
   uses "Update your preferred name in HRS using the 'Update My Personal Information' link below."

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -49,11 +49,15 @@
                 In Personal Information
                   Shows hyperlink to HRS self-service personal information
                     editing, and explananda.
+                In Payroll Information
+                  The "View W-2 Forms" button will link into HRS self-service.
                 When this role is NOT present
                   Shows messages in Payroll Information, Personal Information,
                     and in Benefit Information mitigating the degraded
                     experience of hyperlinks into HRS self-service that will not
                     actually work for the presumably former employee.
+                  In Payroll Information, the "View W-2 Forms" button will link
+                    to a KB article rather than into HRS self-service.
               -->
             <value>ROLE_VIEW_ABSENCE_HISTORIES</value>
                 <!-- effects

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -276,11 +276,19 @@
     <div id="${n}dl-tax-statements" class="dl-tax-statements ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
 
       <div class="dl-payroll-links">
-        <c:if test="${not empty hrsUrls['View W-2']}">
+        <sec:authorize ifAnyGranted="ROLE_UW_EMPLOYEE_ACTIVE">
+          <c:if test="${not empty hrsUrls['View W-2']}">
+            <a class="btn btn-primary"
+              href="${hrsUrls['View W-2']}"
+              target="_blank" rel="noopener noreferrer">View W-2 forms</a>
+          </c:if>
+        </sec:authorize>
+        <sec:authorize ifNotGranted="ROLE_UW_EMPLOYEE_ACTIVE">
           <a class="btn btn-primary"
-            href="${hrsUrls['View W-2']}"
-            target="_blank" rel="noopener noreferrer">View W-2 forms</a>
-        </c:if>
+              href="https://kb.wisc.edu/helpdesk/page.php?id=90392"
+              target="_blank" rel="noopener noreferrer">View W-2 forms</a>
+        </sec:authorize>
+
         <c:if test="${not empty hrsUrls['W-2 Consent']}">
           <a class="btn btn-default"
             href="${hrsUrls['W-2 Consent']}"


### PR DESCRIPTION
Users without HRS role `UW_EMPLOYEE_ACTIVE` cannot use HRS employee self-service and so cannot follow hyperlinks into employee self-service. Instead link to a KB article explaining this and offering alternative means for requesting documents that would have been available via employee self-service.

UI is identical to status quo, except the visually identical "View W-2 Forms" button links to [the relevant KB article](https://kb.wisc.edu/helpdesk/page.php?id=90392) instead of into HRS employee self-service.

For users with HRS role `UW_EMPLOYEE_ACTIVE`, no change.

![screenshot showing the Payroll Information portlet Tax Statements tab highlighting the View W-2 Forms button](https://user-images.githubusercontent.com/952283/102415880-8f925480-3fbe-11eb-840c-444b61894185.png)
