### PR TITLE
remove undocumented, broken deep link to tab feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ new, required `fname` `portlet-preference` in Benefit Information Portlet.
 
 Putatively 9.2.1, thefore currently building 9.2.1-SNAPSHOT.
 
++ Breaking change:
+  Removes undocumented,
+  not-working-as-expected "tab" parameter feature from Benefit Information.
 + In Benefit Information,
   now supports portlet request parameter `requestedContent`,
   as in Payroll Information. Values "ETF WRS Statements of Benefits" and

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitInformationController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitInformationController.java
@@ -95,15 +95,9 @@ public class BenefitInformationController extends HrsControllerBase {
       final String emplId = PrimaryAttributeUtils.getPrimaryId();
       final String etfMemberId = (String) userInfo.get("eduWisconsinETFMemberID");
 
-      final String[] tabArray = request.getParameterMap().get("tab");
-      String tab = "";
-      if(tabArray!=null && tabArray.length == 1) {
-        tab = tabArray[0];
-      }
-
       final BenefitSummary benefitSummary = this.benefitSummaryDao.getBenefitSummary(emplId);
       model.addAttribute("enrollmentFlag", benefitSummary.getEnrollmentFlag());
-      model.addAttribute("tab", tab);
+
       boolean isMadisonUser = !StringUtils.isBlank(userInfo.get("wiscEduHRSEmplid"));
       model.addAttribute("isMadisonUser", isMadisonUser);
       final PortletPreferences preferences = request.getPreferences();

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformation.jsp
@@ -373,22 +373,12 @@
           }
         });
 
-        var opt = 0;
-
-        if("statements" === "${tab}") {
-            opt = 1;
-        } else if ("dependents" === "${tab}") {
-            opt = 2;
-        }
-
         $("#${n}dl-tabs").tabs({
             show: function(event, ui) {
                 $.log("Showing tab: " + ui.index);
                 dl.pager.show(ui.panel);
             }
         });
-
-        $("#${n}dl-tabs").tabs("select",opt);
 
         dl.util.clickableContainer("#${n}dl-benefit-summary");
     });


### PR DESCRIPTION
Remove undocumented "tab" parameter feature from Benefit Information. The feature is broken in that telling it to show the "dependents" tab would actually show a benefit statement tab. This feature also prevented the new "requestedContent" parameter feature from working.

[MYUWADMIN-1475](https://jira.doit.wisc.edu/jira/browse/MYUWADMIN-1475)