### PR TITLE
Update for Annual Benefits Enrollment (enrollment during 2021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ new, required `fname` `portlet-preference` in Benefit Information Portlet.
 
 Now building 9.3.2-SNAPSHOT.
 
++ Use ABE-specific Learn more links during the after-ABE feedback period.
+
 ## 9.3.1
 
 2021-07-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ new, required `fname` `portlet-preference` in Benefit Information Portlet.
 
 Now building 9.3.2-SNAPSHOT.
 
++ Configured dates for enroll-in-2021 for-benefits-in-2022 annual benefits enrollment (ABE).
++ ABE template changes to reduce brevity,
+  referring to abe as "2022 Annual Benefits Enrollment" rather than just "Annual Benefits Enrollment" and
+  "X days left to enroll" rather than just "X days left" before the "Enroll now" link.
 + Use ABE-specific Learn more links during the after-ABE feedback period.
 
 ## 9.3.1

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesService.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesService.java
@@ -22,7 +22,7 @@ public class AnnualBenefitEnrollmentDatesService {
   public static LocalDate lastDayOfAnnualBenefitsEnrollment =
       new LocalDate("2021-10-22");
   public static LocalDate lastDayOfAnnualBenefitsEnrollmentFeedback =
-      new LocalDate("2021-11-27");
+      new LocalDate("2021-11-26");
 
   /**
    * True iff on the given date should show the messages foreshadowing Annual Benefits Enrollment;

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesService.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 public class AnnualBenefitEnrollmentDatesService {
 
   public static LocalDate firstDayOfAnnualBenefitsEnrollmentForeshadowing =
-      new LocalDate("2021-09-19");
+      new LocalDate("2021-09-16");
   /**
    * Date during the ABE foreshadowing period, used in test cases.
    */

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesService.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesService.java
@@ -11,18 +11,18 @@ import org.springframework.stereotype.Service;
 public class AnnualBenefitEnrollmentDatesService {
 
   public static LocalDate firstDayOfAnnualBenefitsEnrollmentForeshadowing =
-      new LocalDate("2020-09-16");
+      new LocalDate("2021-09-19");
   /**
    * Date during the ABE foreshadowing period, used in test cases.
    */
   public static final LocalDate DATE_DURING_ABE_FORESHADOWING =
-      new LocalDate("2020-09-22");
+      new LocalDate("2021-09-22");
   public static LocalDate firstDayOfAnnualBenefitsEnrollment =
-      new LocalDate("2020-09-28");
+      new LocalDate("2021-09-27");
   public static LocalDate lastDayOfAnnualBenefitsEnrollment =
-      new LocalDate("2020-10-23");
+      new LocalDate("2021-10-22");
   public static LocalDate lastDayOfAnnualBenefitsEnrollmentFeedback =
-      new LocalDate("2020-11-27");
+      new LocalDate("2021-11-27");
 
   /**
    * True iff on the given date should show the messages foreshadowing Annual Benefits Enrollment;

--- a/hrs-portlets-api/src/test/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesServiceTest.java
+++ b/hrs-portlets-api/src/test/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesServiceTest.java
@@ -83,13 +83,13 @@ public class AnnualBenefitEnrollmentDatesServiceTest {
       "November 12, 2021, should be considered within the feedback period.",
       service.feedbackPeriod(new LocalDate("2021-11-12")));
 
-    assertTrue("The last day of feedback should be considered within the feedback period.",
-      service.feedbackPeriod(new LocalDate("2021-11-27")));
+    assertTrue("The last day of feedback (November 26, 2021) should be considered within the feedback period.",
+      service.feedbackPeriod(new LocalDate("2021-11-26")));
 
     // but not after its last day
     assertFalse(
       "The day after the last day of the feedback period should not be considered within the feedback period.",
-      service.feedbackPeriod(new LocalDate("2021-11-28")));
+      service.feedbackPeriod(new LocalDate("2021-11-27")));
   }
 
   @Test

--- a/hrs-portlets-api/src/test/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesServiceTest.java
+++ b/hrs-portlets-api/src/test/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesServiceTest.java
@@ -12,69 +12,69 @@ public class AnnualBenefitEnrollmentDatesServiceTest {
   @Test
   public void testForeshadowing() {
     // foreshadowing does not begin prematurely
-    assertFalse(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2020-09-15")));
+    assertFalse(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2021-09-18")));
 
-    // foreshadowing begins Wednesday Sept 16
-    assertTrue(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2020-09-16")));
+    // foreshadowing begins Sunday Sept 19 2021
+    assertTrue(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2021-09-19")));
 
     // and continues
     assertTrue(service.foreshadowAnnualBenefitsEnrollment(AnnualBenefitEnrollmentDatesService.DATE_DURING_ABE_FORESHADOWING));
 
     // through the day before benefit enrollment begins
-    assertTrue(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2020-09-27")));
+    assertTrue(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2021-09-26")));
 
     // and stops once benefit enrollment begins
-    assertFalse(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2020-09-28")));
+    assertFalse(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2021-09-27")));
   }
 
   @Test
   public void testDuringAnnualBenefitsEnrollment() {
     // annual benefits enrollment does not begin prematurely
-    assertFalse(service.duringAnnualBenefitsEnrollment(new LocalDate("2020-09-27")));
+    assertFalse(service.duringAnnualBenefitsEnrollment(new LocalDate("2021-09-26")));
 
     // but does begin punctually
-    assertTrue(service.duringAnnualBenefitsEnrollment(new LocalDate("2020-09-28")));
+    assertTrue(service.duringAnnualBenefitsEnrollment(new LocalDate("2021-09-27")));
 
     // and continues
-    assertTrue(service.duringAnnualBenefitsEnrollment(new LocalDate("2020-10-05")));
+    assertTrue(service.duringAnnualBenefitsEnrollment(new LocalDate("2021-10-05")));
 
     assertTrue(
       "ABE dates service should consider last date of ABE to be during ABE.",
-      service.duringAnnualBenefitsEnrollment(new LocalDate("2020-10-23")));
+      service.duringAnnualBenefitsEnrollment(new LocalDate("2021-10-22")));
 
     assertFalse(
       "ABE dates service should consider the day after ABE ends to NOT be during ABE",
-      service.duringAnnualBenefitsEnrollment(new LocalDate("2020-10-24")));
+      service.duringAnnualBenefitsEnrollment(new LocalDate("2021-10-23")));
   }
 
   @Test
   public void testLastDayAnnualBenefitsEnrollment() {
     // the day before the last day is not the last day
-    assertFalse(service.lastDayOfAnnualBenefitEnrollment(new LocalDate("2020-10-22")));
+    assertFalse(service.lastDayOfAnnualBenefitEnrollment(new LocalDate("2021-10-21")));
 
     // the last day is the last day
-    assertTrue(service.lastDayOfAnnualBenefitEnrollment(new LocalDate("2020-10-23")));
+    assertTrue(service.lastDayOfAnnualBenefitEnrollment(new LocalDate("2021-10-22")));
 
     // the day after the last day is not the last day
-    assertFalse(service.lastDayOfAnnualBenefitEnrollment(new LocalDate("2020-10-24")));
+    assertFalse(service.lastDayOfAnnualBenefitEnrollment(new LocalDate("2021-10-23")));
   }
 
   @Test
   public void testFeedbackPeriod() {
     // the last day of benefit enrollment is not the feedback period
-    assertFalse(service.feedbackPeriod(new LocalDate("2020-10-23")));
+    assertFalse(service.feedbackPeriod(new LocalDate("2021-10-22")));
 
     // but the day after benefit enrollment is within the feedback period
-    assertTrue(service.feedbackPeriod(new LocalDate("2020-10-24")));
+    assertTrue(service.feedbackPeriod(new LocalDate("2021-10-23")));
 
     // and the feedback period continues
-    assertTrue(service.feedbackPeriod(new LocalDate("2020-11-12")));
+    assertTrue(service.feedbackPeriod(new LocalDate("2021-11-12")));
 
     // through its last day
-    assertTrue(service.feedbackPeriod(new LocalDate("2020-11-27")));
+    assertTrue(service.feedbackPeriod(new LocalDate("2021-11-27")));
 
     // but not after its last day
-    assertFalse(service.feedbackPeriod(new LocalDate("2019-11-28")));
+    assertFalse(service.feedbackPeriod(new LocalDate("2021-11-28")));
   }
 
   @Test
@@ -82,30 +82,30 @@ public class AnnualBenefitEnrollmentDatesServiceTest {
     assertEquals(
       "before ABE, daysRemaining...() returns -1",
       -1, service.daysRemainingInAnnualBenefitsEnrollment(
-        new LocalDate("2020-09-20")));
+        new LocalDate("2021-09-20")));
 
     assertEquals(
       "On the antepenultimate day of ABE, there are 2 more days remaining.",
       2,
       service.daysRemainingInAnnualBenefitsEnrollment(
-        new LocalDate("2020-10-21")));
+        new LocalDate("2021-10-20")));
 
     assertEquals(
       "On the penultimate day of ABE, there is 1 more day remaining.",
       1,
       service.daysRemainingInAnnualBenefitsEnrollment(
-        new LocalDate("2020-10-22")));
+        new LocalDate("2021-10-21")));
 
     assertEquals(
       "On the last day of ABE, there are 0 more days remaining.",
       0,
       service.daysRemainingInAnnualBenefitsEnrollment(
-        new LocalDate("2020-10-23")));
+        new LocalDate("2021-10-22")));
 
     assertEquals(
       "After ABE, daysRemaining...() returns -1.",
       -1,
-      service.daysRemainingInAnnualBenefitsEnrollment(new LocalDate("2020-10-24")));
+      service.daysRemainingInAnnualBenefitsEnrollment(new LocalDate("2021-10-24")));
   }
 
 }

--- a/hrs-portlets-api/src/test/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesServiceTest.java
+++ b/hrs-portlets-api/src/test/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesServiceTest.java
@@ -11,32 +11,39 @@ public class AnnualBenefitEnrollmentDatesServiceTest {
 
   @Test
   public void testForeshadowing() {
-    // foreshadowing does not begin prematurely
-    assertFalse(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2021-09-18")));
+    assertFalse(
+      "Foreshadowing Annual Benefits Enrollment should not begin prematurely.",
+      service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2021-09-18")));
 
-    // foreshadowing begins Sunday Sept 19 2021
-    assertTrue(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2021-09-19")));
+    assertTrue(
+      "Foreshadowing Annual Benefits Enrollment should begin on September 19, 2021.",
+      service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2021-09-19")));
 
-    // and continues
-    assertTrue(service.foreshadowAnnualBenefitsEnrollment(AnnualBenefitEnrollmentDatesService.DATE_DURING_ABE_FORESHADOWING));
+    assertTrue(
+      "Foreshadowing Annual Benefits Enrollment should continue during the foreshadowing period.",
+      service.foreshadowAnnualBenefitsEnrollment(AnnualBenefitEnrollmentDatesService.DATE_DURING_ABE_FORESHADOWING));
 
-    // through the day before benefit enrollment begins
-    assertTrue(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2021-09-26")));
+    assertTrue(
+      "Foreshadowing should continue on the day before Annual Benefits Enrollment begins.",
+      service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2021-09-26")));
 
-    // and stops once benefit enrollment begins
-    assertFalse(service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2021-09-27")));
+    assertFalse(
+      "Foreshadowing should stop once Annual Benefits Enrollment begins.",
+      service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2021-09-27")));
   }
 
   @Test
   public void testDuringAnnualBenefitsEnrollment() {
-    // annual benefits enrollment does not begin prematurely
-    assertFalse(service.duringAnnualBenefitsEnrollment(new LocalDate("2021-09-26")));
+    assertFalse(
+      "Annual Benefits Enrollment should not begin prematurely on the day before ABE starts.",
+      service.duringAnnualBenefitsEnrollment(new LocalDate("2021-09-26")));
 
-    // but does begin punctually
-    assertTrue(service.duringAnnualBenefitsEnrollment(new LocalDate("2021-09-27")));
+    assertTrue(
+      "Annual Benefits Enrollment should begin punctually on the first day of ABE (September 27, 2021).",
+      service.duringAnnualBenefitsEnrollment(new LocalDate("2021-09-27")));
 
-    // and continues
-    assertTrue(service.duringAnnualBenefitsEnrollment(new LocalDate("2021-10-05")));
+    assertTrue("Annual Benefits Enrollment should continue during the permitted period.",
+      service.duringAnnualBenefitsEnrollment(new LocalDate("2021-10-05")));
 
     assertTrue(
       "ABE dates service should consider last date of ABE to be during ABE.",
@@ -49,32 +56,40 @@ public class AnnualBenefitEnrollmentDatesServiceTest {
 
   @Test
   public void testLastDayAnnualBenefitsEnrollment() {
-    // the day before the last day is not the last day
-    assertFalse(service.lastDayOfAnnualBenefitEnrollment(new LocalDate("2021-10-21")));
+    assertFalse(
+      "The day before the last day of Annual Benefits Enrollment should not be considered the last day.",
+      service.lastDayOfAnnualBenefitEnrollment(new LocalDate("2021-10-21")));
 
-    // the last day is the last day
-    assertTrue(service.lastDayOfAnnualBenefitEnrollment(new LocalDate("2021-10-22")));
+    assertTrue(
+      "The last day of Annual Benefits Enrollment should be considered the last day.",
+      service.lastDayOfAnnualBenefitEnrollment(new LocalDate("2021-10-22")));
 
-    // the day after the last day is not the last day
-    assertFalse(service.lastDayOfAnnualBenefitEnrollment(new LocalDate("2021-10-23")));
+    assertFalse(
+      "The day after the last day of Annual Benefits Enrollment should not be considered the last day.",
+      service.lastDayOfAnnualBenefitEnrollment(new LocalDate("2021-10-23")));
   }
 
   @Test
   public void testFeedbackPeriod() {
-    // the last day of benefit enrollment is not the feedback period
-    assertFalse(service.feedbackPeriod(new LocalDate("2021-10-22")));
+    assertFalse(
+      "the last day of benefit enrollment should not be within the feedback period",
+      service.feedbackPeriod(new LocalDate("2021-10-22")));
 
-    // but the day after benefit enrollment is within the feedback period
-    assertTrue(service.feedbackPeriod(new LocalDate("2021-10-23")));
+    assertTrue(
+      "the day after benefit enrollment is within the feedback period",
+      service.feedbackPeriod(new LocalDate("2021-10-23")));
 
-    // and the feedback period continues
-    assertTrue(service.feedbackPeriod(new LocalDate("2021-11-12")));
+    assertTrue(
+      "November 12, 2021, should be considered within the feedback period.",
+      service.feedbackPeriod(new LocalDate("2021-11-12")));
 
-    // through its last day
-    assertTrue(service.feedbackPeriod(new LocalDate("2021-11-27")));
+    assertTrue("The last day of feedback should be considered within the feedback period.",
+      service.feedbackPeriod(new LocalDate("2021-11-27")));
 
     // but not after its last day
-    assertFalse(service.feedbackPeriod(new LocalDate("2021-11-28")));
+    assertFalse(
+      "The day after the last day of the feedback period should not be considered within the feedback period.",
+      service.feedbackPeriod(new LocalDate("2021-11-28")));
   }
 
   @Test

--- a/hrs-portlets-api/src/test/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesServiceTest.java
+++ b/hrs-portlets-api/src/test/java/edu/wisc/hr/service/benefits/AnnualBenefitEnrollmentDatesServiceTest.java
@@ -13,11 +13,11 @@ public class AnnualBenefitEnrollmentDatesServiceTest {
   public void testForeshadowing() {
     assertFalse(
       "Foreshadowing Annual Benefits Enrollment should not begin prematurely.",
-      service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2021-09-18")));
+      service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2021-09-15")));
 
     assertTrue(
-      "Foreshadowing Annual Benefits Enrollment should begin on September 19, 2021.",
-      service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2021-09-19")));
+      "Foreshadowing Annual Benefits Enrollment should begin on September 16, 2021.",
+      service.foreshadowAnnualBenefitsEnrollment(new LocalDate("2021-09-16")));
 
     assertTrue(
       "Foreshadowing Annual Benefits Enrollment should continue during the foreshadowing period.",

--- a/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGenerator.java
+++ b/hrs-portlets-webapp/src/main/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGenerator.java
@@ -34,11 +34,23 @@ public class BenefitsLearnMoreLinkGenerator {
       }
     }
 
-    // otherwise, during ABE foreshadowing,
+    // During ABE foreshadowing,
     // everyone gets the annual benefits enrollment preview learn more link
     // because MyUW cannot tell whether the foreshadowing is relevant to the employee
 
     if (datesService.foreshadowAnnualBenefitsEnrollment(new LocalDate())) {
+      if (madisonness) {
+        return "https://hr.wisc.edu/benefits/annual-benefits-enrollment/";
+      } else {
+        return "https://www.wisconsin.edu/abe/";
+      }
+    }
+
+    // During ABE feedback period,
+    // everyone (who lacks a new hire enrollment opportunity) gets the annual benefits enrollment learn more link
+    // because MyUW cannot tell whether rearview mirror of annual benefits enrollment is relevant to the employee
+
+    if (datesService.feedbackPeriod(new LocalDate())) {
       if (madisonness) {
         return "https://hr.wisc.edu/benefits/annual-benefits-enrollment/";
       } else {

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentDuringCountdown.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentDuringCountdown.jsp
@@ -30,7 +30,7 @@
     <div layout="column" layout-align="center center">
       <p>
         <span class="tsc__days-left">${abeDaysRemaining}</span>
-        day<c:if test="${abeDaysRemaining > 1}">s</c:if> left
+        day<c:if test="${abeDaysRemaining > 1}">s</c:if> left to enroll
       </p>
       <p>
         <a

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentDuringCountdown.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentDuringCountdown.jsp
@@ -25,7 +25,7 @@
 <spring:htmlEscape defaultHtmlEscape="true" />
 
 <div class="widget-body layout-align-center-center layout-column">
-  <span class="tsc__title">Annual Benefits Enrollment</span>
+  <span class="tsc__title">2022 Annual Benefits Enrollment</span>
   <div class="tsc__status">
     <div layout="column" layout-align="center center">
       <p>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentFeedback.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentFeedback.jsp
@@ -29,7 +29,7 @@
   <div class="tsc__status">
     <div layout="column" layout-align="center center">
       <p>
-        ended October 23.
+        ended October 22.
       </p>
     </div>
   </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentFeedback.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentFeedback.jsp
@@ -40,6 +40,16 @@
       Give feedback
     </a>
   </div>
+  <div class="tsc__extra-buttons layout-align-center-center layout-row">
+    <c:if test="${not empty learnMoreLink}">
+      <a
+        aria-label="Learn more about benefits"
+        target="_blank" rel="noopener noreferrer"
+        href="${learnMoreLink}">
+        Learn more
+      </a>
+    </c:if>
+  </div>
 </div>
 
 <c:choose>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentFeedback.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentFeedback.jsp
@@ -25,7 +25,7 @@
 <spring:htmlEscape defaultHtmlEscape="true" />
 
 <div class="widget-body layout-align-center-center layout-column">
-  <span class="tsc__title">Annual Benefits Enrollment</span>
+  <span class="tsc__title">2022 Annual Benefits Enrollment</span>
   <div class="tsc__status">
     <div layout="column" layout-align="center center">
       <p>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentForeshadowing.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentForeshadowing.jsp
@@ -27,7 +27,7 @@
 <div class="widget-body layout-align-center-center layout-column">
   <span class="tsc__title">Annual Benefits Enrollment</span>
   <div class="tsc__status">
-    <p>begins September 28.</p>
+    <p>begins September 27.</p>
   </div>
 
   <div class="tsc__extra-buttons layout-align-center-center layout-row">

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentForeshadowing.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentForeshadowing.jsp
@@ -25,7 +25,7 @@
 <spring:htmlEscape defaultHtmlEscape="true" />
 
 <div class="widget-body layout-align-center-center layout-column">
-  <span class="tsc__title">Annual Benefits Enrollment</span>
+  <span class="tsc__title">2022 Annual Benefits Enrollment</span>
   <div class="tsc__status">
     <p>begins September 27.</p>
   </div>

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentLastDay.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/benefitInformationWidgetAnnualEnrollmentLastDay.jsp
@@ -25,7 +25,7 @@
 <spring:htmlEscape defaultHtmlEscape="true" />
 
 <div class="widget-body layout-align-center-center layout-column">
-  <span class="tsc__title">Annual Benefits Enrollment</span>
+  <span class="tsc__title">2022 Annual Benefits Enrollment</span>
   <div layout="column" layout-align="center center">
     <p>
       <span class="tsc__last-day">ends today!</span>

--- a/hrs-portlets-webapp/src/test/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGeneratorTest.java
+++ b/hrs-portlets-webapp/src/test/java/edu/wisc/portlet/hrs/web/benefits/BenefitsLearnMoreLinkGeneratorTest.java
@@ -88,6 +88,50 @@ public class BenefitsLearnMoreLinkGeneratorTest {
   }
 
   @Test
+  public void duringFeedbackPeriodMadisonEmployeesGetMadisonAbeLearnMoreLink() {
+    Set<String> roles = new HashSet<String>();
+
+    LocalDate lastDateOfAnnualBenefitsEnrollment = AnnualBenefitEnrollmentDatesService.lastDayOfAnnualBenefitsEnrollment;
+    LocalDate duringFeedbackPeriod = lastDateOfAnnualBenefitsEnrollment.plusDays(2);
+    DateTimeUtils.setCurrentMillisFixed(duringFeedbackPeriod.toDate().getTime());
+
+    assertEquals(
+      "During the feedback period, Madison employees should get the Madison-specific annual benefits enrollment link",
+      "https://hr.wisc.edu/benefits/annual-benefits-enrollment/",
+      generator.learnMoreLinkFor(roles, true));
+  }
+
+  @Test
+  public void duringFeedbackPeriodNonMadisonEmployeesGetWisconsinAbeLearnMoreLink() {
+    Set<String> roles = new HashSet<String>();
+
+    LocalDate lastDateOfAnnualBenefitsEnrollment = AnnualBenefitEnrollmentDatesService.lastDayOfAnnualBenefitsEnrollment;
+    LocalDate duringFeedbackPeriod = lastDateOfAnnualBenefitsEnrollment.plusDays(2);
+    DateTimeUtils.setCurrentMillisFixed(duringFeedbackPeriod.toDate().getTime());
+
+    assertEquals(
+      "During the feedback period, non-Madison employees should get the learn more link to the wisconsin.edu ABE page.",
+      "https://www.wisconsin.edu/abe/",
+      generator.learnMoreLinkFor(roles, false));
+  }
+
+  @Test
+  public void learningAboutNewHireTakesPrecedenceOverLearningAboutAbeDuringFeedbackForMadisonEmployee() {
+    Set<String> roles = new HashSet<String>();
+    roles.add("ROLE_VIEW_NEW_HIRE_BENEFITS");
+
+    LocalDate lastDateOfAnnualBenefitsEnrollment = AnnualBenefitEnrollmentDatesService.lastDayOfAnnualBenefitsEnrollment;
+    LocalDate duringFeedbackPeriod = lastDateOfAnnualBenefitsEnrollment.plusDays(2);
+    DateTimeUtils.setCurrentMillisFixed(duringFeedbackPeriod.toDate().getTime());
+
+    assertEquals(
+      "During the feedback period, Madison employees with a new hire enrollment opportunity should get the new hire link (not the ABE link).",
+      "https://hr.wisc.edu/benefits/new-employee-benefits-enrollment/",
+      generator.learnMoreLinkFor(roles, true));
+
+  }
+
+  @Test
   public void testNewHireBenefitEnrollmentOpportunityMadisonUser() {
     Set<String> roles = new HashSet<String>();
     roles.add("ROLE_VIEW_NEW_HIRE_BENEFITS");


### PR DESCRIPTION
+ Updates unit tests to reflect this year's dates
+ Updates date service with those dates, passing the tests
+ Updates widget templates to reflect dates and style changes
+ Changes behavior to use Annual Benefits Enrollment (ABE) learn more links during the after-ABE feedback period. Previously after ABE itself ended employees would get the generic about-benefits-generally not-specific-to-ABE learn more links, even during the feedback period.
+ Converts some inline code comments into test assertion messages (makes the test failure report more useful for understanding what expectations were not fulfilled.)

Addresses:

+ [MYUWADMIN-1555: foreshadowing ABE](https://jira.doit.wisc.edu/jira/browse/MYUWADMIN-1555)
+ [MYUWADMIN-1556: enrolling during ABE](https://jira.doit.wisc.edu/jira/browse/MYUWADMIN-1556)
+ [MYUWADMIN-1557: last-day-of-ABE experience](https://jira.doit.wisc.edu/jira/browse/MYUWADMIN-1557)
+ [MYUWADMIN-1556: feedback period](https://jira.doit.wisc.edu/jira/browse/MYUWADMIN-1558)
+ [MYUWADMIN-1559: return to status quo widget post-ABE](https://jira.doit.wisc.edu/jira/browse/MYUWADMIN-1559)