### PR TITLE
Payroll info widget for former employees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@
 The v9 major version was occasioned by the breaking change of the
 new, required `fname` `portlet-preference` in Benefit Information Portlet.
 
-### Next (9.1.1?)
+### Next
 
-(No changes yet.)
++ In Payroll Information list-of-links widget,
+  for users without the HRS role `UW_EMPLOYEE_ACTIVE`,
+  omits the direct deposit and withholdings links and
+  changes the earnings statements and tax statements links
+  to link to a KB article rather than into the Portlet or into HRS self-service.
 
 ### 9.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # MyUW hrs-portlets change log
 
-## HRS Portlets 10 series
-
-The v10 major version was occasioned by the breaking change of no longer offering direct editing of preferred name in the Personal Information portlet, instead hyperlinking to the  Preferred Name portlet for this UI. This reduces the number of copies of that edit UI to maintain.
-
 ## HRS Portlets 9 series
 
 The v9 major version was occasioned by the breaking change of the

--- a/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
+++ b/hrs-portlets-ps-impl/src/main/resources/app-context/psAppContext.xml
@@ -41,7 +41,6 @@
     <!-- maps an HRS side role name to a portlet side role name -->
     <util:map id="hrsRolesMapping">
 
-        <!-- map a role everyone has so there's always a positive test case -->
         <entry key="UW_EMPLOYEE_ACTIVE">
           <set>
             <value>ROLE_UW_EMPLOYEE_ACTIVE</value>
@@ -58,6 +57,10 @@
                     actually work for the presumably former employee.
                   In Payroll Information, the "View W-2 Forms" button will link
                     to a KB article rather than into HRS self-service.
