### PR TITLE
Add Pay and Benefits Deduction Schedule link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ new, required `fname` `portlet-preference` in Benefit Information Portlet.
 
 Now building 9.7.0-SNAPSHOT.
 
++ In Payroll Information, adds "Pay and Benefits Deduction Schedule" hyperlink,
+  linking to the
+  [payroll schedule PDF](https://uwservice.wisconsin.edu/docs/publications/pay-bw-calendar.pdf)
+  via go.wisc URL <https://go.wisc.edu/7o144a>.
+
 ## 9.6.0
 
 2022-01-21

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/jsp/payrollInformation.jsp
@@ -217,6 +217,10 @@
                   Understanding Your Earnings Statement</a>
               </div>
             </c:if>
+            <div class="dl-link">
+              <a href="https://go.wisc.edu/7o144a" target="_blank">
+                Pay and Benefits Deduction Schedule</a>
+            </div>
           </c:when>
 
           <c:when test="${empty earningsStatements && !earningsStatementsError}">


### PR DESCRIPTION
Add a hyperlink to the payroll deduction schedule PDF.

Tracked in [legacy-portals #71](https://git.doit.wisc.edu/wps/myuw-service/myuw-legacy/legacy-portals/-/issues/71/).