### PR TITLE
show all tax statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ new, required `fname` `portlet-preference` in Benefit Information Portlet.
 
 ## Next
 
-Putatively 9.2.1, thefore currently building 9.2.1-SNAPSHOT.
+Putatively 9.3.0, therefore currently building 9.3.0-SNAPSHOT.
 
++ In Payroll Information, tax statements tab now shows all tax statements,
+  prepending rows linking into HRS self-service for 2018-and-later statements.
 + In Benefit Information,
   now supports portlet request parameter `requestedContent`,
   as in Payroll Information. Values "ETF WRS Statements of Benefits" and

--- a/hrs-portlets-api/pom.xml
+++ b/hrs-portlets-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>edu.wisc.my.portlet.hrs</groupId>
         <artifactId>hrs-portlets-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/taxstmt/TaxStatementDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/taxstmt/TaxStatementDao.java
@@ -21,7 +21,7 @@ package edu.wisc.hr.dao.taxstmt;
 
 import org.jasig.springframework.web.client.ExtendedRestOperations.ProxyResponse;
 
-import edu.wisc.hr.dm.taxstmt.TaxStatements;
+import edu.wisc.hr.service.taxstmt.TaxStatements;
 
 /**
  * @author Eric Dalquist

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dm/statement/NameYearUrl.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dm/statement/NameYearUrl.java
@@ -1,9 +1,12 @@
 package edu.wisc.hr.dm.statement;
 
+import org.apache.commons.lang.builder.CompareToBuilder;
+
 /**
  * Simple JavaBean. It's got a String name, an int year, and a String URL.
  */
