### PR TITLE
use & to delimit paycheck_nbr when URL already contains ?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ new, required `fname` `portlet-preference` in Benefit Information Portlet.
 
 Putatively 9.3.0, therefore currently building 9.3.0-SNAPSHOT.
 
++ In Payroll Information, appending the `paycheck_nbr` parameter
+  to the URL linking into HRS self-service to access an earnings statement
+  now correctly uses `&` to delimit the parameter when the URL already contains a `?`.
 + In Payroll Information, tax statements tab now shows all tax statements,
   prepending rows linking into HRS self-service for 2018-and-later statements.
 + In Benefit Information,

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/ernstmt/SoapEarningsStatementDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/ernstmt/SoapEarningsStatementDao.java
@@ -107,7 +107,12 @@ public class SoapEarningsStatementDao
       final String baseUrl = this.hrsUrlDao.getHrsUrls().get(HrsUrlDao.EARNINGS_STATEMENT_KEY);
       final PAYCHECKNBRTypeShape soapPaycheckNumber = soapEarningsStatement.getPAYCHECKNBR();
       final int paycheckNumber = soapPaycheckNumber.getValue();
-      simpleEarningsStatement.setUrl(baseUrl + "?paycheck_nbr=" + paycheckNumber);
+
+      if (baseUrl.contains("?")) {
+        simpleEarningsStatement.setUrl(baseUrl + "&paycheck_nbr=" + paycheckNumber);
+      } else {
+        simpleEarningsStatement.setUrl(baseUrl + "?paycheck_nbr=" + paycheckNumber);
+      }
 
       simpleEarningsStatements.add(simpleEarningsStatement);
 

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/ernstmt/SoapEarningsStatementDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/ernstmt/SoapEarningsStatementDao.java
@@ -129,7 +129,7 @@ public class SoapEarningsStatementDao
     if (baseUrl.contains("?")) {
       return baseUrl + "&paycheck_nbr=" + paycheckNumber;
     } else {
-      return baseUrl + "?paycheck_nbr" + paycheckNumber;
+      return baseUrl + "?paycheck_nbr=" + paycheckNumber;
     }
   }
 

--- a/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/ernstmt/SoapEarningsStatementDao.java
+++ b/hrs-portlets-ps-impl/src/main/java/edu/wisc/hrs/dao/ernstmt/SoapEarningsStatementDao.java
@@ -108,11 +108,7 @@ public class SoapEarningsStatementDao
       final PAYCHECKNBRTypeShape soapPaycheckNumber = soapEarningsStatement.getPAYCHECKNBR();
       final int paycheckNumber = soapPaycheckNumber.getValue();
 
-      if (baseUrl.contains("?")) {
-        simpleEarningsStatement.setUrl(baseUrl + "&paycheck_nbr=" + paycheckNumber);
-      } else {
-        simpleEarningsStatement.setUrl(baseUrl + "?paycheck_nbr=" + paycheckNumber);
-      }
+      simpleEarningsStatement.setUrl(earningsStatementUrl(baseUrl, paycheckNumber));
 
       simpleEarningsStatements.add(simpleEarningsStatement);
 
@@ -120,6 +116,21 @@ public class SoapEarningsStatementDao
 
     return simpleEarningsStatements;
 
+  }
+
+  /**
+   * Given the base URL into HRS self-service for accessing earnings statement and the paycheck number,
+   * returns the composed URL linking into HRS self-service to access that specific earnings statement.
+   * @param baseUrl
+   * @param paycheckNumber
+   * @return
+   */
+  private String earningsStatementUrl(String baseUrl, int paycheckNumber) {
+    if (baseUrl.contains("?")) {
+      return baseUrl + "&paycheck_nbr=" + paycheckNumber;
+    } else {
+      return baseUrl + "?paycheck_nbr" + paycheckNumber;
+    }
   }
 
 }


### PR DESCRIPTION
Support HRS self-service URLs deep linking to earnings statements coming from HRS with pre-existing request parameter(s), such that the `paycheck_nbr` parameter that the HRS portlets set is not reliably the first request parameter.

[MYUWADMIN-1544](https://jira.doit.wisc.edu/jira/browse/MYUWADMIN-1544)