+                  In the Payroll Information list-of-links widget,
+                    suppresses the direct deposit and withholdings links and
+                    changes the tax and earnings statements links to link to a
+                    KB article.
               -->
             <value>ROLE_VIEW_ABSENCE_HISTORIES</value>
                 <!-- effects

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollListOfLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollListOfLinksController.java
@@ -105,9 +105,25 @@ public class PayrollListOfLinksController
 
   private Link earningsStatementsLink(String fname) {
 
+    final String emplId = PrimaryAttributeUtils.getPrimaryId();
+    Set<String> roles = this.hrsRolesDao.getHrsRoles(emplId);
+
+    // if the employee is not UW_EMPLOYEE_ACTIVE,
+    // drop the direct deposit link
+    if (! roles.contains("ROLE_UW_EMPLOYEE_ACTIVE")) {
+      return null;
+    }
+
     Link earningsStatementsLink = new Link();
     earningsStatementsLink.setTitle("Earnings Statements");
-    earningsStatementsLink.setHref("/web/exclusive/" + fname);
+
+    if (roles.contains("ROLE_UW_EMPLOYEE_ACTIVE")) {
+      earningsStatementsLink.setHref("/web/exclusive/" + fname);
+    } else {
+      earningsStatementsLink.setHref("https://kb.wisc.edu/helpdesk/6856");
+      earningsStatementsLink.setTarget("_blank");
+    }
+
     earningsStatementsLink.setIcon("attach_money");
 
     return earningsStatementsLink;
@@ -115,9 +131,19 @@ public class PayrollListOfLinksController
 
   private Link taxStatementsLink(String fname) {
 
+    final String emplId = PrimaryAttributeUtils.getPrimaryId();
+    Set<String> roles = this.hrsRolesDao.getHrsRoles(emplId);
+
     Link taxStatementsLink = new Link();
     taxStatementsLink.setTitle("Tax Statements");
-    taxStatementsLink.setHref("/portal/p/" + fname + "?pP_requestedContent=Tax%20Statements");
+
+    if (roles.contains("ROLE_UW_EMPLOYEE_ACTIVE")) {
+      taxStatementsLink.setHref("/portal/p/" + fname + "?pP_requestedContent=Tax%20Statements");
+    } else {
+      taxStatementsLink.setHref("https://kb.wisc.edu/helpdesk/6856");
+      taxStatementsLink.setTarget("_blank");
+    }
+
     taxStatementsLink.setIcon("toll");
 
     return taxStatementsLink;

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollListOfLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollListOfLinksController.java
@@ -113,9 +113,19 @@ public class PayrollListOfLinksController
    * honoring the self-service direct deposit role iff HRS has provided that HRS self-service URL,
    * otherwise using the static PDF URL.
    *
-   * @return Direct Deposit link appropriate for the viewing user
+   * @return Direct Deposit link appropriate for the viewing user, or null if no link
    */
   private Link directDepositLink() {
+
+    final String emplId = PrimaryAttributeUtils.getPrimaryId();
+    Set<String> roles = this.hrsRolesDao.getHrsRoles(emplId);
+
+    // if the employee is not UW_EMPLOYEE_ACTIVE,
+    // drop the direct deposit link
+    if (! roles.contains("ROLE_UW_EMPLOYEE_ACTIVE")) {
+      return null;
+    }
+
     Link directDepositLink = new Link();
     directDepositLink.setTitle("Update Direct Deposit");
     directDepositLink.setTarget("_blank");
@@ -124,8 +134,6 @@ public class PayrollListOfLinksController
     // and the self-service direct deposit URL is set
     // then use this HRS self-service URL, otherwise use the URL to the PDF
 
-    final String emplId = PrimaryAttributeUtils.getPrimaryId();
-    Set<String> roles = this.hrsRolesDao.getHrsRoles(emplId);
     Map<String, String> urls = this.getHrsUrls();
 
     if (roles.contains(ROLE_SELF_SERVICE_DIRECT_DEPOSIT) &&
@@ -142,9 +150,19 @@ public class PayrollListOfLinksController
   /**
    * Returns the applicable W4 link, which is the HRS "ESS W-4" URL unless that
    * URL is not configured, in which case falls back on hard-coded URL to PDF.
-   * @return best available W4 link
+   * @return best available W4 link, or null if no link
    */
   private Link withholdingsLink() {
+
+    final String emplId = PrimaryAttributeUtils.getPrimaryId();
+    Set<String> roles = this.hrsRolesDao.getHrsRoles(emplId);
+
+    // if the employee is not UW_EMPLOYEE_ACTIVE,
+    // drop the withholdings link
+    if (! roles.contains("ROLE_UW_EMPLOYEE_ACTIVE")) {
+      return null;
+    }
+
     Link withholdingsLink = new Link();
     withholdingsLink.setTitle("Update W4");
 

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollListOfLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollListOfLinksController.java
@@ -50,10 +50,7 @@ public class PayrollListOfLinksController
 
     String fname = fname(request);
 
-    Link earningsStatementsLink = new Link();
-    earningsStatementsLink.setTitle("Earnings Statements");
-    earningsStatementsLink.setHref("/web/exclusive/" + fname);
-    earningsStatementsLink.setIcon("attach_money");
+    Link earningsStatementsLink = earningsStatementsLink(request);
 
     Link directDepositLink = directDepositLink();
 
@@ -106,6 +103,19 @@ public class PayrollListOfLinksController
       fname = SYSTEM_FNAME;
     }
     return fname;
+  }
+
+
+  private Link earningsStatementsLink(PortletRequest request) {
+
+    String fname = fname(request);
+
+    Link earningsStatementsLink = new Link();
+    earningsStatementsLink.setTitle("Earnings Statements");
+    earningsStatementsLink.setHref("/web/exclusive/" + fname);
+    earningsStatementsLink.setIcon("attach_money");
+
+    return earningsStatementsLink;
   }
 
   /**

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollListOfLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollListOfLinksController.java
@@ -54,10 +54,7 @@ public class PayrollListOfLinksController
 
     Link directDepositLink = directDepositLink();
 
-    Link taxStatementsLink = new Link();
-    taxStatementsLink.setTitle("Tax Statements");
-    taxStatementsLink.setHref("/portal/p/" + fname + "?pP_requestedContent=Tax%20Statements");
-    taxStatementsLink.setIcon("toll");
+    Link taxStatementsLink = taxStatementsLink(request);
 
     Link withholdingsLink = withholdingsLink();
 
@@ -116,6 +113,18 @@ public class PayrollListOfLinksController
     earningsStatementsLink.setIcon("attach_money");
 
     return earningsStatementsLink;
+  }
+
+  private Link taxStatementsLink(PortletRequest request) {
+
+    String fname = fname(request);
+
+    Link taxStatementsLink = new Link();
+    taxStatementsLink.setTitle("Tax Statements");
+    taxStatementsLink.setHref("/portal/p/" + fname + "?pP_requestedContent=Tax%20Statements");
+    taxStatementsLink.setIcon("toll");
+
+    return taxStatementsLink;
   }
 
   /**

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollListOfLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollListOfLinksController.java
@@ -50,11 +50,11 @@ public class PayrollListOfLinksController
 
     String fname = fname(request);
 
-    Link earningsStatementsLink = earningsStatementsLink(request);
+    Link earningsStatementsLink = earningsStatementsLink(fname);
 
     Link directDepositLink = directDepositLink();
 
-    Link taxStatementsLink = taxStatementsLink(request);
+    Link taxStatementsLink = taxStatementsLink(fname);
 
     Link withholdingsLink = withholdingsLink();
 
@@ -103,9 +103,7 @@ public class PayrollListOfLinksController
   }
 
 
-  private Link earningsStatementsLink(PortletRequest request) {
-
-    String fname = fname(request);
+  private Link earningsStatementsLink(String fname) {
 
     Link earningsStatementsLink = new Link();
     earningsStatementsLink.setTitle("Earnings Statements");
@@ -115,9 +113,7 @@ public class PayrollListOfLinksController
     return earningsStatementsLink;
   }
 
-  private Link taxStatementsLink(PortletRequest request) {
-
-    String fname = fname(request);
+  private Link taxStatementsLink(String fname) {
 
     Link taxStatementsLink = new Link();
     taxStatementsLink.setTitle("Tax Statements");

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollListOfLinksController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollListOfLinksController.java
@@ -65,10 +65,23 @@ public class PayrollListOfLinksController
     Link withholdingsLink = withholdingsLink();
 
     final List<Link> linkList = new ArrayList<Link>();
-    linkList.add(earningsStatementsLink);
-    linkList.add(directDepositLink);
-    linkList.add(taxStatementsLink);
-    linkList.add(withholdingsLink);
+
+    if (null != earningsStatementsLink) {
+      linkList.add(earningsStatementsLink);
+    }
+
+    if (null != directDepositLink) {
+      linkList.add(directDepositLink);
+    }
+
+    if (null != taxStatementsLink) {
+      linkList.add(taxStatementsLink);
+    }
+
+    if (null != withholdingsLink) {
+      linkList.add(withholdingsLink);
+    }
+
 
     final Map<String, Object[]> content = new HashMap<String, Object[]>();
     content.put("links", linkList.toArray());


### PR DESCRIPTION
Status quo, former employees see the same Payroll Information widget as current employees.

![prod-status-quo-payroll-info-widget](https://user-images.githubusercontent.com/952283/104063374-aee95f80-51c1-11eb-93e9-c8a47cf5706e.png)

For former employees, the _Update Direct Deposit_ link switches to link to a PDF for updating direct deposit preferences rather than linking into HRS self-service. (This is because former employees lose the HRS role for self-service direct deposit. This link changes in the same way for current employees who lack that role, e.g. because of insufficient identity proofing.)

The _Update W4_ link is into HRS self-service, which will not work for employees without the UW_EMPLOYEE_ACTIVE role.

The earnings and tax statements links are to tabs in the Payroll Information portlet. Within the Portlet, the hyperlinks to statements in HRS self service will not actually work for these employees because HRS self service access requires UW_EMPLOYEE_ACTIVE.  https://github.com/UW-Madison-DoIT/hrs-portlets/pull/229 would mitigate this by making the prominent tax statements button within the Payroll Information portlet link to the relevant KB documentation rather than into HRS self-service for former employees. Links to older statements vended from Cypress rather than from HRS self-service continue to work for former employees.

This changeset would

+ Remove the _Update W4_ and _Update Direct Deposit_ links from the widget, for former staff without the UW_EMPLOYEE_ACTIVE role.
+ Change the _Tax Statements_ and _Earnings Statements_ links in the widget to link to a KB document rather than into the Payroll Information portlet, for former staff without the UW_EMPLOYEE_ACTIVE role.
+ Leave the experience un-changed for employees with the UW_EMPLOYEE_ACTIVE role.

![mockup-former-employees-payroll-information](https://user-images.githubusercontent.com/952283/104063748-46e74900-51c2-11eb-9cb5-5f78ddd9700a.png)