-public class NameYearUrl {
+public class NameYearUrl
+  implements Comparable<NameYearUrl> {
 
   private String name;
   private int year;
@@ -34,4 +37,8 @@ public class NameYearUrl {
   }
 
 
+  @Override
+  public int compareTo(NameYearUrl o) {
+    return new CompareToBuilder().append(this.year, o.year).append(this.name, o.name).toComparison();
+  }
 }

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/service/taxstmt/TaxStatementService.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/service/taxstmt/TaxStatementService.java
@@ -1,0 +1,16 @@
+package edu.wisc.hr.service.taxstmt;
+
+import edu.wisc.hr.dm.statement.NameYearUrl;
+
+import java.util.List;
+
+public interface TaxStatementService {
+
+  /**
+   * Statements, most recent to oldest.
+   * @param emplid
+   * @return
+   */
+  List<NameYearUrl> statementsForEmplid(String emplid);
+
+}

--- a/hrs-portlets-bnsemail-impl/pom.xml
+++ b/hrs-portlets-bnsemail-impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>edu.wisc.my.portlet.hrs</groupId>
         <artifactId>hrs-portlets-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/hrs-portlets-cypress-impl/pom.xml
+++ b/hrs-portlets-cypress-impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>edu.wisc.my.portlet.hrs</groupId>
         <artifactId>hrs-portlets-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/taxstmt/TaxStatementToNameYearUrlConverter.java
+++ b/hrs-portlets-cypress-impl/src/main/java/edu/wisc/cypress/dao/taxstmt/TaxStatementToNameYearUrlConverter.java
@@ -1,0 +1,33 @@
+package edu.wisc.cypress.dao.taxstmt;
+
+import edu.wisc.hr.dm.statement.NameYearUrl;
+import edu.wisc.hr.service.taxstmt.TaxStatement;
+
+/**
+ * Converts from Cypress TaxStatement to NameYearUrl
+ */
+public class TaxStatementToNameYearUrlConverter {
+
+  private String payrollInformationPortletFName = "earnings-statement-for-all";
+
+  public NameYearUrl convertToNameYearUrl (TaxStatement taxStatement) {
+
+    if (null == taxStatement) {
+      throw new NullPointerException("Cannot convert null tax statement.");
+    }
+
+    NameYearUrl convertedStatement = new NameYearUrl();
+
+    convertedStatement.setName(taxStatement.getName());
+    convertedStatement.setYear(taxStatement.getYear());
+
+    String statementUrl = "/portal/p/" + payrollInformationPortletFName +
+      "/exclusive/irs_statement.pdf.resource.uP?pP_docId=" +
+      taxStatement.getDocId();
+
+    convertedStatement.setUrl(statementUrl);
+
+    return convertedStatement;
+  }
+
+}

--- a/hrs-portlets-ps-impl/pom.xml
+++ b/hrs-portlets-ps-impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>edu.wisc.my.portlet.hrs</groupId>
         <artifactId>hrs-portlets-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/hrs-portlets-webapp/pom.xml
+++ b/hrs-portlets-webapp/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>edu.wisc.my.portlet.hrs</groupId>
         <artifactId>hrs-portlets-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollInformationController.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/payroll/PayrollInformationController.java
@@ -27,6 +27,7 @@ import java.util.List;
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
 
+import edu.wisc.hr.service.taxstmt.TaxStatementService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -48,6 +49,7 @@ import edu.wisc.portlet.hrs.web.HrsControllerBase;
 public class PayrollInformationController extends HrsControllerBase {
     private ContactInfoDao contactInfoDao;
     private EarningsStatementService earningsStatementService;
+    private TaxStatementService taxStatementService;
 
     @Autowired
     public void setContactInfoDao(ContactInfoDao contactInfoDao) {
@@ -58,7 +60,12 @@ public class PayrollInformationController extends HrsControllerBase {
     public void setEarningsStatementService(EarningsStatementService service) {
         this.earningsStatementService = service;
     }
-    
+
+    @Autowired
+    public void setTaxStatementService(TaxStatementService service) {
+      this.taxStatementService = service;
+    }
+
     /**
      * Gets the URL to a page describing your earnings statement
      * @param request the request
@@ -88,7 +95,10 @@ public class PayrollInformationController extends HrsControllerBase {
 
         model.addAttribute("earningsStatements", statements.getStatements());
         model.addAttribute("earningsStatementsError", statements.isErrored());
-        
+
+        model.addAttribute("taxStatements",
+          taxStatementService.statementsForEmplid(emplId));
+
         return "payrollInformation";
     }
 }

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -276,29 +276,12 @@
     <div id="${n}dl-tax-statements" class="dl-tax-statements ui-tabs-panel ui-widget-content ui-corner-bottom ui-tabs-hide">
 
       <div class="dl-payroll-links">
-        <sec:authorize ifAnyGranted="ROLE_UW_EMPLOYEE_ACTIVE">
-          <c:if test="${not empty hrsUrls['View W-2']}">
-            <a class="btn btn-primary"
-              href="${hrsUrls['View W-2']}"
-              target="_blank" rel="noopener noreferrer">View W-2 forms</a>
-          </c:if>
-        </sec:authorize>
-        <sec:authorize ifNotGranted="ROLE_UW_EMPLOYEE_ACTIVE">
-          <a class="btn btn-primary"
-              href="https://kb.wisc.edu/helpdesk/page.php?id=90392"
-              target="_blank" rel="noopener noreferrer">View W-2 forms</a>
-        </sec:authorize>
 
         <c:if test="${not empty hrsUrls['W-2 Consent']}">
           <a class="btn btn-default"
             href="${hrsUrls['W-2 Consent']}"
             target="_blank" rel="noopener noreferrer">
             Consent to receive W-2 electronically</a>
-        </c:if>
-        <c:if test="${not empty hrsUrls['View 1095-C']}">
-          <a class="btn btn-primary"
-            href="${hrsUrls['View 1095-C']}"
-            target="_blank" rel="noopener noreferrer">View 1095-C forms</a>
         </c:if>
         <c:if test="${not empty hrsUrls['1095-C Consent']}">
           <a class="btn btn-default"
@@ -308,34 +291,62 @@
         </c:if>
       </div>
 
-      <div>
-        <form action="#">
-          <label for="${n}dl-show-old-tax-statements-toggle">
-            Show 2017 and earlier tax statements</label>
-          <input type="checkbox"
-            id="${n}dl-show-old-tax-statements-toggle"
-            name="dl-show-old-tax-statements-toggle" />
-        </form>
-      </div>
 
-      <div id="${n}old-tax-statements" class="fl-pager old-tax-statements" style="display:none">
+
+      <div id="${n}old-tax-statements" class="fl-pager old-tax-statements">
         <div class="fl-container-flex dl-pager-table-data fl-pager-data table-responsive">
           <table class="dl-table table" tabindex="0" aria-label="Tax Statement table">
             <thead>
-              <tr rsf:id="header:">
-                <th scope="col" class="flc-pager-sort-header dl-col-5p" rsf:id="year"><a href="javascript:;">Year</a></th>
-                <th scope="col" class="flc-pager-sort-header" rsf:id="name"><a href="javascript:;">Statement</a></th>
+              <tr>
+                <th scope="col" class="flc-pager-sort-header dl-col-5p">Year</th>
+                <th scope="col" class="flc-pager-sort-header">Statement</th>
               </tr>
             </thead>
             <tbody>
-              <tr rsf:id="row:" class="dl-clickable">
-                <td headers="year" class="hrs-data-text dl-col-5p"><a href="#" target="_blank" rsf:id="year"></a></td>
-                <td headers="name" class="dl-data-text"><a href="#" target="_blank" rsf:id="name"></a></td>
+              <tr class="dl-clickable">
+                <td class="hrs-data-text dl-col-5p">2018 and later</td>
+
+                <sec:authorize ifAnyGranted="ROLE_UW_EMPLOYEE_ACTIVE">
+                  <c:if test="${not empty hrsUrls['View W-2']}">
+                    <td class="dl-data-text"><a href="${hrsUrls['View W-2']}" target="_blank">W-2 forms</a></td>
+                  </c:if>
+                  <c:if test="${empty hrsUrls['View W-2']}">
+                    <td class="dl-data-text">Error: HRS URL `View W-2` not defined.</td>
+                  </c:if>
+                </sec:authorize>
+                <sec:authorize ifNotGranted="ROLE_UW_EMPLOYEE_ACTIVE">
+                  <td class="dl-data-text"><a href="https://kb.wisc.edu/helpdesk/page.php?id=90392" target="_blank">W-2 forms</a></td>
+                </sec:authorize>
               </tr>
+
+              <tr class="dl-clickable">
+                <sec:authorize ifAnyGranted="ROLE_UW_EMPLOYEE_ACTIVE">
+                  <c:if test="${not empty hrsUrls['View 1095-C']}">
+                    <td class="hrs-data-text dl-col-5p"><a href="${hrsUrls['View 1095-C']}" target="_blank">2018 and later</a></td>
+                    <td class="dl-data-text"><a href="${hrsUrls['View 1095-C']}" target="_blank">1095-C forms</a></td>
+                  </c:if>
+                  <c:if test="${empty hrsUrls['View 1095-C']}">
+                    <td class="hrs-data-text dl-col-5p">2018 and later</td>
+                    <td class="dl-data-text">Error: HRS URL `View 1095-C` not defined.</td>
+                  </c:if>
+                </sec:authorize>
+                <sec:authorize ifNotGranted="ROLE_UW_EMPLOYEE_ACTIVE">
+                  <td class="hrs-data-text dl-col-5p"><a href="https://kb.wisc.edu/helpdesk/page.php?id=90392" target="_blank">2018 and later</a></td>
+                  <td class="dl-data-text"><a href="https://kb.wisc.edu/helpdesk/page.php?id=90392" target="_blank">1095-C forms</a></td>
+                </sec:authorize>
+              </tr>
+
+              <c:forEach var="taxStatement" items="${taxStatements}">
+              <tr class="dl-clickable">
+                <td class="hrs-data-text dl-col-5p"><a href="${taxStatement.url}" target="_blank">${taxStatement.year}</a></td>
+                <td class="dl-data-text"><a href="${taxStatement.url}" target="_blank">${taxStatement.name}</a></td>
+              </c:forEach>
+
+
+
             </tbody>
           </table>
         </div>
-        <hrs:pagerNavBar position="bottom" />
       </div>
 
       <div class="dl-link">
@@ -393,13 +404,6 @@
   <%@ include file="/WEB-INF/jsp/footer.jsp"%>
 
 </div>
-
-
-
-<portlet:resourceURL var="taxStatementsUrl" id="taxStatements" escapeXml="false"/>
-<portlet:resourceURL var="irsStatementPdfUrl" id="irs_statement.pdf" escapeXml="false">
-  <portlet:param name="docId" value="TMPLT_*.docId_TMPLT"/>
-</portlet:resourceURL>
 
 
 <script type="text/javascript" language="javascript">
@@ -485,47 +489,6 @@
           updateShowAllEarningsStatements(showAllEarningsStatementsToggle);
         });
       </c:if>
-
-      var updateShowOldTaxStatements = function(checkbox) {
-        var checked = checkbox.is(':checked');
-
-        var oldTaxStatements = $("#${n}old-tax-statements");
-
-        if (checked) {
-          oldTaxStatements.show();
-        } else {
-          oldTaxStatements.hide();
-        }
-      }
-
-      var showOldTaxStatementsToggle = $("#${n}dl-show-old-tax-statements-toggle");
-
-      showOldTaxStatementsToggle.change(function() {
-        updateShowOldTaxStatements(showOldTaxStatementsToggle);
-      });
-
-      var taxStatementUrl = dl.util.templateUrl("${irsStatementPdfUrl}");
-      dl.pager.init("#${n}dl-tax-statements", {
-        model: {
-          sortKey: "year",
-          sortDir: -1
-        },
-        summary: {
-          type: "fluid.pager.summary",
-          options: {
-            message: "%first-%last of %total statements"
-          }
-        },
-        columnDefs: [
-          dl.pager.linkColDef("year", taxStatementUrl, {sortable: true}),
-          dl.pager.linkColDef("name", taxStatementUrl, {sortable: false})
-        ],
-        dataList: {
-          url: "${taxStatementsUrl}",
-          dataKey: "report",
-          dataLoadErrorMsg: "${genericErrorMessage}"
-        }
-      });
 
       dl.tabs("#${n}dl-tabs");
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.wisc.my.portlet.hrs</groupId>
     <artifactId>hrs-portlets-parent</artifactId>
-    <version>9.2.1-SNAPSHOT</version>
+    <version>9.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <repositories>


### PR DESCRIPTION
Status quo: recent tax statements other than W-2s and 1095-Cs are buried with pre-2018 W-2s and 1095-Cs.

With this change: in Payroll Information, on the Tax Statements tab, it shows all the tax statements in the table, prefacing it with one virtual row each for the 2018-and-later W-2s and 1095-Cs that are in HRS self-service.

Resultingly, the most recent W-2s and 1095-Cs are still the most prominent links (first in the table), other most recent links follow, and the old stuff is at the bottom of the table, making all the available tax statements easier to discover.