### PR TITLE
remove mention of HRS preferred name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ new, required `fname` `portlet-preference` in Benefit Information Portlet.
 
 Now building 9.6.0-SNAPSHOT.
 
++ In Personal Information, remove text about "preferred name" feature within HRS.
+  This HRS feature does not in practice do anything,
+  so drawing employee attention drawn to this feature does not best serve employees.
+
 ## 9.5.0
 
 2022-01-10

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/contactInfo.jsp
@@ -71,15 +71,6 @@
                   </span>
               </div>
 
-
-            <div class='edit-notice'>
-                <p class='edit-notice'>
-                  Update your preferred name in HRS
-                  using the 'Update My Personal Information' link below.
-                  This will appear in employee self-service
-                  (e.g. your timesheet) only.
-                </p>
-            </div>
         </c:when>
         <c:otherwise>
         <div class="contact-info-official-name">
@@ -178,7 +169,7 @@
               <strong>
                 <sec:authorize ifAllGranted="ROLE_VIEW_DIRECT_DEPOSIT">
                   Addresses (Home &amp; Mail); Contact Details (Phone &amp; Email);</sec:authorize>
-                Preferred Name; Emergency Contacts;
+                Emergency Contacts;
                 <sec:authorize ifAllGranted="ROLE_VIEW_DIRECT_DEPOSIT">Release Home Information;</sec:authorize>
                 Marital Status; Coordination of Benefits; Medicare Information;
                 Ethnic Groups; Veteran Status; Disability.


### PR DESCRIPTION
Remove mention of the within-HRS Preferred Name feature as that feature does not affect change and is a distraction from the campus IAM features that do affect change.