### PR TITLE
reflect limits on self-service for single-factor-authentication users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@
 The v9 major version was occasioned by the breaking change of the
 new, required `fname` `portlet-preference` in Benefit Information Portlet.
 
-### Next
+### 9.2.0
 
-(No changes yet.)
++ In Personal Information,
+  employees lacking the HRS role `UW_DYN_PY_DIRDEP_SS`
+  see descriptive text accurately reflecting
+  the smaller set of things they can adjust on a self-service basis
+  and the larger set of things they will need to contact their HR office to update.
+  (By policy, users lacking multifactor authentication are ineligible for self-service contact updating).
+
 
 ### 9.1.2
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -176,8 +176,10 @@
             </strong>
             <p style="padding-left: 2cm;">
               <strong>
-                Addresses (Home &amp; Mail); Contact Details (Phone &amp; Email);
-                Preferred Name; Emergency Contacts; Release Home Information;
+                <sec:authorize ifAllGranted="ROLE_VIEW_DIRECT_DEPOSIT">
+                  Addresses (Home &amp; Mail); Contact Details (Phone &amp; Email);</sec:authorize>
+                Preferred Name; Emergency Contacts;
+                <sec:authorize ifAllGranted="ROLE_VIEW_DIRECT_DEPOSIT">Release Home Information;</sec:authorize>
                 Marital Status; Coordination of Benefits; Medicare Information;
                 Ethnic Groups; Veteran Status; Disability.
               </strong>
@@ -185,20 +187,21 @@
           </p>
           <p>
             <strong>
-              <spring:message code="updateBusinessOfficeAddressInstructionsPart1"
-                text="To update your Business/Office Address, please contact"/>
+              To update your Business/Office Address,
+              <sec:authorize ifNotGranted="ROLE_VIEW_DIRECT_DEPOSIT">
+                Addresses (Home &amp; Mail), Contact Details (Phone &amp; Email), and Release Home Information,
+              </sec:authorize>
+              please contact
               <c:choose>
                 <c:when test="${not empty humanResourceOfficeContactUrl}">
                   <a href="${humanResourceOfficeContactUrl}"
                    target="_blank"
                    rel="noopener noreferer">
-                    <spring:message code="updateBusinessOfficeAddressInstructionsPart2"
-                     text="your human resources office"/>
+                    your human resources office
                   </a>.
                 </c:when>
                 <c:otherwise>
-                  <spring:message code="updateBusinessOfficeAddressInstructionsPart2"
-                   text="your human resources office"/>.
+                  your human resources office
                 </c:otherwise>
               </c:choose>
             </strong>


### PR DESCRIPTION
Employees accessing HRS self-service using a single authentication factor (i.e., password) rather than multi-factor authentication will be unable to self-service update their contact information, per policy.
This updates the descriptive text to accurately list what the user can expect in HRS self-service vs what they should contact their human resources office to update.

[MYUWADMIN-1448](https://jira.doit.wisc.edu/jira/browse/MYUWADMIN-1448)